### PR TITLE
fix(kll): weight-preserving cross-host merge (#68)

### DIFF
--- a/src/sketches/kll.rs
+++ b/src/sketches/kll.rs
@@ -496,10 +496,10 @@ impl<T: NumericalValue> KLL<T> {
     /// retained items at that level are combined (level 0 is unsorted, so
     /// it's concatenated and re-sorted; levels ≥ 1 are each already sorted
     /// in a valid KLL, so the two runs are combined in place with
-    /// [`merge_sorted_runs`]). Any level left over its own capacity by the
+    /// `merge_sorted_runs`). Any level left over its own capacity by the
     /// merge is then compacted with the exact same randomized
-    /// halve-and-promote step ordinary inserts use, via [`randomly_halve_up`]
-    /// and [`merge_sorted_runs`] again, looping at that level until it
+    /// halve-and-promote step ordinary inserts use, via `randomly_halve_up`
+    /// and `merge_sorted_runs` again, looping at that level until it
     /// settles back within bounds. A merge can leave a level arbitrarily far
     /// over capacity, unlike a single `push_value`, which can only overshoot
     /// by one element, so unlike `compress_while_updating` this cascade can

--- a/src/sketches/kll.rs
+++ b/src/sketches/kll.rs
@@ -105,7 +105,12 @@ fn compute_max_capacity(k: usize, m: usize) -> usize {
 /// `items[begin..begin+pop]` so they are contiguous with the level above.
 /// Traverses backwards to avoid overwriting unread source elements.
 #[inline]
-fn randomly_halve_up<T: Copy>(items: &mut [T], begin: usize, pop: usize, offset: usize) -> usize {
+pub(crate) fn randomly_halve_up<T: Copy>(
+    items: &mut [T],
+    begin: usize,
+    pop: usize,
+    offset: usize,
+) -> usize {
     let num_survivors = (pop - offset).div_ceil(2);
     let dest = begin + pop - num_survivors;
     for d in (0..num_survivors).rev() {
@@ -118,7 +123,11 @@ fn randomly_halve_up<T: Copy>(items: &mut [T], begin: usize, pop: usize, offset:
 /// `slice[..left_len]` is the first sorted run, `slice[left_len..]` is the
 /// second.  `buf` is a reusable scratch buffer.
 #[inline]
-fn merge_sorted_runs<T: NumericalValue>(slice: &mut [T], left_len: usize, buf: &mut Vec<T>) {
+pub(crate) fn merge_sorted_runs<T: NumericalValue>(
+    slice: &mut [T],
+    left_len: usize,
+    buf: &mut Vec<T>,
+) {
     let total = slice.len();
     if left_len == 0 || left_len >= total {
         return;
@@ -478,12 +487,128 @@ impl<T: NumericalValue> KLL<T> {
         cdf
     }
 
-    /// Merges all items from another KLL sketch into this one.
+    /// Merges another KLL sketch's retained items into this one,
+    /// **preserving each retained item's level weight** (`2^level`)
+    /// instead of discarding it.
+    ///
+    /// This is the standard weight-preserving KLL merge: for every
+    /// compactor level `h` present in either sketch, the two sketches'
+    /// retained items at that level are combined (level 0 is unsorted, so
+    /// it's concatenated and re-sorted; levels ≥ 1 are each already sorted
+    /// in a valid KLL, so the two runs are combined in place with
+    /// [`merge_sorted_runs`]). Any level left over its own capacity by the
+    /// merge is then compacted with the exact same randomized
+    /// halve-and-promote step ordinary inserts use, via [`randomly_halve_up`]
+    /// and [`merge_sorted_runs`] again, looping at that level until it
+    /// settles back within bounds. A merge can leave a level arbitrarily far
+    /// over capacity, unlike a single `push_value`, which can only overshoot
+    /// by one element, so unlike `compress_while_updating` this cascade can
+    /// revisit the same level more than once.
+    ///
+    /// ### The bug this replaces
+    ///
+    /// The previous implementation was pure item-replay: it walked every
+    /// retained item of `other` (regardless of which level it lived at)
+    /// and re-inserted it via `push_value` — i.e. at weight 1. A retained
+    /// item at level `L` represents `2^L` original observations, so
+    /// replaying it at weight 1 silently collapsed `other`'s total ingested
+    /// weight down to just its *retained item count*. This was most
+    /// visible merging into an *empty* target: e.g. merging a KLL built
+    /// over `1..=1000` (`k=200`, which compacts most of its mass up to
+    /// levels ≥ 1) into a fresh sketch dropped the count from 1000 down to
+    /// roughly the ~350 items `other` had physically retained, and
+    /// skewed the median upward because the high-weight upper-level items
+    /// (which cover the full value range) were undercounted relative to
+    /// the low-weight level-0 leftovers. Interleaving level-by-level
+    /// (this implementation) has no such special case: merging into an
+    /// empty target is simply a no-op union at every level, so the
+    /// source's structure — and its weight — comes through exactly.
     pub fn merge(&mut self, other: &KLL<T>) {
-        let used_start = other.levels[0];
-        let used_end = other.levels[other.num_levels];
-        for &value in &other.items[used_start..used_end] {
-            self.push_value(value);
+        let other_start = other.levels[0];
+        let other_end = other.levels[other.num_levels];
+        if other_end == other_start {
+            return; // `other` is empty: nothing to merge.
+        }
+
+        let target_num_levels = self.num_levels.max(other.num_levels);
+
+        // work[h] holds level h's combined (not-yet-compacted) retained
+        // items. +1 slack so `work[h + 1]` is always valid while cascading.
+        let mut work: Vec<Vec<T>> = vec![Vec::new(); target_num_levels + 1];
+        #[allow(clippy::needless_range_loop)] // `h` also indexes self.levels/self.items
+        for h in 0..self.num_levels {
+            let s = self.levels[h];
+            let e = self.levels[h + 1];
+            work[h].extend_from_slice(&self.items[s..e]);
+        }
+        let mut merge_buf: Vec<T> = Vec::new();
+        #[allow(clippy::needless_range_loop)] // `h` also indexes other.levels/other.items
+        for h in 0..other.num_levels {
+            let s = other.levels[h];
+            let e = other.levels[h + 1];
+            let self_len = work[h].len();
+            work[h].extend_from_slice(&other.items[s..e]);
+            // Levels >= 1 are individually sorted in both operands already;
+            // normalize the concatenation into one sorted run up front so
+            // the cascade below can treat every level >= 1 as sorted, same
+            // as the invariant a settled KLL always maintains.
+            if h > 0 {
+                merge_sorted_runs(work[h].as_mut_slice(), self_len, &mut merge_buf);
+            }
+        }
+
+        // Grow self's level bookkeeping to cover the merged height.
+        self.num_levels = target_num_levels;
+        self.rebuild_capacity_cache();
+
+        // Cascade-compact exactly like `compress_while_updating`/`compact`,
+        // except a level may need more than one halving pass here (a merge
+        // can leave a level far over capacity, not just one element over).
+        let mut h = 0;
+        while h < self.num_levels {
+            if h == 0 {
+                work[0].sort_unstable_by(T::total_cmp);
+            }
+            while work[h].len() > self.capacity_for_level(h) {
+                if h + 1 == self.num_levels {
+                    self.num_levels += 1;
+                    self.rebuild_capacity_cache();
+                    work.resize(self.num_levels + 1, Vec::new());
+                }
+                let pop = work[h].len();
+                let offset = usize::from(self.co.toss());
+                let num_survivors = randomly_halve_up(work[h].as_mut_slice(), 0, pop, offset);
+                let discard = pop - num_survivors;
+                work[h].drain(0..discard);
+
+                // Promote the (sorted) survivors into level h+1, merging
+                // with its existing (already-sorted) content.
+                let mut promoted = std::mem::take(&mut work[h]);
+                let left_len = promoted.len();
+                promoted.append(&mut work[h + 1]);
+                merge_sorted_runs(promoted.as_mut_slice(), left_len, &mut merge_buf);
+                work[h + 1] = promoted;
+            }
+            h += 1;
+        }
+
+        // Write the compacted per-level vectors back into the fixed
+        // buffer, top level first (matches the buffer's grow-leftward
+        // layout). `total <= max_capacity` is guaranteed here because
+        // every level 0..self.num_levels now satisfies its own capacity
+        // bound — the same invariant a live KLL always maintains — and
+        // max_capacity is exactly the sum of all per-level capacities.
+        let mc = self.max_capacity;
+        let mut cursor = mc;
+        for h in (0..self.num_levels).rev() {
+            let len = work[h].len();
+            cursor -= len;
+            self.items[cursor..cursor + len].copy_from_slice(&work[h]);
+            self.levels[h] = cursor;
+        }
+        self.levels[self.num_levels] = mc;
+        for lvl in self.levels[self.num_levels + 1..].iter_mut() {
+            *lvl = mc;
         }
     }
 
@@ -1266,6 +1391,140 @@ mod tests {
             "merge",
             values.len(),
             0x00C0_FFEE,
+        );
+    }
+
+    // Exact repro from asap_sketchlib issue #68: merging a KLL(k=200) over
+    // 1..=1000 into an empty sketch used to drop N from 1000 to ~350 and
+    // drift the median from ~500 to ~700, because the old `merge` replayed
+    // every retained item through `update()` at weight 1 — discarding the
+    // level weight of every item retained above level 0.
+    //
+    // Note on the count assertion: `count()` is only *approximately* N even
+    // for a sketch built by plain `update()` calls with no merge involved —
+    // odd-sized levels can resolve to `2*ceil(pop/2)` or `2*floor(pop/2)`
+    // depending on the compaction coin, off by +/-1 per affected level (see
+    // `generic_kll_i64_sanity` above, which already documents this and
+    // budgets a 5% tolerance). That's an inherent, pre-existing property of
+    // randomized-halving KLL and orthogonal to this bug. What the fix
+    // guarantees is that merging into an *empty* target is a pure
+    // structural no-op — `other`'s levels already each satisfy their own
+    // capacity, so folding them into an empty self triggers no further
+    // compaction at all — so `dst.count()` must come out **exactly equal**
+    // to `src.count()`, whatever that value is, not rescaled down to
+    // src's *retained item count* the way the old buggy merge did.
+    #[test]
+    fn merge_into_empty_target_preserves_weight_issue_68_repro() {
+        let mut src = KLL::<f64>::init_kll(SKETCH_K);
+        for i in 1..=1000u32 {
+            src.update(&(i as f64));
+        }
+
+        // Sanity: plain inserts (no merge) track N closely; confirms the
+        // source sketch itself is healthy before we exercise merge.
+        let src_count = src.count();
+        assert!(
+            (980..=1020).contains(&src_count),
+            "source sketch count before merge should track N=1000 closely, got {src_count}"
+        );
+
+        let mut dst = KLL::<f64>::init_kll(SKETCH_K);
+        assert_eq!(dst.count(), 0, "target must start empty for this repro");
+
+        dst.merge(&src);
+
+        assert_eq!(
+            dst.count(),
+            src_count,
+            "merge into an empty target must preserve total weight EXACTLY \
+             (the old item-replay merge rescaled this down to src's \
+             retained-item count, e.g. 1000 -> ~350)"
+        );
+
+        let median = dst.quantile(0.5);
+        // True median of 1..=1000 is 500/500.5. KLL's guaranteed rank error
+        // at k=200 is well under 5% of the domain for this small, orderly
+        // input; allow a generous +/-5% band (pre-fix this drifted to
+        // ~700, a 40% error, so this comfortably distinguishes fixed vs.
+        // buggy behavior).
+        assert!(
+            (475.0..=525.0).contains(&median),
+            "merged median drifted outside tolerance: median={median} \
+             (pre-fix this drifted to ~700)"
+        );
+    }
+
+    // General case: merging two NON-empty KLLs must still preserve total
+    // count (within the same inherent +/-1-per-compacted-level rounding
+    // budget as ordinary inserts — see the note above) and produce
+    // quantile estimates consistent with a reference built from the union
+    // of both inputs' raw data (within KLL's accuracy bound). This guards
+    // against a fix that only special-cases the empty-target repro above
+    // without being a genuinely correct weighted merge for the general
+    // case.
+    #[test]
+    fn merge_two_nonempty_sketches_preserves_weight_and_quantiles() {
+        const TOLERANCE: f64 = 0.03;
+        const QUANTILES: &[(f64, &str)] = &[
+            (0.0, "min"),
+            (0.10, "p10"),
+            (0.25, "p25"),
+            (0.50, "p50"),
+            (0.75, "p75"),
+            (0.90, "p90"),
+            (1.0, "max"),
+        ];
+
+        // Each side gets enough volume (and a different distribution) to
+        // force real compaction, i.e. non-trivial retained-item weights at
+        // multiple levels on BOTH operands before they're merged.
+        let values_a = sample_uniform_f64(0.0, 1_000_000.0, 50_000, 0xA11CE);
+        let values_b = sample_zipf_f64(0.0, 1_000_000.0, 8_192, 1.1, 50_000, 0xB0B);
+
+        let mut a = KLL::<f64>::init_kll(SKETCH_K);
+        for v in &values_a {
+            a.update(v);
+        }
+        let mut b = KLL::<f64>::init_kll(SKETCH_K);
+        for v in &values_b {
+            b.update(v);
+        }
+
+        let count_a = a.count();
+        let count_b = b.count();
+        // Sanity: plain-insert counts track N closely (see note above).
+        assert!(
+            (count_a as f64 - values_a.len() as f64).abs() / (values_a.len() as f64) < 0.03,
+            "sketch a count before merge diverged from N: count={count_a}, n={}",
+            values_a.len()
+        );
+        assert!(
+            (count_b as f64 - values_b.len() as f64).abs() / (values_b.len() as f64) < 0.03,
+            "sketch b count before merge diverged from N: count={count_b}, n={}",
+            values_b.len()
+        );
+
+        a.merge(&b);
+
+        let merged_count = a.count() as f64;
+        let expected_count = (count_a + count_b) as f64;
+        assert!(
+            (merged_count - expected_count).abs() / expected_count < 0.03,
+            "merging two non-empty sketches must preserve total weight (within the \
+             same rounding budget as ordinary inserts): merged={merged_count}, \
+             expected~={expected_count} (count_a={count_a}, count_b={count_b})"
+        );
+
+        let mut union: Vec<f64> = values_a.iter().chain(values_b.iter()).copied().collect();
+        union.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        assert_quantiles_within_error(
+            &a,
+            &union,
+            QUANTILES,
+            TOLERANCE,
+            "merge_two_nonempty",
+            union.len(),
+            0xA11C_E0B0,
         );
     }
 

--- a/src/sketches/kll_dynamic.rs
+++ b/src/sketches/kll_dynamic.rs
@@ -329,6 +329,21 @@ impl<T: NumericalValue> KLLDynamic<T> {
         // items. +1 slack so `work[h + 1]` is always valid while cascading.
         let mut work: Vec<Vec<T>> = vec![Vec::new(); target_num_levels + 1];
 
+        // Unlike `KLL` (fixed-capacity), whose `compact` only ever sorts
+        // level 0 and otherwise maintains sortedness of levels >= 1 as a
+        // standing invariant via merge-promotion, `KLLDynamic::compact`
+        // re-sorts a level's *entire* current contents from scratch on
+        // every call. So a level here is only guaranteed sorted right
+        // after its own last compaction — one that has since received a
+        // promotion from below is a concatenation of separately-sorted
+        // runs, not one sorted run as a whole. Neither operand's levels
+        // (including >= 1) can be assumed pre-sorted, so sort each
+        // operand's own contribution to a level before combining. That's
+        // also cheaper than concatenating first and sorting the combined
+        // (up to 2x larger) run: O(a log a + b log b) beats O((a+b)
+        // log(a+b)), and the two now-genuinely-sorted runs merge in
+        // linear time via the existing `merge_sorted_runs`.
+        //
         // Absolute level `h` lives at array index `num_levels - 1 - h`.
         #[allow(clippy::needless_range_loop)] // `h` also indexes self.levels/self.items
         for h in 0..self.num_levels {
@@ -336,6 +351,7 @@ impl<T: NumericalValue> KLLDynamic<T> {
             let levels = self.levels.as_slice();
             let (s, e) = (levels[idx], levels[idx + 1]);
             work[h].extend_from_slice(&self.items.as_slice()[s..e]);
+            work[h].sort_unstable_by(T::total_cmp);
         }
         let mut merge_buf: Vec<T> = Vec::new();
         #[allow(clippy::needless_range_loop)] // `h` also indexes other.levels/other.items
@@ -345,12 +361,8 @@ impl<T: NumericalValue> KLLDynamic<T> {
             let (s, e) = (levels[idx], levels[idx + 1]);
             let self_len = work[h].len();
             work[h].extend_from_slice(&other.items.as_slice()[s..e]);
-            // Levels >= 1 are individually sorted in both operands
-            // already; normalize the concatenation into one sorted run up
-            // front, same as the invariant a settled sketch maintains.
-            if h > 0 {
-                merge_sorted_runs(work[h].as_mut_slice(), self_len, &mut merge_buf);
-            }
+            work[h][self_len..].sort_unstable_by(T::total_cmp);
+            merge_sorted_runs(work[h].as_mut_slice(), self_len, &mut merge_buf);
         }
 
         // Grow self's level bookkeeping to cover the merged height.
@@ -360,11 +372,11 @@ impl<T: NumericalValue> KLLDynamic<T> {
         // Cascade-compact exactly like `compress_while_needed`/`compact`,
         // except a level may need more than one halving pass here (a merge
         // can leave a level far over capacity, not just one element over).
+        // Every level was sorted up front (above), and each promotion
+        // below keeps its target level sorted via `merge_sorted_runs`, so
+        // no level needs re-sorting once the cascade begins.
         let mut h = 0;
         while h < self.num_levels {
-            if h == 0 {
-                work[0].sort_unstable_by(T::total_cmp);
-            }
             while work[h].len() > self.capacity_for_level(h) {
                 if h + 1 == self.num_levels {
                     self.num_levels += 1;
@@ -913,6 +925,54 @@ mod tests {
             union.len(),
             0xA11C_E0B0,
         );
+    }
+
+    // Deterministic regression for a PR #71 review comment: `merge`
+    // assumed level h (h >= 1) is always a single sorted run in both
+    // operands. That holds for `KLL` (fixed-capacity), whose `compact`
+    // maintains it as a standing invariant via merge-promotion — but
+    // `KLLDynamic::compact` re-sorts a level's *entire* contents from
+    // scratch on every call instead, so a level that received a
+    // promotion since its last compaction can be a concatenation of
+    // separately-sorted chunks, not one sorted run. `randomly_halve_up`'s
+    // alternating-position subsampling is only value-order-correct on
+    // truly sorted input, and doesn't sort its input itself — so feeding
+    // it an unsorted level silently produces an unsorted (and thus not
+    // rank-error-bounded) survivor set.
+    //
+    // Hand-build `other`'s level 1 in exactly that legitimate-but-unsorted
+    // shape (two independently-ascending chunks concatenated out of
+    // order), small enough to stay well under capacity so level 1 is
+    // never itself compacted during the merge — the output then reflects
+    // the construction phase's ordering assumption directly, with no
+    // randomized (`Coin`) compaction able to mask the bug, keeping this
+    // test deterministic.
+    #[test]
+    fn merge_handles_operand_level_that_is_not_a_single_sorted_run() {
+        let mut other = KLLDynamic::<f64>::init(50, 4);
+        other.items = Vector1D::from_vec(vec![30.0, 40.0, 10.0, 20.0, 5.0]);
+        other.levels = Vector1D::from_vec(vec![0, 4, 5]);
+        other.num_levels = 2;
+        other.rebuild_capacity_cache();
+        assert!(
+            other.capacity_for_level(1) >= 4,
+            "test setup needs level 1 to stay under capacity, uncompacted"
+        );
+
+        let mut dst = KLLDynamic::<f64>::init(50, 4);
+        dst.merge(&other);
+
+        let levels = dst.levels.as_slice();
+        let items = dst.items.as_slice();
+        for h in 1..dst.num_levels {
+            let level_idx = dst.num_levels - 1 - h;
+            let (s, e) = (levels[level_idx], levels[level_idx + 1]);
+            assert!(
+                items[s..e].windows(2).all(|w| w[0] <= w[1]),
+                "level {h} is not a single ascending sorted run after merge: {:?}",
+                &items[s..e]
+            );
+        }
     }
 
     #[test]

--- a/src/sketches/kll_dynamic.rs
+++ b/src/sketches/kll_dynamic.rs
@@ -20,7 +20,7 @@ use crate::common::input::data_input_to_f64;
 use crate::common::numerical::NumericalValue;
 use crate::{DataInput, Vector1D};
 
-use super::kll::Coin;
+use super::kll::{Coin, merge_sorted_runs, randomly_halve_up};
 
 const CAPACITY_CACHE_LEN: usize = 20;
 const MAX_CACHEABLE_K: usize = 26_602;
@@ -305,11 +305,102 @@ impl<T: NumericalValue> KLLDynamic<T> {
         cdf
     }
 
-    /// Merges another sketch into this one.
+    /// Merges another sketch's retained items into this one, preserving
+    /// each retained item's level weight (`2^level`) instead of discarding
+    /// it. See [`KLL::merge`](super::kll::KLL::merge) for the full
+    /// rationale — this is the same weight-preserving, level-by-level
+    /// interleave-and-recompact merge (concatenate each level's retained
+    /// items, then re-run the same randomized halve-and-promote compaction
+    /// ordinary inserts use), adapted to `KLLDynamic`'s growable (rather
+    /// than fixed-capacity) backing storage.
+    ///
+    /// The previous implementation replayed *every* item of `other` —
+    /// across all of its levels — through `push_value`, i.e. at weight 1,
+    /// silently discarding the level weight of everything `other` had
+    /// retained above level 0 (the same class of bug as `KLL::merge`, see
+    /// asap_sketchlib issue #68).
     pub fn merge(&mut self, other: &KLLDynamic<T>) {
-        for &value in other.items.as_slice() {
-            self.push_value(value);
+        if other.items.is_empty() {
+            return; // `other` is empty: nothing to merge.
         }
+
+        let target_num_levels = self.num_levels.max(other.num_levels);
+        // work[h] holds level h's combined (not-yet-compacted) retained
+        // items. +1 slack so `work[h + 1]` is always valid while cascading.
+        let mut work: Vec<Vec<T>> = vec![Vec::new(); target_num_levels + 1];
+
+        // Absolute level `h` lives at array index `num_levels - 1 - h`.
+        #[allow(clippy::needless_range_loop)] // `h` also indexes self.levels/self.items
+        for h in 0..self.num_levels {
+            let idx = self.num_levels - 1 - h;
+            let levels = self.levels.as_slice();
+            let (s, e) = (levels[idx], levels[idx + 1]);
+            work[h].extend_from_slice(&self.items.as_slice()[s..e]);
+        }
+        let mut merge_buf: Vec<T> = Vec::new();
+        #[allow(clippy::needless_range_loop)] // `h` also indexes other.levels/other.items
+        for h in 0..other.num_levels {
+            let idx = other.num_levels - 1 - h;
+            let levels = other.levels.as_slice();
+            let (s, e) = (levels[idx], levels[idx + 1]);
+            let self_len = work[h].len();
+            work[h].extend_from_slice(&other.items.as_slice()[s..e]);
+            // Levels >= 1 are individually sorted in both operands
+            // already; normalize the concatenation into one sorted run up
+            // front, same as the invariant a settled sketch maintains.
+            if h > 0 {
+                merge_sorted_runs(work[h].as_mut_slice(), self_len, &mut merge_buf);
+            }
+        }
+
+        // Grow self's level bookkeeping to cover the merged height.
+        self.num_levels = target_num_levels;
+        self.rebuild_capacity_cache();
+
+        // Cascade-compact exactly like `compress_while_needed`/`compact`,
+        // except a level may need more than one halving pass here (a merge
+        // can leave a level far over capacity, not just one element over).
+        let mut h = 0;
+        while h < self.num_levels {
+            if h == 0 {
+                work[0].sort_unstable_by(T::total_cmp);
+            }
+            while work[h].len() > self.capacity_for_level(h) {
+                if h + 1 == self.num_levels {
+                    self.num_levels += 1;
+                    self.rebuild_capacity_cache();
+                    work.resize(self.num_levels + 1, Vec::new());
+                }
+                let pop = work[h].len();
+                let offset = usize::from(self.co.toss());
+                let num_survivors = randomly_halve_up(work[h].as_mut_slice(), 0, pop, offset);
+                let discard = pop - num_survivors;
+                work[h].drain(0..discard);
+
+                // Promote the (sorted) survivors into level h+1, merging
+                // with its existing (already-sorted) content.
+                let mut promoted = std::mem::take(&mut work[h]);
+                let left_len = promoted.len();
+                promoted.append(&mut work[h + 1]);
+                merge_sorted_runs(promoted.as_mut_slice(), left_len, &mut merge_buf);
+                work[h + 1] = promoted;
+            }
+            h += 1;
+        }
+
+        // Rebuild `items`/`levels` from the compacted per-level vectors,
+        // top level first, matching this type's storage order (array
+        // index 0 == top level, growing toward level 0 at the tail).
+        let total: usize = work[..self.num_levels].iter().map(Vec::len).sum();
+        let mut items = Vec::with_capacity(total);
+        let mut levels = Vec::with_capacity(self.num_levels + 1);
+        levels.push(0usize);
+        for h in (0..self.num_levels).rev() {
+            items.extend_from_slice(&work[h]);
+            levels.push(items.len());
+        }
+        self.items = Vector1D::from_vec(items);
+        self.levels = Vector1D::from_vec(levels);
     }
 
     /// Returns the estimated value at quantile `q`.
@@ -709,6 +800,118 @@ mod tests {
             "merge",
             values.len(),
             0x00C0_FFEE,
+        );
+    }
+
+    // Exact repro from asap_sketchlib issue #68 (KLLDynamic variant):
+    // merging a KLL(k=200) over 1..=1000 into an empty sketch used to
+    // rescale N down to `other`'s retained-item count and drift the
+    // median, because the old `merge` replayed every retained item
+    // through `push_value` at weight 1 regardless of which level it was
+    // retained at. Merging into an empty target is a pure structural
+    // no-op (interleaving with nothing) with the fix, so `dst.count()`
+    // must come out EXACTLY equal to `src.count()` — no further
+    // compaction is triggered since `other`'s levels already each satisfy
+    // their own capacity. (`count()` itself is only approximately N even
+    // for plain inserts, per KLL's randomized-halving rounding — see
+    // `generic_kll_dynamic_i64_sanity` above — so we compare src vs. dst,
+    // not against a literal 1000.)
+    #[test]
+    fn merge_into_empty_target_preserves_weight_issue_68_repro() {
+        let mut src = KLLDynamic::<f64>::init_kll(SKETCH_K);
+        for i in 1..=1000u32 {
+            src.update(&(i as f64));
+        }
+        let src_count = src.count();
+        assert!(
+            (980..=1020).contains(&src_count),
+            "source sketch count before merge should track N=1000 closely, got {src_count}"
+        );
+
+        let mut dst = KLLDynamic::<f64>::init_kll(SKETCH_K);
+        assert_eq!(dst.count(), 0, "target must start empty for this repro");
+
+        dst.merge(&src);
+
+        assert_eq!(
+            dst.count(),
+            src_count,
+            "merge into an empty target must preserve total weight EXACTLY \
+             (the old item-replay merge rescaled this down to src's \
+             retained-item count)"
+        );
+
+        let median = dst.quantile(0.5);
+        assert!(
+            (475.0..=525.0).contains(&median),
+            "merged median drifted outside tolerance: median={median}"
+        );
+    }
+
+    // General case: merging two NON-empty KLLDynamic sketches must still
+    // preserve total count (within the same inherent rounding budget as
+    // ordinary inserts) and produce quantile estimates consistent with a
+    // reference built from the union of both inputs' raw data. Guards
+    // against a fix that only special-cases the empty-target repro above.
+    #[test]
+    fn merge_two_nonempty_sketches_preserves_weight_and_quantiles() {
+        const TOLERANCE: f64 = 0.03;
+        const QUANTILES: &[(f64, &str)] = &[
+            (0.0, "min"),
+            (0.10, "p10"),
+            (0.25, "p25"),
+            (0.50, "p50"),
+            (0.75, "p75"),
+            (0.90, "p90"),
+            (1.0, "max"),
+        ];
+
+        let values_a = sample_uniform_f64(0.0, 1_000_000.0, 50_000, 0xA11CE);
+        let values_b = sample_zipf_f64(0.0, 1_000_000.0, 8_192, 1.1, 50_000, 0xB0B);
+
+        let mut a = KLLDynamic::<f64>::init_kll(SKETCH_K);
+        for v in &values_a {
+            a.update(v);
+        }
+        let mut b = KLLDynamic::<f64>::init_kll(SKETCH_K);
+        for v in &values_b {
+            b.update(v);
+        }
+
+        let count_a = a.count();
+        let count_b = b.count();
+        assert!(
+            (count_a as f64 - values_a.len() as f64).abs() / (values_a.len() as f64) < 0.03,
+            "sketch a count before merge diverged from N: count={count_a}, n={}",
+            values_a.len()
+        );
+        assert!(
+            (count_b as f64 - values_b.len() as f64).abs() / (values_b.len() as f64) < 0.03,
+            "sketch b count before merge diverged from N: count={count_b}, n={}",
+            values_b.len()
+        );
+
+        a.merge(&b);
+
+        let merged_count = a.count() as f64;
+        let expected_count = (count_a + count_b) as f64;
+        assert!(
+            (merged_count - expected_count).abs() / expected_count < 0.03,
+            "merging two non-empty sketches must preserve total weight (within the \
+             same rounding budget as ordinary inserts): merged={merged_count}, \
+             expected~={expected_count} (count_a={count_a}, count_b={count_b})"
+        );
+
+        let mut union: Vec<f64> = values_a.iter().chain(values_b.iter()).copied().collect();
+        union.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        assert_quantiles_within_error(
+            &a,
+            &union,
+            QUANTILES,
+            TOLERANCE,
+            "merge_two_nonempty",
+            union.len(),
+            0xA11C_E0B0,
         );
     }
 


### PR DESCRIPTION
Fixes #68 — KLL cross-host merge loses level weights.

## Root cause
`KLL::merge` (and the identical bug in `KLLDynamic::merge`) was pure item-replay: it walked every retained item of `other` regardless of compactor level and re-inserted each via `push_value()` at weight 1. A retained item at level `L` represents `2^L` observations, so this silently rescaled `other`'s total weight down to its retained-item count. Confirmed against the issue's repro: KLL(k=200) over `1..=1000` (count ≈995) merged into an empty sketch → count **353**, median drifts out of the ±5% band around 500 (matches the reported 1000→~350 / 500→~700).

## Fix
Standard weight-preserving KLL merge: for every compactor level present in either sketch, concatenate both sketches' retained items at that level (re-sort L0; merge the two already-sorted runs for L≥1 via the existing `merge_sorted_runs`), then cascade-compact any over-capacity level using the existing `randomly_halve_up` + `merge_sorted_runs` primitives — the same algorithm ordinary inserts use — looping at a level since a merge can leave it far over capacity (unlike a single insert). Merging into an empty target is now a true per-level no-op, no special case. `randomly_halve_up`/`merge_sorted_runs` made `pub(crate)` so `KLLDynamic::merge` reuses them.

The msgpack ingest surface (`KllSketch::merge`/`merge_refs`, `HydraKllSketch::merge`) delegates straight to `KLL::merge`, so it's fixed automatically. No separate proto replay path exists in the crate (`KllProtoItems` is decode/one-shot only). `asap-precompute-rs`'s `KLLWrapper` (a separate repo) switching off item-replay is an out-of-scope follow-up.

Motivation: the ASAPCollector GOS work ships many more, smaller KLL segments than the old periodic model, so a weight-losing merge corrupts backend-reconstructed quantiles progressively worse — this fix is a prerequisite for that to be correct.

## Test plan
- [x] `merge_into_empty_target_preserves_weight_issue_68_repro` — exact repro; verified it FAILS on old code (995→353) and passes after (count preserved, median in 475..=525).
- [x] `merge_two_nonempty_sketches_preserves_weight_and_quantiles` — two heavily-compacted sketches (uniform + Zipf, 50k each), total weight + quantiles vs the raw union.
- [x] `cargo build`, `cargo test` (430 unit + 12 msgpack-compat + 4 go-parity + 1 xtest + 19 doctests), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo fmt --check` — all clean, matching CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)