### PR TITLE
Add MessagePack delta codec for DDSketch/HLL/CMS/CountSketch

### DIFF
--- a/src/message_pack_format/portable/countminsketch.rs
+++ b/src/message_pack_format/portable/countminsketch.rs
@@ -394,6 +394,59 @@ impl CountMinSketch {
         self.apply_delta(&delta)
     }
 
+    /// MessagePack twin of [`Self::compute_delta`]. Computes the same
+    /// sparse cell delta of `self` against `snapshot` (a cell is carried
+    /// when `|Δcount|` is non-zero and `>= threshold`), but serializes it
+    /// as the cells-only parallel-array MessagePack layout via
+    /// [`CountMinSketchDelta`]'s [`MessagePackCodec`] instead of proto. The
+    /// per-row `l1`/`l2` norms and `hh_keys` the proto delta carries are
+    /// dropped — the plain-sketch estimate path does not consume them.
+    /// Delta-against-empty carries this window's own cell counts.
+    pub fn compute_delta_msgpack(
+        &self,
+        snapshot: &CountMinSketch,
+        threshold: f64,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        if self.rows != snapshot.rows || self.cols != snapshot.cols {
+            return Err(format!(
+                "CountMinSketch dimension mismatch: self={}x{}, snapshot={}x{}",
+                self.rows, self.cols, snapshot.rows, snapshot.cols
+            )
+            .into());
+        }
+        let cur = self.sketch();
+        let snap = snapshot.sketch();
+        let mut delta = CountMinSketchDelta {
+            rows: self.rows as u32,
+            cols: self.cols as u32,
+            ..CountMinSketchDelta::default()
+        };
+        for r in 0..self.rows {
+            for c in 0..self.cols {
+                let dc = (cur[r][c] - snap[r][c]) as i64;
+                if dc != 0 && (dc.unsigned_abs() as f64) >= threshold {
+                    delta.cells.push((r as u32, c as u32, dc));
+                }
+            }
+        }
+        Ok(delta.to_msgpack()?)
+    }
+
+    /// MessagePack twin of [`Self::apply_delta_bytes`]. Decodes the
+    /// cells-only parallel-array MessagePack [`CountMinSketchDelta`] and
+    /// applies it in place (additive cell merge).
+    ///
+    /// Returns `Err` if `bytes` is not a valid MessagePack
+    /// `CountMinSketchDelta` or a cell is out of range for this sketch's
+    /// dimensions.
+    pub fn apply_delta_msgpack_bytes(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let delta = CountMinSketchDelta::from_msgpack(bytes)?;
+        self.apply_delta(&delta)
+    }
+
     /// One-shot aggregation: build a sketch from parallel key/value slices
     /// and return the msgpack bytes.
     pub fn aggregate_count(
@@ -456,9 +509,97 @@ impl MessagePackCodec for CountMinSketch {
     }
 }
 
+impl MessagePackCodec for CountMinSketchDelta {
+    /// Encodes the sparse cell delta as the 5-element MessagePack array
+    /// `[ rows:u64, cols:u64, row_idx:[]u32, col_idx:[]u32, d_count:[]i64 ]`
+    /// — byte-identical to Rust
+    /// `rmp_serde::to_vec(&(u64, u64, Vec<u32>, Vec<u32>, Vec<i64>))`
+    /// (compact mode), the same struct-of-parallel-arrays shape the Go
+    /// `count_sketch_delta_sparse.go` established. Only the matrix cells
+    /// cross the wire; the per-row `l1`/`l2` norms and the `hh_keys`
+    /// heavy-hitter surface are not carried.
+    fn to_msgpack(&self) -> Result<Vec<u8>, MsgPackError> {
+        let mut row_idx: Vec<u32> = Vec::with_capacity(self.cells.len());
+        let mut col_idx: Vec<u32> = Vec::with_capacity(self.cells.len());
+        let mut d_count: Vec<i64> = Vec::with_capacity(self.cells.len());
+        for (r, c, d) in &self.cells {
+            row_idx.push(*r);
+            col_idx.push(*c);
+            d_count.push(*d);
+        }
+        Ok(rmp_serde::to_vec(&(
+            self.rows as u64,
+            self.cols as u64,
+            row_idx,
+            col_idx,
+            d_count,
+        ))?)
+    }
+
+    fn from_msgpack(bytes: &[u8]) -> Result<Self, MsgPackError> {
+        let (rows, cols, row_idx, col_idx, d_count): (u64, u64, Vec<u32>, Vec<u32>, Vec<i64>) =
+            rmp_serde::from_slice(bytes)?;
+        let cells = row_idx
+            .into_iter()
+            .zip(col_idx)
+            .zip(d_count)
+            .map(|((r, c), d)| (r, c, d))
+            .collect();
+        Ok(CountMinSketchDelta {
+            rows: rows as u32,
+            cols: cols as u32,
+            cells,
+            ..CountMinSketchDelta::default()
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn msgpack_delta_against_empty_round_trips() {
+        let (rows, cols) = (5, 1024);
+        let mut w = CountMinSketch::new(rows, cols);
+        for _ in 0..200 {
+            w.update("hot", 1.0);
+        }
+        let empty = CountMinSketch::new(rows, cols);
+        let bytes = w.compute_delta_msgpack(&empty, 1.0).unwrap();
+        let mut recon = CountMinSketch::new(rows, cols);
+        recon.apply_delta_msgpack_bytes(&bytes).unwrap();
+        let (got, want) = (recon.estimate("hot"), w.estimate("hot"));
+        assert!((got - want).abs() <= want * 0.1, "got={got} want={want}");
+    }
+
+    #[test]
+    fn msgpack_delta_wire_layout_is_parallel_arrays() {
+        use crate::message_pack_format::MessagePackCodec;
+        let (rows, cols) = (3, 8);
+        let mut w = CountMinSketch::new(rows, cols);
+        w.update("x", 5.0);
+        let empty = CountMinSketch::new(rows, cols);
+        let bytes = w.compute_delta_msgpack(&empty, 1.0).unwrap();
+        let cur = w.sketch();
+        let (mut ri, mut ci, mut dc): (Vec<u32>, Vec<u32>, Vec<i64>) =
+            (Vec::new(), Vec::new(), Vec::new());
+        for r in 0..rows {
+            for c in 0..cols {
+                let d = cur[r][c] as i64;
+                if d != 0 {
+                    ri.push(r as u32);
+                    ci.push(c as u32);
+                    dc.push(d);
+                }
+            }
+        }
+        let expected = rmp_serde::to_vec(&(rows as u64, cols as u64, ri, ci, dc)).unwrap();
+        assert_eq!(bytes, expected);
+        let d = CountMinSketchDelta::from_msgpack(&bytes).unwrap();
+        assert_eq!(d.rows, rows as u32);
+        assert_eq!(d.cols, cols as u32);
+    }
 
     #[test]
     fn test_count_min_sketch_creation() {

--- a/src/message_pack_format/portable/countminsketch.rs
+++ b/src/message_pack_format/portable/countminsketch.rs
@@ -584,9 +584,9 @@ mod tests {
         let cur = w.sketch();
         let (mut ri, mut ci, mut dc): (Vec<u32>, Vec<u32>, Vec<i64>) =
             (Vec::new(), Vec::new(), Vec::new());
-        for r in 0..rows {
-            for c in 0..cols {
-                let d = cur[r][c] as i64;
+        for (r, row) in cur.iter().enumerate() {
+            for (c, &cell) in row.iter().enumerate() {
+                let d = cell as i64;
                 if d != 0 {
                     ri.push(r as u32);
                     ci.push(c as u32);

--- a/src/message_pack_format/portable/countsketch.rs
+++ b/src/message_pack_format/portable/countsketch.rs
@@ -571,9 +571,9 @@ mod tests {
         let cur = w.sketch();
         let (mut ri, mut ci, mut dc): (Vec<u32>, Vec<u32>, Vec<i64>) =
             (Vec::new(), Vec::new(), Vec::new());
-        for r in 0..rows {
-            for c in 0..cols {
-                let d = cur[r][c] as i64;
+        for (r, row) in cur.iter().enumerate() {
+            for (c, &cell) in row.iter().enumerate() {
+                let d = cell as i64;
                 if d != 0 {
                     ri.push(r as u32);
                     ci.push(c as u32);

--- a/src/message_pack_format/portable/countsketch.rs
+++ b/src/message_pack_format/portable/countsketch.rs
@@ -415,6 +415,59 @@ impl CountSketch {
         self.apply_delta(&delta)
     }
 
+    /// MessagePack twin of [`Self::compute_delta`]. Computes the same
+    /// sparse signed-cell delta of `self` against `snapshot` (a cell is
+    /// carried when `Δcount` is non-zero and `|Δcount| >= threshold`, the
+    /// threshold truncated to an integer), but serializes it as the
+    /// cells-only parallel-array MessagePack layout via
+    /// [`CountSketchDelta`]'s [`MessagePackCodec`] instead of proto. The
+    /// per-row `l2` norms and `hh_keys` the proto delta carries are dropped
+    /// — the plain-sketch estimate path does not consume them.
+    /// Delta-against-empty carries this window's own signed cell counts.
+    pub fn compute_delta_msgpack(
+        &self,
+        snapshot: &CountSketch,
+        threshold: f64,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        if self.rows != snapshot.rows || self.cols != snapshot.cols {
+            return Err(format!(
+                "CountSketch dimension mismatch: self={}x{}, snapshot={}x{}",
+                self.rows, self.cols, snapshot.rows, snapshot.cols
+            )
+            .into());
+        }
+        let thresh = threshold as i64;
+        let mut delta = CountSketchDelta {
+            rows: self.rows as u32,
+            cols: self.cols as u32,
+            ..CountSketchDelta::default()
+        };
+        for r in 0..self.rows {
+            for c in 0..self.cols {
+                let dc = (self.matrix[r][c] - snapshot.matrix[r][c]) as i64;
+                if dc != 0 && (dc <= -thresh || dc >= thresh) {
+                    delta.cells.push((r as u32, c as u32, dc));
+                }
+            }
+        }
+        Ok(delta.to_msgpack()?)
+    }
+
+    /// MessagePack twin of [`Self::apply_delta_bytes`]. Decodes the
+    /// cells-only parallel-array MessagePack [`CountSketchDelta`] and
+    /// applies it in place (additive signed-cell merge).
+    ///
+    /// Returns `Err` if `bytes` is not a valid MessagePack
+    /// `CountSketchDelta` or a cell is out of range for this sketch's
+    /// dimensions.
+    pub fn apply_delta_msgpack_bytes(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let delta = CountSketchDelta::from_msgpack(bytes)?;
+        self.apply_delta(&delta)
+    }
+
     /// Merge a slice of references into a single new sketch. All inputs
     /// must share the same dimensions; returns `Err` on mismatch or an
     /// empty input.
@@ -442,9 +495,98 @@ impl MessagePackCodec for CountSketch {
     }
 }
 
+impl MessagePackCodec for CountSketchDelta {
+    /// Encodes the sparse signed-cell delta as the 5-element MessagePack
+    /// array
+    /// `[ rows:u64, cols:u64, row_idx:[]u32, col_idx:[]u32, d_count:[]i64 ]`
+    /// — byte-identical to Rust
+    /// `rmp_serde::to_vec(&(u64, u64, Vec<u32>, Vec<u32>, Vec<i64>))`
+    /// (compact mode), the layout the Go `count_sketch_delta_sparse.go`
+    /// established (with signed `d_count` in place of the F2-broadcast's
+    /// `f64` vals). Only the matrix cells cross the wire; the per-row `l2`
+    /// norms and `hh_keys` heavy-hitter surface are not carried.
+    fn to_msgpack(&self) -> Result<Vec<u8>, MsgPackError> {
+        let mut row_idx: Vec<u32> = Vec::with_capacity(self.cells.len());
+        let mut col_idx: Vec<u32> = Vec::with_capacity(self.cells.len());
+        let mut d_count: Vec<i64> = Vec::with_capacity(self.cells.len());
+        for (r, c, d) in &self.cells {
+            row_idx.push(*r);
+            col_idx.push(*c);
+            d_count.push(*d);
+        }
+        Ok(rmp_serde::to_vec(&(
+            self.rows as u64,
+            self.cols as u64,
+            row_idx,
+            col_idx,
+            d_count,
+        ))?)
+    }
+
+    fn from_msgpack(bytes: &[u8]) -> Result<Self, MsgPackError> {
+        let (rows, cols, row_idx, col_idx, d_count): (u64, u64, Vec<u32>, Vec<u32>, Vec<i64>) =
+            rmp_serde::from_slice(bytes)?;
+        let cells = row_idx
+            .into_iter()
+            .zip(col_idx)
+            .zip(d_count)
+            .map(|((r, c), d)| (r, c, d))
+            .collect();
+        Ok(CountSketchDelta {
+            rows: rows as u32,
+            cols: cols as u32,
+            cells,
+            ..CountSketchDelta::default()
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn msgpack_delta_against_empty_round_trips() {
+        let (rows, cols) = (5, 1024);
+        let mut w = CountSketch::new(rows, cols);
+        for _ in 0..200 {
+            w.update("hot", 1.0);
+        }
+        let empty = CountSketch::new(rows, cols);
+        let bytes = w.compute_delta_msgpack(&empty, 1.0).unwrap();
+        let mut recon = CountSketch::new(rows, cols);
+        recon.apply_delta_msgpack_bytes(&bytes).unwrap();
+        // CountSketch round-trips its cells exactly under delta-against-empty.
+        assert_eq!(recon.sketch(), w.sketch());
+    }
+
+    #[test]
+    fn msgpack_delta_wire_layout_is_parallel_arrays() {
+        use crate::message_pack_format::MessagePackCodec;
+        let (rows, cols) = (3, 8);
+        let mut w = CountSketch::new(rows, cols);
+        w.update("x", 5.0);
+        let empty = CountSketch::new(rows, cols);
+        let bytes = w.compute_delta_msgpack(&empty, 1.0).unwrap();
+        let cur = w.sketch();
+        let (mut ri, mut ci, mut dc): (Vec<u32>, Vec<u32>, Vec<i64>) =
+            (Vec::new(), Vec::new(), Vec::new());
+        for r in 0..rows {
+            for c in 0..cols {
+                let d = cur[r][c] as i64;
+                if d != 0 {
+                    ri.push(r as u32);
+                    ci.push(c as u32);
+                    dc.push(d);
+                }
+            }
+        }
+        let expected = rmp_serde::to_vec(&(rows as u64, cols as u64, ri, ci, dc)).unwrap();
+        assert_eq!(bytes, expected);
+        let d = CountSketchDelta::from_msgpack(&bytes).unwrap();
+        assert_eq!(d.rows, rows as u32);
+        assert_eq!(d.cols, cols as u32);
+    }
 
     #[test]
     fn test_new_empty() {

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -271,6 +271,57 @@ impl DdSketch {
         Ok(())
     }
 
+    /// MessagePack twin of [`Self::compute_delta`]. Computes the same
+    /// sparse bucket delta of `self` against `snapshot` (a bucket is
+    /// carried when its `Δcount = self − snapshot` clamped at 0 is
+    /// `>= threshold`), but serializes it as the parallel-array
+    /// MessagePack layout via [`DdSketchDelta`]'s [`MessagePackCodec`]
+    /// instead of proto. Same delta-against-empty semantics: against the
+    /// empty sketch every surviving delta equals this window's own bucket
+    /// count.
+    pub fn compute_delta_msgpack(&self, snapshot: &DdSketch, threshold: u64) -> Vec<u8> {
+        let mut delta = DdSketchDelta::default();
+        if !self.store_counts.is_empty() {
+            for (i, &c) in self.store_counts.iter().enumerate() {
+                if c == 0 {
+                    continue;
+                }
+                let k = self.store_offset + i as i32;
+                let snap_count: u64 = if !snapshot.store_counts.is_empty() {
+                    let idx = k as i64 - snapshot.store_offset as i64;
+                    if idx >= 0 && (idx as usize) < snapshot.store_counts.len() {
+                        snapshot.store_counts[idx as usize]
+                    } else {
+                        0
+                    }
+                } else {
+                    0
+                };
+                let dc = c.saturating_sub(snap_count);
+                if dc >= threshold {
+                    delta.buckets.push((k, dc));
+                }
+            }
+        }
+        delta
+            .to_msgpack()
+            .expect("DdSketchDelta msgpack encode is infallible for owned bucket arrays")
+    }
+
+    /// MessagePack twin of [`Self::apply_delta_bytes`]. Decodes the
+    /// parallel-array MessagePack [`DdSketchDelta`] and applies it in
+    /// place (additive bucket merge).
+    ///
+    /// Returns `Err` if `bytes` is not a valid MessagePack `DdSketchDelta`.
+    pub fn apply_delta_msgpack_bytes(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let delta = DdSketchDelta::from_msgpack(bytes)?;
+        self.apply_delta(&delta);
+        Ok(())
+    }
+
     /// Merge a slice of references into a single new sketch. Returns
     /// `Err` on alpha mismatch or an empty input.
     pub fn merge_refs(
@@ -411,10 +462,80 @@ impl MessagePackCodec for DdSketch {
     }
 }
 
+impl MessagePackCodec for DdSketchDelta {
+    /// Encodes the sparse bucket delta as the 2-element MessagePack array
+    /// `[ idx:[]i32, d_count:[]u64 ]` — parallel arrays of absolute bucket
+    /// index → Δcount — byte-identical to Rust
+    /// `rmp_serde::to_vec(&(Vec<i32>, Vec<u64>))` (compact mode), the layout
+    /// the `sketchlib-go` `asapmsgpack` DDSketch delta encoder mirrors. Only
+    /// the bucket cells cross the wire; the DataPoint-level metric scalars
+    /// (`d_count`/`d_sum`/`new_min`/`new_max`) are reconstructable and are
+    /// not carried, matching the proto delta.
+    fn to_msgpack(&self) -> Result<Vec<u8>, MsgPackError> {
+        let idx: Vec<i32> = self.buckets.iter().map(|(i, _)| *i).collect();
+        let d_count: Vec<u64> = self.buckets.iter().map(|(_, c)| *c).collect();
+        Ok(rmp_serde::to_vec(&(idx, d_count))?)
+    }
+
+    fn from_msgpack(bytes: &[u8]) -> Result<Self, MsgPackError> {
+        let (idx, d_count): (Vec<i32>, Vec<u64>) = rmp_serde::from_slice(bytes)?;
+        Ok(DdSketchDelta {
+            buckets: idx.into_iter().zip(d_count).collect(),
+            ..DdSketchDelta::default()
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::message_pack_format::MessagePackCodec;
+
+    #[test]
+    fn msgpack_delta_against_empty_round_trips() {
+        let mut w = DdSketch::new(0.01);
+        for i in 1..=200 {
+            w.update(i as f64);
+        }
+        let empty = DdSketch::new(0.01);
+        let bytes = w.compute_delta_msgpack(&empty, 1);
+        let mut recon = DdSketch::new(0.01);
+        recon.apply_delta_msgpack_bytes(&bytes).unwrap();
+        assert_eq!(recon.total_count(), w.total_count());
+        for q in [0.5, 0.9, 0.99] {
+            let got = recon.quantile(q).unwrap();
+            let want = w.quantile(q).unwrap();
+            assert!(
+                (got / want - 1.0).abs() <= 0.01,
+                "q={q}: got={got} want={want}"
+            );
+        }
+    }
+
+    #[test]
+    fn msgpack_delta_wire_layout_is_parallel_arrays() {
+        // Lock the cross-language wire shape: a 2-element array of parallel
+        // (idx, d_count) arrays, byte-identical to the tuple encoding the Go
+        // asapmsgpack DDSketch delta mirrors.
+        let mut w = DdSketch::new(0.01);
+        w.update(1.0);
+        w.update(1.0);
+        w.update(1000.0);
+        let empty = DdSketch::new(0.01);
+        let bytes = w.compute_delta_msgpack(&empty, 1);
+        let mut idx: Vec<i32> = Vec::new();
+        let mut d_count: Vec<u64> = Vec::new();
+        for (i, &c) in w.store_counts.iter().enumerate() {
+            if c != 0 {
+                idx.push(w.store_offset + i as i32);
+                d_count.push(c);
+            }
+        }
+        let expected = rmp_serde::to_vec(&(idx, d_count)).unwrap();
+        assert_eq!(bytes, expected);
+        let d = DdSketchDelta::from_msgpack(&bytes).unwrap();
+        assert_eq!(d.buckets.len(), 2, "two distinct buckets expected");
+    }
 
     #[test]
     fn test_new_empty() {

--- a/src/message_pack_format/portable/hll.rs
+++ b/src/message_pack_format/portable/hll.rs
@@ -241,6 +241,51 @@ impl HllSketch {
         self.apply_delta(&delta)
     }
 
+    /// MessagePack twin of [`Self::compute_delta`]. Carries every register
+    /// that increased over `snapshot` (`self[i] > snapshot[i]`) as an
+    /// `(index, new_value)` pair, serialized as the parallel-array
+    /// MessagePack layout via [`HllSketchDelta`]'s [`MessagePackCodec`]
+    /// instead of proto. HLL uses max semantics, so the delta is lossless
+    /// regardless of `_threshold` (accepted for a uniform delta API).
+    /// Delta-against-empty carries every non-zero register — this window's
+    /// full register state encoded as a delta.
+    pub fn compute_delta_msgpack(&self, snapshot: &HllSketch, _threshold: u64) -> Vec<u8> {
+        let cur = &self.registers;
+        let snap = &snapshot.registers;
+        let n = cur.len().min(snap.len());
+        let mut updates: Vec<(u32, u8)> = Vec::new();
+        for i in 0..n {
+            if cur[i] > snap[i] {
+                updates.push((i as u32, cur[i]));
+            }
+        }
+        // Guard: registers present in `self` beyond the snapshot length
+        // (should not happen at a fixed precision) carry their non-zero
+        // values. Matches the proto path's trailing-register guard.
+        for (i, &v) in cur.iter().enumerate().skip(n) {
+            if v > 0 {
+                updates.push((i as u32, v));
+            }
+        }
+        HllSketchDelta { updates }
+            .to_msgpack()
+            .expect("HllSketchDelta msgpack encode is infallible for owned update arrays")
+    }
+
+    /// MessagePack twin of [`Self::apply_delta_bytes`]. Decodes the
+    /// parallel-array MessagePack [`HllSketchDelta`] and applies it in
+    /// place (register max-merge).
+    ///
+    /// Returns `Err` if `bytes` is not a valid MessagePack `HllSketchDelta`
+    /// or a register index is out of range for this sketch's precision.
+    pub fn apply_delta_msgpack_bytes(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let delta = HllSketchDelta::from_msgpack(bytes)?;
+        self.apply_delta(&delta)
+    }
+
     pub fn merge_refs(
         inputs: &[&HllSketch],
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
@@ -438,9 +483,72 @@ impl MessagePackCodec for HllSketch {
     }
 }
 
+impl MessagePackCodec for HllSketchDelta {
+    /// Encodes the register delta as the 2-element MessagePack array
+    /// `[ reg_idx:[]u32, reg_val:[]u8 ]` — parallel arrays of register
+    /// index → new (max) value — byte-identical to Rust
+    /// `rmp_serde::to_vec(&(Vec<u32>, Vec<u8>))` (compact mode). The
+    /// `Vec<u8>` serializes as a msgpack array-of-int (not `bin`), matching
+    /// the Go `asapmsgpack` register-array convention.
+    fn to_msgpack(&self) -> Result<Vec<u8>, MsgPackError> {
+        let reg_idx: Vec<u32> = self.updates.iter().map(|(i, _)| *i).collect();
+        let reg_val: Vec<u8> = self.updates.iter().map(|(_, v)| *v).collect();
+        Ok(rmp_serde::to_vec(&(reg_idx, reg_val))?)
+    }
+
+    fn from_msgpack(bytes: &[u8]) -> Result<Self, MsgPackError> {
+        let (reg_idx, reg_val): (Vec<u32>, Vec<u8>) = rmp_serde::from_slice(bytes)?;
+        Ok(HllSketchDelta {
+            updates: reg_idx.into_iter().zip(reg_val).collect(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn msgpack_delta_against_empty_round_trips() {
+        let mut w = HllSketch::new(HllVariant::Regular, 12);
+        for i in 0..2000u64 {
+            w.update(&i.to_le_bytes());
+        }
+        let empty = HllSketch::new(HllVariant::Regular, 12);
+        let bytes = w.compute_delta_msgpack(&empty, 1);
+        let mut recon = HllSketch::new(HllVariant::Regular, 12);
+        recon.apply_delta_msgpack_bytes(&bytes).unwrap();
+        // Register delta over an empty base carries every non-zero register,
+        // so reconstructed registers are identical.
+        assert_eq!(recon.registers, w.registers);
+        let (got, want) = (recon.estimate(), w.estimate());
+        assert!((got - want).abs() <= want * 0.001, "got={got} want={want}");
+    }
+
+    #[test]
+    fn msgpack_delta_wire_layout_is_parallel_arrays() {
+        use crate::message_pack_format::MessagePackCodec;
+        let mut w = HllSketch::new(HllVariant::Regular, 4);
+        w.update(b"a");
+        w.update(b"b");
+        let empty = HllSketch::new(HllVariant::Regular, 4);
+        let bytes = w.compute_delta_msgpack(&empty, 1);
+        let mut reg_idx: Vec<u32> = Vec::new();
+        let mut reg_val: Vec<u8> = Vec::new();
+        for (i, &v) in w.registers.iter().enumerate() {
+            if v > 0 {
+                reg_idx.push(i as u32);
+                reg_val.push(v);
+            }
+        }
+        let expected = rmp_serde::to_vec(&(reg_idx, reg_val)).unwrap();
+        assert_eq!(bytes, expected);
+        let d = HllSketchDelta::from_msgpack(&bytes).unwrap();
+        assert_eq!(
+            d.updates.len(),
+            w.registers.iter().filter(|&&v| v > 0).count()
+        );
+    }
 
     #[test]
     fn test_new_empty() {

--- a/src/message_pack_format/portable/kll.rs
+++ b/src/message_pack_format/portable/kll.rs
@@ -357,9 +357,45 @@ impl MessagePackCodec for KllSketch {
     }
 }
 
+impl MessagePackCodec for KllSketchData {
+    /// Encodes the `(k, sketch_bytes)` DTO directly, byte-identical to
+    /// [`KllSketch::to_msgpack`] (which serializes this same struct). Lets
+    /// producers that hold a raw sketchlib KLL backend (via
+    /// `serialize_to_bytes`) emit the portable KLL msgpack form without
+    /// constructing a [`KllSketch`] facade.
+    fn to_msgpack(&self) -> Result<Vec<u8>, MsgPackError> {
+        Ok(rmp_serde::to_vec(self)?)
+    }
+
+    fn from_msgpack(bytes: &[u8]) -> Result<Self, MsgPackError> {
+        Ok(rmp_serde::from_slice(bytes)?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn kll_data_msgpack_matches_kll_sketch() {
+        let mut sk = KllSketch::new(200);
+        for i in 0..500 {
+            sk.update(i as f64);
+        }
+        let via_sketch = sk.to_msgpack().unwrap();
+        let data = KllSketchData {
+            k: sk.k(),
+            sketch_bytes: sk.sketch_bytes(),
+        };
+        let via_data = data.to_msgpack().unwrap();
+        assert_eq!(
+            via_sketch, via_data,
+            "KllSketchData codec must byte-match KllSketch"
+        );
+        let rt = KllSketchData::from_msgpack(&via_data).unwrap();
+        assert_eq!(rt.k, data.k);
+        assert_eq!(rt.sketch_bytes, data.sketch_bytes);
+    }
 
     #[test]
     fn test_kll_creation() {

--- a/src/sketches/countsketch.rs
+++ b/src/sketches/countsketch.rs
@@ -467,7 +467,7 @@ impl<M, H: SketchHasher> Count<Vector2D<i32>, M, H> {
     /// Human-friendly helper used by the serializer demo binaries.
     pub fn debug(&self) {
         for row in 0..self.counts.rows() {
-            println!("row {}: {:?}", row, &self.counts.row_slice(row));
+            println!("row {}: {:?}", row, self.counts.row_slice(row));
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds the **msgpack twin** of the existing proto delta path to the four delta-capable portable sketches, so sketch state can ship over the wire as MessagePack (full + sparse delta) instead of proto.

- `impl MessagePackCodec for {DdSketch,Hll,CountMin,CountSketch}Delta` — serializes to the **struct-of-parallel-arrays** layout via `rmp_serde::to_vec` (compact), matching the Go `wire/asapmsgpack/count_sketch_delta_sparse.go` convention:
  - DDSketch: `(Vec<i32> idx, Vec<u64> dCount)`
  - HLL: `(Vec<u32> regIdx, Vec<u8> regVal)`
  - CMS / CountSketch: `(u64 rows, u64 cols, Vec<u32> r, Vec<u32> c, Vec<i64> dCount)` — **cells-only** (per-row `l1`/`l2` norms and `hh_keys` are dropped from the msgpack wire).
- `compute_delta_msgpack` / `apply_delta_msgpack_bytes` on each sketch — thin twins of the proto `compute_delta` / `apply_delta_bytes`, reusing the identical per-bucket/cell/register diff loops but serializing via the new codec.

KLL stays full-only (no delta type). The proto path is untouched.

## Tests

Per sketch: round-trip (`compute_delta_msgpack` → `apply_delta_msgpack_bytes` reconstructs state), delta-against-empty parity, and a wire-layout-lock test pinning the parallel-array tuple (the fixture the Go side mirrors).

`cargo test --lib` → 434 passed. `cargo clippy -- -D warnings` + `cargo fmt --check` clean.

## Follow-up

Go parity for the 3 not-yet-done encoders (DDSketch/HLL/CMS deltas) under `sketchlib-go/wire/asapmsgpack/` — CountSketch already exists; the wire layout is frozen by the Rust golden tests here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)