### PR TITLE
fix(cms): stop clamping RegularPath estimates at i32::MAX

### DIFF
--- a/src/sketches/countminsketch.rs
+++ b/src/sketches/countminsketch.rs
@@ -311,8 +311,11 @@ where
     pub fn estimate(&self, value: &DataInput) -> S::Counter {
         let rows = self.counts.rows();
         let cols = self.counts.cols();
-        let mut min = S::Counter::from(i32::MAX);
-        for r in 0..rows {
+        // Seed the running minimum from row 0's probed cell, then fold in the
+        // rest. Mirrors the fast path's `fast_query_min`.
+        let col0 = ((H::hash64_seeded(0, value) & LOWER_32_MASK) as usize) % cols;
+        let mut min = self.counts.query_one_counter(0, col0);
+        for r in 1..rows {
             let hashed = H::hash64_seeded(r, value);
             let col = ((hashed & LOWER_32_MASK) as usize) % cols;
             let v = self.counts.query_one_counter(r, col);
@@ -710,6 +713,25 @@ mod tests {
                 "fast path should match standard insert for key {key:?}"
             );
         }
+    }
+
+    #[test]
+    fn estimate_does_not_clamp_i64_counts_above_i32_max() {
+        // Regression: the running minimum used to be seeded with `i32::MAX`,
+        // which clamped i64 estimates whenever every probed cell exceeded
+        // 2147483647, capping large counts at 2147483647.
+        let mut sk = CountMin::<Vector2D<i64>, RegularPath>::with_dimensions(3, 64);
+        let key = DataInput::Str("pkt_len");
+        let count: i64 = 35_000_000_000; // ~35 billion, well past i32::MAX
+
+        sk.insert_many(&key, count);
+
+        let est = sk.estimate(&key);
+        assert!(
+            est >= count,
+            "estimate {est} should be at least the true count {count}, not clamped"
+        );
+        assert_ne!(est, i32::MAX as i64, "estimate must not clamp to i32::MAX");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`CountMin::estimate` on the **regular path** seeds the running minimum with `S::Counter::from(i32::MAX)`:

```rust
let mut min = S::Counter::from(i32::MAX);
for r in 0..rows {
    ...
    if v < min { min = v; }
}
min
```

For counters wider than `i32` (`i64`/`i128`), any key whose probed cells **all** exceed `2147483647` never fires the `v < min` update, so `estimate` returns the seed unchanged — silently capping every large count at exactly `2147483647`.

This bites real workloads: e.g. `CMSHeap<Vector2D<i64>, RegularPath>` over a `SUM(pkt_len)` window where true per-key totals run into the tens of billions. Every such key comes back as `2147483647`.

### Scope
- **CMS RegularPath** — affected (this fix).
- **CMS FastPath** — not affected; `fast_query_min` already seeds from row 0.
- **CMSHeap** — affected only when built on `RegularPath` (the struct default `Mode`); it delegates to `cms.estimate`.
- **CountSketch / CSHeap** — not affected; they take a median over `f64`, no constant seed.

The bug only manifests with counts `> i32::MAX` **and** a counter type wider than `i32`, which is why existing tests (small counts / `i32` counters) never caught it.

## Fix

Seed the running minimum from row 0's probed cell, then fold in rows `1..rows` — mirroring the fast path's `fast_query_min`. No trait-bound or API changes.

## Test

Adds `estimate_does_not_clamp_i64_counts_above_i32_max`: an `i64` sketch loaded with ~35 billion and asserting the estimate is not clamped. Fails on the old seed, passes now. Full `countminsketch` suite (64 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)