### PR TITLE
feat: mark UnivMon-Q experimental and add evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,15 @@ signals a backwards-compatible change.
 - Removed duplicate stream-weight accounting in experimental UnivMon windows.
 
 ### Added
-- **UnivMon-Q core sketch.** Adds `UnivMonQ<H>`, a Joltik-style terminal-stratum
-  UnivMon implementation extended with a coordinated ordered sample for rank,
-  CDF, and quantile estimates. The sketch supports pluggable `SketchHasher`,
-  compatible merges, native MessagePack round-trips, exact extrema, point
-  frequency, F0, F2, F3, generic g-sums, entropy, and recovered heavy-hitter
-  queries. Reusable prepared query views share logical-hierarchy and CDF
-  reconstruction across a metric batch. The API is initially marked
-  `Unstable`; an ASAPv1 cross-language kind is not yet assigned.
+- **Experimental UnivMon-Q core sketch.** Adds `UnivMonQ<H>`, a Joltik-style
+  terminal-stratum UnivMon implementation extended with an adaptively assisted
+  occurrence sample for rank, CDF, and quantile estimates. The sketch supports
+  pluggable `SketchHasher`, compatible merges, native MessagePack round-trips,
+  exact extrema, point frequency, F0, F2, compatible generic g-sums, entropy,
+  and recovered heavy-hitter queries. Reusable prepared query views share
+  logical-hierarchy and CDF reconstruction across a metric batch. The API,
+  estimators, and guarantees are experimental; an ASAPv1 cross-language kind
+  is not yet assigned.
 
 ### Changed (breaking — wire format)
 - **Drop the DataPoint-level METRIC scalars from `DDSketchState`.** Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,15 @@ signals a backwards-compatible change.
   threshold, tracked whether bounded candidate sets are complete, and made
   queries refresh candidate frequencies from current CountSketch counters.
 - Removed duplicate stream-weight accounting in experimental UnivMon windows.
+- Made L1 exact for UnivMon, UnivMonPyramid, and experimental UnivMon-Q by
+  returning their tracked non-negative stream weight instead of evaluating a
+  noisy generic recurrence.
 
 ### Added
 - **Experimental UnivMon-Q core sketch.** Adds `UnivMonQ<H>`, a Joltik-style
   terminal-stratum UnivMon implementation extended with an adaptively assisted
-  occurrence sample for rank, CDF, and quantile estimates. The sketch supports
-  pluggable `SketchHasher`, compatible merges, native MessagePack round-trips,
+  occurrence sample for entropy, rank, CDF, and quantile estimates. The sketch
+  supports pluggable `SketchHasher`, compatible merges, native MessagePack round-trips,
   exact extrema, point frequency, F0, F2, compatible generic g-sums, entropy,
   and recovered heavy-hitter queries. Reusable prepared query views share
   logical-hierarchy and CDF reconstruction across a metric batch. The API,

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ A Rust library for **streaming data sketches** — compact data structures that 
 | --- | --- | --- | --- | --- |
 | Frequency estimation | `CountMin`, `Count` | Fast approximate counts for high-volume keys | Estimates how often each key appears in a stream | `df.group_by("key").agg(pl.len())` |
 | Cardinality estimation | `HyperLogLog` (`Classic`, `ErtlMLE`, `HIP`) | Approximate distinct counts with bounded memory | Estimates the number of unique elements | `df["col"].n_unique()` |
-| Quantiles / distribution | `KLL`, `DDSketch`, `UnivMonQ` | Percentiles alone, or percentiles sharing state with universal frequency metrics | Approximates arbitrary quantiles (e.g. p50, p99) of a value distribution | `df["col"].quantile(0.99)` |
+| Quantiles / distribution | `KLL`, `DDSketch`, `UnivMonQ` (experimental) | Percentiles alone, or percentiles sharing state with universal frequency metrics | Approximates arbitrary quantiles (e.g. p50, p99) of a value distribution | `df["col"].quantile(0.99)` |
 | Subpopulation queries | `Hydra` | Hierarchical / filtered sketch queries | Answers sketch queries over arbitrary subpopulations without maintaining per-group sketches | No direct equivalent — requires per-group aggregation |
 | Universal monitoring | `UnivMon` | G-sum queries (L1/L2 norms, cardinality, entropy) | Estimates a broad class of streaming statistics in a single pass | No direct equivalent — requires custom multi-pass pipelines |
-| Universal monitoring + quantiles | `UnivMonQ` | One mergeable structure for frequencies, F0/F2/F3/g-sums, entropy, heavy hitters, ranks, and quantiles | Extends a terminal-stratum UnivMon core with an ordered residual sample | No direct equivalent — requires multiple aggregations |
+| Universal monitoring + quantiles | `UnivMonQ` (experimental) | One mergeable structure for frequencies, F0/F2/compatible g-sums, entropy, heavy hitters, ranks, and quantiles | Extends a terminal-stratum UnivMon core with an adaptively assisted occurrence sample | No direct equivalent — requires multiple aggregations |
 | Update acceleration | `NitroBatch` | Batch-accelerated sketch updates | Speeds up sketch insertions by batching updates | No direct equivalent |
 
 Full sketch status and API details: [APIs Index](./docs/apis.md).
@@ -123,7 +123,11 @@ let p99 = sketch.quantile(0.99);
 println!("median ≈ {p50:.1} ms, p99 ≈ {p99:.1} ms");
 ```
 
-### Share one sketch across universal metrics and quantiles
+### Experiment with one sketch for universal metrics and quantiles
+
+`UnivMonQ` is experimental: its API, estimators, and guarantees may change as
+the construction is evaluated further. See the
+[large synthetic comparison with UnivMon](./docs/univmon_q_evaluation.md).
 
 ```rust
 use asap_sketchlib::{UnivMonQ, UnivMonQConfig};
@@ -140,7 +144,6 @@ let query = sketch.prepare_queries();
 println!("p50 ≈ {:?}", query.quantile(0.5));
 println!("distinct ≈ {}", query.estimate_distinct());
 println!("F2 ≈ {}", query.estimate_f2());
-println!("F3 ≈ {}", query.estimate_f3());
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 

--- a/docs/api/api_univmon.md
+++ b/docs/api/api_univmon.md
@@ -40,6 +40,10 @@ fn calc_card(&self) -> f64
 fn calc_g_sum<F>(&self, g: F, is_card: bool) -> f64
 ```
 
+Because UnivMon accepts only non-negative updates, `calc_l1()` returns the
+exact tracked total weight. The generic recurrence remains available through
+`calc_g_sum` for compatible frequency functions.
+
 ## Merge
 
 ```rust

--- a/docs/api/api_univmon_optimized.md
+++ b/docs/api/api_univmon_optimized.md
@@ -53,6 +53,10 @@ fn available(&self) -> usize
 fn total_allocated(&self) -> usize
 ```
 
+For the supported non-negative update stream, `calc_l1()` returns the exact
+tracked total weight rather than estimating the linear sum through the
+hierarchy.
+
 ## Merge
 
 ```rust

--- a/docs/api/api_univmon_q.md
+++ b/docs/api/api_univmon_q.md
@@ -81,8 +81,11 @@ fn source_id(&self) -> u64
 fn estimate_frequency(&self, value: f64) -> u64
 fn estimate_distinct(&self) -> f64
 fn estimate_f2(&self) -> f64
+fn estimate_l1(&self) -> f64
 fn estimate_g_sum<F>(&self, g: F) -> f64 where F: Fn(f64) -> f64
 fn estimate_entropy(&self) -> f64
+fn estimate_entropy_universal(&self) -> f64
+fn estimate_entropy_occurrence(&self) -> Option<f64>
 fn heavy_hitters(&self, k: usize) -> Vec<(f64, u64)>
 
 fn estimate_rank_universal(&self, value: f64) -> Option<u64>
@@ -99,6 +102,13 @@ The public generic g-sum API preserves UnivMon's ability to evaluate compatible
 frequency functions. Super-quadratic moments such as F3 are deliberately not
 advertised: the current memory profile does not provide their stronger space
 guarantees.
+
+`estimate_l1()` returns the exact observation count for the supported
+insertion-only stream. `estimate_entropy()` adaptively selects between the
+original UnivMon recurrence and the coordinated occurrence-sample identity
+`H = E[ln(N/f_X)]`. The recurrence is used for diffuse streams and complete
+candidate recovery; concentrated streams with incomplete recovery use the
+occurrence path. The two component estimators remain exposed for experiments.
 
 `prepare_queries` reconstructs candidate frequencies, logical sampled levels,
 F2 thresholds, and the ordered CDF once. Its returned immutable view exposes
@@ -126,7 +136,37 @@ set of fixed thresholds. Separate calls are not constrained to be monotone, so
 this experimental method is not used to implement `quantile` or `cdf`.
 
 Setting `ordered_samples = 0` removes ordered-sample memory and disables
-non-endpoint rank/quantile/CDF queries while retaining the universal metrics.
+non-endpoint rank/quantile/CDF queries. Entropy then always uses the universal
+recurrence; the other universal metrics are unchanged.
+
+### Entropy guarantee boundary
+
+For recovered heavy set `A`, residual mass `P_R`, and an occurrence-uniform
+residual value `X_R`, Shannon entropy decomposes as
+
+```text
+H = sum_(h in A) (f_h/N) ln(N/f_h) + P_R E[ln(N/f_X_R)].
+```
+
+If retained residual occurrences used exact frequencies, Hoeffding's
+inequality gives residual sampling error at most
+
+```text
+P_R ln(N) * sqrt(ln(2 / delta) / (2 m_R))
+```
+
+with probability `1 - delta`, where `m_R` is the number of retained residual
+occurrences. Replacing `f_X` by CountSketch estimate `f_hat_X` adds
+`P_R mean |ln(f_X/f_hat_X)|`; if every sampled residual frequency has relative
+error at most `rho < 1`, that term is at most `-P_R ln(1-rho)`. Heavy-frequency
+and residual-mass estimation add their corresponding plug-in error. UnivMon-Q's
+occurrence priorities use a separate hash domain from its key-frequency hashes.
+
+The adaptive selector keeps the original recurrence when recovery is complete
+or estimated concentration is below `1/k`; otherwise it uses this occurrence
+identity. The component bounds explain the estimator, but selection at that
+empirical gate is not yet a new end-to-end theorem. UnivMon-Q remains
+experimental.
 
 ### Ordered-query guarantee boundary
 

--- a/docs/api/api_univmon_q.md
+++ b/docs/api/api_univmon_q.md
@@ -1,18 +1,25 @@
 # API: UnivMon-Q
 
-Status: `Unstable`
+Status: `Experimental`
 
 ## Purpose
 
-`UnivMonQ` combines universal frequency-vector measurements with additive-rank
+The experimental `UnivMonQ` API combines universal frequency-vector measurements with additive-rank
 quantile estimation. Choose it when one stream must answer point frequency,
 distinct count, F2, entropy, heavy-hitter, rank, CDF, and quantile queries from
 shared mergeable state. For quantiles alone, KLL or DDSketch is normally much
-smaller.
+smaller. Its API, estimators, and guarantees may change as the construction is
+evaluated further.
 
-The update path uses one 128-bit hash and one physical CountSketch layer per
-observation. Disjoint hash fields select each row's bucket/sign, the Joltik
-terminal stratum, and the coordinated bottom-k sample priority.
+The update path uses one key hash and one physical CountSketch layer per
+observation. A second hash of `(source_id, local_sequence)` supplies an
+independent coordinated bottom-k priority for occurrence sampling.
+
+Each terminal stratum keeps the identities with the largest observed
+CountSketch frequency estimates. A separate `ever_evicted` bit records whether
+that bounded identity set has ever become incomplete; merely filling the table
+does not count as eviction. Query reconstruction applies the L2 threshold only
+to incomplete logical candidate sets.
 
 ## Types
 
@@ -27,11 +34,17 @@ terminal stratum, and the coordinated bottom-k sample priority.
 ```rust
 fn default() -> Self
 fn new(config: UnivMonQConfig) -> Result<Self, UnivMonQError>
+fn new_with_source_id(config: UnivMonQConfig, source_id: u64)
+    -> Result<Self, UnivMonQError>
 fn with_hasher(config: UnivMonQConfig) -> Result<Self, UnivMonQError>
+fn with_hasher_and_source_id(config: UnivMonQConfig, source_id: u64)
+    -> Result<Self, UnivMonQError>
 ```
 
-`new` selects `DefaultXxHasher`. Use `UnivMonQ::<CustomHasher>::with_hasher`
-for the pluggable hash API.
+`new` selects `DefaultXxHasher` and allocates a process-local source ID. Use
+`new_with_source_id` with a stable, globally unique partition or shard ID for
+distributed or cross-process merging. The `with_hasher` variants provide the
+same choices for a custom hash implementation.
 
 `UnivMonQConfig::with_window_bound(max_updates, failure_probability)` chooses
 the smallest level count whose deepest sample fits the candidate table under a
@@ -63,15 +76,16 @@ fn len(&self) -> u64
 fn is_empty(&self) -> bool
 fn min(&self) -> Option<f64>
 fn max(&self) -> Option<f64>
+fn source_id(&self) -> u64
 
 fn estimate_frequency(&self, value: f64) -> u64
 fn estimate_distinct(&self) -> f64
 fn estimate_f2(&self) -> f64
-fn estimate_f3(&self) -> f64
 fn estimate_g_sum<F>(&self, g: F) -> f64 where F: Fn(f64) -> f64
 fn estimate_entropy(&self) -> f64
 fn heavy_hitters(&self, k: usize) -> Vec<(f64, u64)>
 
+fn estimate_rank_universal(&self, value: f64) -> Option<u64>
 fn rank(&self, value: f64) -> Option<u64>
 fn quantile(&self, q: f64) -> Option<f64>
 fn quantiles(&self, quantiles: &[f64]) -> Vec<Option<f64>>
@@ -81,13 +95,14 @@ fn prepare_queries(&self) -> UnivMonQQuery<'_, H>
 fn estimated_memory_bytes(&self) -> usize
 ```
 
-F3 uses the same universal recurrence with `g(f) = f^3`. The public generic
-g-sum API preserves UnivMon's ability to evaluate other compatible frequency
-functions.
+The public generic g-sum API preserves UnivMon's ability to evaluate compatible
+frequency functions. Super-quadratic moments such as F3 are deliberately not
+advertised: the current memory profile does not provide their stronger space
+guarantees.
 
 `prepare_queries` reconstructs candidate frequencies, logical sampled levels,
 F2 thresholds, and the ordered CDF once. Its returned immutable view exposes
-count/min/max/frequency, F0/F2/F3/g-sum/entropy/heavy hitters, rank, batched
+count/min/max/frequency, F0/F2/g-sum/entropy/heavy hitters, rank, batched
 quantiles, and a borrowed CDF slice. Prefer it when a scrape or report asks for
 multiple metrics from one snapshot:
 
@@ -95,7 +110,6 @@ multiple metrics from one snapshot:
 let query = sketch.prepare_queries();
 let f0 = query.estimate_distinct();
 let f2 = query.estimate_f2();
-let f3 = query.estimate_f3();
 let entropy = query.estimate_entropy();
 let percentiles = query.quantiles(&[0.5, 0.9, 0.99]);
 let cdf = query.cdf();
@@ -104,8 +118,58 @@ let cdf = query.cdf();
 The direct methods remain convenient for isolated queries. `quantiles` is the
 batched alternative to repeated `quantile` calls and constructs the CDF once.
 
+`estimate_rank_universal(x)` is the most direct extension of the original
+UnivMon construction. It evaluates the key-dependent separable function
+`g_x(v, f_v) = f_v * I[v <= x]` through the usual sampled-level recurrence and
+does not require `ordered_samples`. It is intended for a small, predetermined
+set of fixed thresholds. Separate calls are not constrained to be monotone, so
+this experimental method is not used to implement `quantile` or `cdf`.
+
 Setting `ordered_samples = 0` removes ordered-sample memory and disables
 non-endpoint rank/quantile/CDF queries while retaining the universal metrics.
+
+### Ordered-query guarantee boundary
+
+There are two rank mechanisms with different guarantee boundaries:
+
+1. `estimate_rank_universal(x)` stays within the original UnivMon hierarchy.
+   Subject to the standard L2-heavy recovery assumptions, it estimates one
+   fixed threshold using the same recurrence as other separable sums. In a
+   diffuse stream its additive error has the sampling scale `N / sqrt(k)`, so
+   obtaining normalized rank error `epsilon` requires `k` on the order of
+   `1 / epsilon^2` (before confidence amplification). A uniform guarantee over
+   the full CDF also needs simultaneous control over all thresholds.
+2. `rank`, `cdf`, and `quantile` expose one adaptive assisted estimator. The
+   implementation always retains a uniform bottom-k sample of occurrences. It
+   uses UnivMon's F2 estimate to detect concentration and, only then, replaces
+   reliable heavy-value sample mass with recovered CountSketch frequencies.
+   The occurrence sample estimates the remaining residual distribution. When
+   no heavy value qualifies, the same algorithm has an empty heavy set and
+   reduces internally to the ordinary empirical occurrence CDF; this is not a
+   separate public mode.
+
+Let `H` be the recovered heavy set, `f_h` and `f_hat_h` its exact and estimated
+frequencies, `P_hat_R = 1 - sum_h f_hat_h/N` the estimated residual mass, and
+`m_R` the retained occurrences outside `H`. Define
+
+```text
+E_H = sum_h |f_hat_h - f_h| / N
+epsilon_R = sqrt(log(2 / delta) / (2 m_R)).
+```
+
+Conditioned on the recovered heavy set and sufficiently independent occurrence
+priorities, the monotone assisted CDF obeys
+
+```text
+sup_x |F_hat(x) - F(x)| <= 2 E_H + P_hat_R * epsilon_R.
+```
+
+The adaptive gate is `F2_hat / N^2 >= 1 / ordered_samples`; admitted heavy
+values also satisfy `f_hat_h >= sqrt(F2_hat / width)`. Thus diffuse streams use
+the distribution-independent occurrence bound directly, while concentrated
+streams can reduce residual sampling error at the cost of the explicit
+UnivMon heavy-frequency error term. This remains `O(1/epsilon^2)` sample space;
+use KLL when optimal quantile-only space is the primary requirement.
 
 ## Merge
 
@@ -113,11 +177,14 @@ non-endpoint rank/quantile/CDF queries while retaining the universal metrics.
 fn merge(&mut self, other: &Self) -> Result<(), UnivMonQError>
 ```
 
-Merges require identical dimensions and `hash_seed`, as well as the same
-compile-time hasher type. Terminal counters add, SpaceSaving candidate
-summaries use a parallel merge, and coordinated samples are unioned and pruned
-by their common priority. With 32-bit counters, callers must size the aggregate
-window so no signed cell saturates; use `counter_bits = 64` otherwise.
+Merges require identical dimensions and `hash_seed`, the same compile-time
+hasher type, and globally unique occurrence source IDs. Terminal counters add,
+candidate identities are unioned and rescored from the merged CountSketch,
+eviction history is ORed with any merge-time truncation, and occurrence samples
+are unioned and pruned by their common priorities. Source-ID uniqueness is a
+caller contract rather than an unbounded registry stored in the sketch. With
+32-bit counters, callers must size the aggregate window so no signed cell
+saturates; use `counter_bits = 64` otherwise.
 
 `UnivMonQ` also implements `TumblingWindowSketch`, so it can be used directly
 with `TumblingWindow<UnivMonQ>`. The window adapter treats the `DataInput` key
@@ -131,8 +198,10 @@ fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
 ```
 
 These helpers exist for `UnivMonQ<DefaultXxHasher>` and use a validated native
-MessagePack DTO. No ASAPv1 kind id or cross-language protobuf contract has been
-assigned yet.
+MessagePack v2 DTO containing occurrence and source metadata. A v1 state with
+a nonempty distinct-key ordered sample is rejected because discarded
+occurrence identities cannot be reconstructed. No ASAPv1 kind id or
+cross-language protobuf contract has been assigned yet.
 
 ## Example
 
@@ -141,8 +210,8 @@ use asap_sketchlib::{UnivMonQ, UnivMonQConfig};
 
 let config = UnivMonQConfig::default()
     .with_window_bound(100_000, 1e-6)?;
-let mut left = UnivMonQ::new(config)?;
-let mut right = UnivMonQ::new(config)?;
+let mut left = UnivMonQ::new_with_source_id(config, 10)?;
+let mut right = UnivMonQ::new_with_source_id(config, 20)?;
 
 for value in 0..50_000 {
     left.add(&value);
@@ -160,9 +229,19 @@ assert!(left.estimate_distinct() > 0.0);
 ## Accuracy caveat
 
 This is an empirically validated UnivMon extension, not a replacement for
-KLL's formal `O(1/epsilon)` additive-rank guarantee. Its ordered residual sample
-has the natural subset-sampling `O(1/epsilon^2)` space behavior, and the joint
-CountSketch recovery/residual-ratio analysis remains research work.
+KLL's formal `O(1/epsilon)` additive-rank guarantee. Its occurrence sample has
+the natural `O(1/epsilon^2)` space behavior, and the assisted theorem includes
+the recovered-heavy frequency error explicitly.
+
+## Empirical comparison with UnivMon
+
+The reproducible [large synthetic evaluation](../univmon_q_evaluation.md)
+compares UnivMon-Q with terminal-only UnivMon over seven skew levels and five
+trials. At the tested compact candidate budget, UnivMon was generally more
+accurate for shared universal metrics, while UnivMon-Q added ordered queries
+and used substantially less update time, merge time, query time, and memory.
+The document also separates construction differences from the current
+UnivMon heavy-hitter metadata bottleneck.
 
 ## References
 

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -16,8 +16,9 @@ This is the canonical API entry point for `asap_sketchlib`.
   - Reference: Karnin, Lang & Liberty, "Optimal Quantile Approximation in Streams," FOCS 2016. [https://arxiv.org/abs/1603.05346](https://arxiv.org/abs/1603.05346)
 - [DDSketch](./api/api_ddsketch.md) - `Ready`
   - Reference: Masson, Rim & Lee, "DDSketch: A Fast and Fully-Mergeable Quantile Sketch with Relative-Error Guarantees," VLDB 2019. [https://arxiv.org/abs/1908.10693](https://arxiv.org/abs/1908.10693)
-- [UnivMon-Q](./api/api_univmon_q.md) - `Unstable`
-  - Universal F0/F2/F3/g-sum/entropy/heavy-hitter measurements plus additive-rank quantiles in one mergeable sketch.
+- [UnivMon-Q](./api/api_univmon_q.md) - `Experimental`
+  - Universal F0/F2/compatible g-sum/entropy/heavy-hitter measurements plus additive-rank quantiles in one mergeable sketch. Its API, estimators, and guarantees may change.
+  - Evaluation: [large synthetic comparison with UnivMon](./univmon_q_evaluation.md).
   - References: UnivMon (SIGCOMM 2016), Joltik (MobiCom 2020), and universal subset-norm sampling.
 - [CMSHeap](./api/api_cms_heap.md) - `Ready`
 - [CSHeap](./api/api_cs_heap.md) - `Ready`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -123,7 +123,7 @@ The experimental `UnivMonQ` sketch is intended for cases where quantiles are
 required together with frequency, distinct count, F2, compatible generic
 g-sums, entropy, or heavy-hitter queries. It shares a terminal-stratum
 CountSketch pyramid across the universal metrics and adds an adaptively
-assisted bottom-k occurrence sample for ordered ranks.
+assisted bottom-k occurrence sample for entropy and ordered ranks.
 
 ```rust
 use asap_sketchlib::{UnivMonQ, UnivMonQConfig};

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -117,12 +117,13 @@ API reference: [`docs/api/api_kll.md`](./api/api_kll.md)
 
 ---
 
-## Universal quantiles — [`examples/quantile_univmon_q.rs`](../examples/quantile_univmon_q.rs)
+## Experimental universal quantiles — [`examples/quantile_univmon_q.rs`](../examples/quantile_univmon_q.rs)
 
-Use `UnivMonQ` when quantiles are required together with frequency, distinct
-count, F2/F3, generic g-sums, entropy, or heavy-hitter queries. It shares a terminal-stratum
-CountSketch pyramid across the universal metrics and adds a coordinated
-bottom-k sample for ordered ranks.
+The experimental `UnivMonQ` sketch is intended for cases where quantiles are
+required together with frequency, distinct count, F2, compatible generic
+g-sums, entropy, or heavy-hitter queries. It shares a terminal-stratum
+CountSketch pyramid across the universal metrics and adds an adaptively
+assisted bottom-k occurrence sample for ordered ranks.
 
 ```rust
 use asap_sketchlib::{UnivMonQ, UnivMonQConfig};
@@ -137,7 +138,7 @@ for value in 1..=100_000 {
 let query = sketch.prepare_queries();
 let percentiles = query.quantiles(&[0.50, 0.90, 0.99]);
 let distinct = query.estimate_distinct();
-let f3 = query.estimate_f3();
+let f2 = query.estimate_f2();
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,7 +36,7 @@ This document provides a high-level overview of implemented and planned features
 
 **UnivMonPyramid** - Optimized two-tier UnivMon with `UnivSketchPool` for insert and memory management ([apis.md](apis.md))
 
-**UnivMonQ (Experimental)** - Terminal-stratum UnivMon with F0/F2/compatible g-sum queries, an adaptively assisted occurrence sample for ranks and quantiles, and reusable prepared query views. Its API, estimators, and guarantees may change.
+**UnivMonQ (Experimental)** - Terminal-stratum UnivMon with exact insertion-only L1, F0/F2/compatible g-sum queries, an adaptively assisted occurrence sample for entropy, ranks, and quantiles, and reusable prepared query views. Its API, estimators, and guarantees may change.
 
 **HashSketchEnsemble** - Hash-once-use-many pattern for coordinating multiple sketches with single hash computation
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,7 +36,7 @@ This document provides a high-level overview of implemented and planned features
 
 **UnivMonPyramid** - Optimized two-tier UnivMon with `UnivSketchPool` for insert and memory management ([apis.md](apis.md))
 
-**UnivMonQ** - Terminal-stratum UnivMon with F0/F2/F3/g-sum queries, a coordinated ordered residual sample for ranks and quantiles, and reusable prepared query views (currently `Unstable`)
+**UnivMonQ (Experimental)** - Terminal-stratum UnivMon with F0/F2/compatible g-sum queries, an adaptively assisted occurrence sample for ranks and quantiles, and reusable prepared query views. Its API, estimators, and guarantees may change.
 
 **HashSketchEnsemble** - Hash-once-use-many pattern for coordinating multiple sketches with single hash computation
 
@@ -46,7 +46,7 @@ This document provides a high-level overview of implemented and planned features
 
 **ExponentialHistogram** - Sliding window coordinator for mergeable sketches
 
-**TumblingWindow** - Non-overlapping windows with built-in UnivMon-Q support
+**TumblingWindow** - Non-overlapping windows with built-in support for the experimental UnivMon-Q sketch
 
 **EHUnivOptimized** - Hybrid two-tier ExponentialHistogram for UnivMon with sketch memory reuse (currently `Unstable`)
 
@@ -121,7 +121,7 @@ MessagePack (`rmp-serde`) support. **serde support** means the type derives `Ser
 | CMSHeap / CSHeap | In Progress | In Progress |
 | Hydra | Yes | Yes |
 | UnivMon | Yes | Yes |
-| UnivMonQ | Internal wire DTO | Yes (native MessagePack) |
+| UnivMonQ (experimental) | Internal wire DTO | Yes (native MessagePack) |
 | NitroBatch | Yes | In Progress |
 | EHSketchList | Yes | In Progress |
 

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -27,6 +27,7 @@ implementations, and orchestration/windowing frameworks in one crate.
 - **Ready**: Core sketch APIs marked `Ready` in [apis.md](./apis.md): `CountMin`, `Count`, `HyperLogLog`, `KLL`, `DDSketch`, `CMSHeap`, `CSHeap`
 - **Notice**: Core sketch APIs currently marked `Unstable`: `Elastic`, `Coco`, `UniformSampling`, `KMV`
 - Framework APIs marked `Ready`: `Hydra`, `HashSketchEnsemble`, `UnivMon`, `UnivMon Optimized`, `NitroBatch`, `ExponentialHistogram`, `EHSketchList`
-- Framework APIs currently marked `Unstable`: `EHUnivOptimized`, `UnivMonQ`
+- Framework APIs currently marked `Unstable`: `EHUnivOptimized`
+- Experimental framework APIs: `UnivMonQ`
 - Shared common-layer APIs are available under [Common Utility APIs](./apis.md#common-utility-apis)
 - **Ongoing** work focuses on API stabilization, broader tests, and benchmark depth (see [Feature Status](./features.md))

--- a/docs/univmon_q_evaluation.md
+++ b/docs/univmon_q_evaluation.md
@@ -8,6 +8,7 @@ estimators, configuration defaults, wire state, and performance may change.
 
 ```bash
 cargo run --release --example evaluate_univmon_q_skew -- 1000000 5 100000 256
+cargo run --release --example evaluate_univmon_q_skew -- 1000000 5 100000 256 all equal-memory
 ```
 
 The comparison uses one million observations per dataset, five independent
@@ -26,8 +27,8 @@ Worst p95 error across the seven skew levels:
 | Point-frequency normalized RMSE | 0.378% | 0.383% |
 | F0 relative error | 9.52% | 12.04% |
 | F2 relative error | 4.96% | 10.12% |
-| Entropy relative error | 17.32% | 83.13% |
-| Generic L1 relative error | 6.34% | 44.98% |
+| Entropy relative error | 17.32% | 3.05% |
+| L1 relative error | 0% (exact count) | 0% (exact count) |
 | Quantile mean rank error | Not supported | 0.45% |
 | Maximum CDF error | Not supported | 2.42% |
 
@@ -35,16 +36,90 @@ Median performance ranges across the seven skew levels:
 
 | Measurement | UnivMon | UnivMon-Q | UnivMon-Q improvement |
 | --- | ---: | ---: | ---: |
-| Update | 1.0–11.9 us/item | 48–130 ns/item | 7.8–211x |
-| Eight-way merge | 33–217 ms | 2.2–4.1 ms | 15–53x |
-| All-metric query batch | 0.92–2.78 ms | 0.19–0.63 ms | 4.4–5.3x |
+| Update | 1.12–12.03 us/item | 52–140 ns/item | 8–204x |
+| Eight-way merge | 36–223 ms | 2.2–4.3 ms | 16–52x |
+| All-metric query batch | 1.00–3.13 ms | 0.24–1.16 ms | 2.6–4.4x |
 | In-memory core | At least 2.188 MiB of counters, before heap metadata | 0.707 MiB estimated | At least 3.1x smaller |
 
-UnivMon was generally more accurate for the shared universal metrics at this
-candidate budget. UnivMon-Q added ordered queries and was substantially faster
-and smaller. Entropy and generic g-sums were the clearest UnivMon-Q weakness;
-profiles requesting them need more candidate/core capacity than this compact
-256-candidate configuration.
+UnivMon-Q's point-frequency accuracy was similar while its compact F0/F2 core
+was less accurate. L1 is exact in both sketches for this insertion-only
+stream. Entropy uses an adaptive assisted estimator: diffuse streams and
+complete candidate sets use
+the original universal recurrence, while concentrated streams with incomplete
+recovery use the coordinated occurrence sample and CountSketch frequency
+estimates. This removes the large candidate-threshold failure observed with
+the recurrence-only entropy estimator.
+
+### Conservative equal-memory profile
+
+The compact table above is not an equal-memory comparison. To separate the
+construction from that resource difference, the `equal-memory` profile keeps
+UnivMon at 4,096 columns and 256 candidates, then configures UnivMon-Q with
+full-width levels and the largest candidate table that fits under the memory
+occupied by UnivMon's counters alone. This gives UnivMon-Q 1,560 candidates
+and 2.187 MiB of estimated reserved state versus 2.188 MiB of UnivMon counters,
+before counting UnivMon's heap metadata. The comparison is therefore
+conservative in UnivMon's favor.
+
+Worst p95 error across the same seven skews and five trials:
+
+| Metric | UnivMon | Equal-memory UnivMon-Q |
+| --- | ---: | ---: |
+| Point-frequency normalized RMSE | 0.378% | 0.379% |
+| F0 relative error | 9.52% | 6.13% |
+| F2 relative error | 4.96% | 2.63% |
+| Entropy relative error | 17.32% | 3.05% |
+| L1 relative error | 0% (exact count) | 0% (exact count) |
+| Quantile mean rank error | Not supported | 0.45% |
+| Maximum CDF error | Not supported | 2.42% |
+
+Median performance ranges across the seven skews:
+
+| Measurement | UnivMon | Equal-memory UnivMon-Q | UnivMon-Q improvement |
+| --- | ---: | ---: | ---: |
+| Update | 1.12–12.70 us/item | 51–153 ns/item | 7.4–199x |
+| Eight-way merge | 35–222 ms | 2.6–12.1 ms | 13.2–18.3x |
+| All-metric query batch | 0.98–3.23 ms | 0.44–2.09 ms | 1.4–2.2x |
+
+For this insertion-only stream, both implementations answer L1 from their
+exact stored observation count;
+`estimate_g_sum(|f| f)` remains available as a generic-recurrence diagnostic
+but is not used for L1. The assisted entropy estimator lowers the worst p95
+error from 54.05% for recurrence-only equal-memory UnivMon-Q to 3.05%. The
+largest residual error occurs around Zipf alpha 1.6, where recovery is
+incomplete and the occurrence path has a 0.082-nat p95 absolute error.
+Those 35-trial figures precede the heavy/residual variance reduction below and
+are therefore conservative for the current estimator.
+
+### Entropy stress matrix
+
+The dedicated entropy evaluator broadens the distribution family and varies
+the occurrence-sample budget:
+
+```bash
+cargo run --release --example evaluate_univmon_q_entropy -- 200000 8 50000
+```
+
+It covers four uniform supports, nine Zipf exponents from 0.5 through 2.5,
+and five heavy-head/uniform-tail mixtures with head mass from 0.5 through
+0.9999. Each of the 18 workloads uses eight trials and an eight-way merge.
+Four memory/sample profiles produce 576 merged evaluations in total.
+
+| Profile | Estimated memory | Occurrence samples | Worst adaptive entropy p95 |
+| --- | ---: | ---: | ---: |
+| Compact | 0.592 MiB | 512 | 4.86% |
+| Compact default | 0.674 MiB | 4,096 | 1.75% |
+| Compact large sample | 0.955 MiB | 16,384 | 1.46% |
+| Equal-memory | 1.874 MiB | 4,096 | 1.36% |
+
+A raw occurrence mean initially exposed a 22.76% p95 error for a 99% heavy
+head and large diffuse tail. The final assisted estimator computes the
+recovered-heavy entropy contribution directly, fixes its residual mass, and
+uses occurrences only for conditional residual entropy. This reduced that
+case to 0.32% p95. Every profile produced bit-identical entropy across left
+fold and balanced merge trees. Extremely concentrated cases whose observed
+support fits the candidate table use the complete universal recurrence and
+were exact in this matrix.
 
 The update gap is not solely a construction-level result. The current UnivMon
 `HHHeap` rebuilds its candidate-position map after retained-key updates, so its

--- a/docs/univmon_q_evaluation.md
+++ b/docs/univmon_q_evaluation.md
@@ -1,0 +1,69 @@
+# Experimental UnivMon-Q Evaluation
+
+`UnivMonQ` is experimental. The measurements below are empirical results for
+the current Rust implementations, not new theoretical guarantees. APIs,
+estimators, configuration defaults, wire state, and performance may change.
+
+## Reproduction
+
+```bash
+cargo run --release --example evaluate_univmon_q_skew -- 1000000 5 100000 256
+```
+
+The comparison uses one million observations per dataset, five independent
+trials, a 100,000-value domain, Zipf exponents from 0.0 through 2.0, and an
+eight-way merge. Both constructions use 14 logical levels, a top width of
+4,096, depth 5, and 256 candidates. UnivMon uses terminal-only `fast_insert`.
+UnivMon-Q additionally uses 32-bit counters, width halving every three levels,
+and 4,096 coordinated occurrence samples.
+
+## Comparison with UnivMon
+
+Worst p95 error across the seven skew levels:
+
+| Metric | UnivMon | UnivMon-Q |
+| --- | ---: | ---: |
+| Point-frequency normalized RMSE | 0.378% | 0.383% |
+| F0 relative error | 9.52% | 12.04% |
+| F2 relative error | 4.96% | 10.12% |
+| Entropy relative error | 17.32% | 83.13% |
+| Generic L1 relative error | 6.34% | 44.98% |
+| Quantile mean rank error | Not supported | 0.45% |
+| Maximum CDF error | Not supported | 2.42% |
+
+Median performance ranges across the seven skew levels:
+
+| Measurement | UnivMon | UnivMon-Q | UnivMon-Q improvement |
+| --- | ---: | ---: | ---: |
+| Update | 1.0–11.9 us/item | 48–130 ns/item | 7.8–211x |
+| Eight-way merge | 33–217 ms | 2.2–4.1 ms | 15–53x |
+| All-metric query batch | 0.92–2.78 ms | 0.19–0.63 ms | 4.4–5.3x |
+| In-memory core | At least 2.188 MiB of counters, before heap metadata | 0.707 MiB estimated | At least 3.1x smaller |
+
+UnivMon was generally more accurate for the shared universal metrics at this
+candidate budget. UnivMon-Q added ordered queries and was substantially faster
+and smaller. Entropy and generic g-sums were the clearest UnivMon-Q weakness;
+profiles requesting them need more candidate/core capacity than this compact
+256-candidate configuration.
+
+The update gap is not solely a construction-level result. The current UnivMon
+`HHHeap` rebuilds its candidate-position map after retained-key updates, so its
+cost grows with candidate capacity and hot-key skew. UnivMon-Q maintains its
+candidate state incrementally. UnivMon-Q also saves memory through packed
+32-bit counters and geometric width reduction, whereas this UnivMon baseline
+uses fixed-width 64-bit counter layers.
+
+## Correctness checks
+
+Across 35 large trials, both sketches preserved exact stream counts, produced
+finite universal estimates, and round-tripped through their native MessagePack
+state. Shared UnivMon metrics and all UnivMon-Q queries were stable across left
+fold and balanced merge trees. Two uniform trials selected different
+equal-frequency identities for UnivMon's top-20 result; the metric estimates
+were unchanged, so these are reported as tie warnings rather than correctness
+failures.
+
+For UnivMon-Q, exact extrema, monotone CDF construction, monotone quantiles,
+and ordered-query merge equivalence were also checked. These tests support the
+implementation but do not replace the guarantees and caveats in the
+[UnivMon-Q API documentation](./api/api_univmon_q.md).

--- a/examples/audit_univmon_q_order.rs
+++ b/examples/audit_univmon_q_order.rs
@@ -1,0 +1,528 @@
+//! Rank/CDF/quantile audit for UnivMon-Q.
+//!
+//! Run with:
+//!
+//!   cargo run --release --example audit_univmon_q_order -- 50000 5
+
+use asap_sketchlib::{KLL, UnivMonQ, UnivMonQConfig};
+
+const SAMPLE_SIZES: [usize; 7] = [128, 256, 512, 1_024, 2_048, 4_096, 8_192];
+const CANDIDATE_SIZES: [usize; 5] = [64, 128, 256, 512, 1_024];
+const FANOUTS: [usize; 4] = [1, 2, 8, 32];
+const KLL_K: i32 = 200;
+const QUANTILES: [f64; 13] = [
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.995, 0.999,
+];
+type Generator = fn(usize, u64) -> Vec<i64>;
+
+fn main() {
+    let n: usize = std::env::args()
+        .nth(1)
+        .map(|value| value.parse().expect("n must be positive"))
+        .unwrap_or(50_000);
+    let trials: usize = std::env::args()
+        .nth(2)
+        .map(|value| value.parse().expect("trials must be positive"))
+        .unwrap_or(5);
+    assert!(n > 0 && trials > 0);
+
+    let workloads: [(&str, Generator); 5] = [
+        ("uniform", uniform),
+        ("exponential", exponential),
+        ("bimodal", bimodal),
+        ("zipf", zipf),
+        ("elephants", elephants),
+    ];
+
+    println!("UnivMon-Q ordered-query audit: n={n}, trials={trials}");
+    println!("Errors are normalized rank errors; lower is better.");
+    println!();
+    println!("sample-size sweep (one-pass sketches)");
+    println!(
+        "  {:<12} {:>7} {:>8} {:>11} {:>11} {:>11} {:>11} {:>11} {:>11}",
+        "workload",
+        "sample",
+        "KiB",
+        "Q mean-p50",
+        "res CDF-p95",
+        "UM fixed95",
+        "UM CDF-p95",
+        "Q tail-p95",
+        "KLL CDF-p95"
+    );
+    for (workload_index, (name, generator)) in workloads.iter().enumerate() {
+        let mut kll_cdf_errors = Vec::with_capacity(trials);
+        let mut datasets = Vec::with_capacity(trials);
+        for trial in 0..trials {
+            let seed = trial_seed(workload_index, trial);
+            let data = generator(n, seed);
+            let truth = Truth::new(&data);
+            let kll = build_kll(&data, seed, 1);
+            kll_cdf_errors.push(score_kll(&kll, &truth).cdf_max);
+            datasets.push((seed, data, truth));
+        }
+        let kll_p95 = percentile(&kll_cdf_errors, 0.95);
+        for samples in SAMPLE_SIZES {
+            let mut mean_errors = Vec::with_capacity(trials);
+            let mut cdf_errors = Vec::with_capacity(trials);
+            let mut universal_errors = Vec::with_capacity(trials);
+            let mut universal_fixed_errors = Vec::with_capacity(trials);
+            let mut tail_errors = Vec::with_capacity(trials);
+            let mut memory = 0;
+            for (trial, (_, data, truth)) in datasets.iter().enumerate() {
+                let config = config(samples, 256, trial);
+                let sketch = build_q(data, config, 1);
+                memory = sketch.estimated_memory_bytes();
+                let score = score_q(&sketch, truth);
+                mean_errors.push(score.quantile_mean);
+                cdf_errors.push(score.cdf_max);
+                let universal = score_universal_rank(&sketch, truth);
+                universal_fixed_errors.push(universal.fixed);
+                universal_errors.push(universal.maximum);
+                tail_errors.push(score.tail_max);
+            }
+            println!(
+                "  {name:<12} {samples:>7} {:>8.1} {:>11.5} {:>11.5} {:>11.5} {:>11.5} {:>11.5} {:>11.5}",
+                memory as f64 / 1024.0,
+                percentile(&mean_errors, 0.5),
+                percentile(&cdf_errors, 0.95),
+                percentile(&universal_fixed_errors, 0.95),
+                percentile(&universal_errors, 0.95),
+                percentile(&tail_errors, 0.95),
+                kll_p95,
+            );
+        }
+    }
+
+    println!();
+    println!("worst CDF breakpoint (trial 0, 1024 ordered samples)");
+    println!(
+        "  {:<12} {:>14} {:>11} {:>11} {:>11}",
+        "workload", "value", "exact", "estimate", "error"
+    );
+    for (workload_index, (name, generator)) in workloads.iter().enumerate() {
+        let data = generator(n, trial_seed(workload_index, 0));
+        let truth = Truth::new(&data);
+        let sketch = build_q(&data, config(1_024, 256, 0), 1);
+        let (value, exact, estimate, error) = worst_cdf_q(&sketch, &truth);
+        println!("  {name:<12} {value:>14} {exact:>11.5} {estimate:>11.5} {error:>11.5}");
+    }
+
+    println!();
+    println!("candidate-size sweep on Zipf (1024 ordered samples)");
+    println!(
+        "  {:>10} {:>9} {:>12} {:>12} {:>12}",
+        "candidates", "KiB", "mean-rank-p50", "CDF-p95", "tail-p95"
+    );
+    for candidates in CANDIDATE_SIZES {
+        let mut mean_errors = Vec::with_capacity(trials);
+        let mut cdf_errors = Vec::with_capacity(trials);
+        let mut tail_errors = Vec::with_capacity(trials);
+        let mut memory = 0;
+        for trial in 0..trials {
+            let data = zipf(n, trial_seed(3, trial));
+            let truth = Truth::new(&data);
+            let sketch = build_q(&data, config(1_024, candidates, trial), 1);
+            memory = sketch.estimated_memory_bytes();
+            let score = score_q(&sketch, &truth);
+            mean_errors.push(score.quantile_mean);
+            cdf_errors.push(score.cdf_max);
+            tail_errors.push(score.tail_max);
+        }
+        println!(
+            "  {candidates:>10} {:>9.1} {:>12.5} {:>12.5} {:>12.5}",
+            memory as f64 / 1024.0,
+            percentile(&mean_errors, 0.5),
+            percentile(&cdf_errors, 0.95),
+            percentile(&tail_errors, 0.95),
+        );
+    }
+
+    println!();
+    println!("merge-tree sweep over identical source sketches (1024 ordered samples)");
+    println!(
+        "  {:<12} {:>6} {:>11} {:>12} {:>12} {:>13}",
+        "workload", "shards", "Q CDF-p95", "Q tree-p95", "KLL CDF-p95", "KLL tree-p95"
+    );
+    for (workload_index, (name, generator)) in workloads.iter().enumerate() {
+        for fanout in FANOUTS {
+            let mut q_errors = Vec::with_capacity(trials);
+            let mut q_drifts = Vec::with_capacity(trials);
+            let mut kll_errors = Vec::with_capacity(trials);
+            let mut kll_drifts = Vec::with_capacity(trials);
+            for trial in 0..trials {
+                let seed = trial_seed(workload_index, trial);
+                let data = generator(n, seed);
+                let truth = Truth::new(&data);
+                let config = config(1_024, 256, trial);
+                let q_shards = build_q_shards(&data, config, fanout, seed);
+                let q_merged = merge_q_tree(q_shards.clone());
+                let q_left = merge_q_left(q_shards);
+                q_errors.push(score_q(&q_merged, &truth).cdf_max);
+                q_drifts.push(cdf_drift_q(&q_left, &q_merged, &truth));
+
+                let kll_shards = build_kll_shards(&data, seed, fanout);
+                let kll_merged = merge_kll_tree(kll_shards.clone());
+                let kll_left = merge_kll_left(kll_shards);
+                kll_errors.push(score_kll(&kll_merged, &truth).cdf_max);
+                kll_drifts.push(cdf_drift_kll(&kll_left, &kll_merged, &truth));
+            }
+            println!(
+                "  {name:<12} {fanout:>6} {:>11.5} {:>12.5} {:>12.5} {:>13.5}",
+                percentile(&q_errors, 0.95),
+                percentile(&q_drifts, 0.95),
+                percentile(&kll_errors, 0.95),
+                percentile(&kll_drifts, 0.95),
+            );
+        }
+    }
+}
+
+fn config(ordered_samples: usize, candidates: usize, trial: usize) -> UnivMonQConfig {
+    UnivMonQConfig {
+        levels: 12,
+        width: 1_024,
+        width_halving_period: 3,
+        depth: 5,
+        counter_bits: 32,
+        candidates,
+        ordered_samples,
+        hash_seed: 5 + trial,
+    }
+}
+
+fn build_q(data: &[i64], config: UnivMonQConfig, fanout: usize) -> UnivMonQ {
+    merge_q_tree(build_q_shards(data, config, fanout, 0))
+}
+
+fn build_q_shards(
+    data: &[i64],
+    config: UnivMonQConfig,
+    fanout: usize,
+    source_base: u64,
+) -> Vec<UnivMonQ> {
+    let fanout = fanout.min(data.len()).max(1);
+    let mut shards = Vec::with_capacity(fanout);
+    for shard in 0..fanout {
+        let start = shard * data.len() / fanout;
+        let end = (shard + 1) * data.len() / fanout;
+        let source_id = source_base
+            .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+            .wrapping_add(shard as u64 + 1);
+        let mut sketch = UnivMonQ::new_with_source_id(config, source_id).unwrap();
+        for value in &data[start..end] {
+            sketch.add(value);
+        }
+        shards.push(sketch);
+    }
+    shards
+}
+
+fn merge_q_tree(mut sketches: Vec<UnivMonQ>) -> UnivMonQ {
+    while sketches.len() > 1 {
+        let mut merged = Vec::with_capacity(sketches.len().div_ceil(2));
+        let mut iter = sketches.into_iter();
+        while let Some(mut left) = iter.next() {
+            if let Some(right) = iter.next() {
+                left.merge(&right).unwrap();
+            }
+            merged.push(left);
+        }
+        sketches = merged;
+    }
+    sketches.pop().unwrap()
+}
+
+fn merge_q_left(mut sketches: Vec<UnivMonQ>) -> UnivMonQ {
+    let mut merged = sketches.remove(0);
+    for sketch in sketches {
+        merged.merge(&sketch).unwrap();
+    }
+    merged
+}
+
+fn build_kll(data: &[i64], seed: u64, fanout: usize) -> KLL<i64> {
+    merge_kll_tree(build_kll_shards(data, seed, fanout))
+}
+
+fn build_kll_shards(data: &[i64], seed: u64, fanout: usize) -> Vec<KLL<i64>> {
+    let fanout = fanout.min(data.len()).max(1);
+    let mut shards = Vec::with_capacity(fanout);
+    for shard in 0..fanout {
+        let start = shard * data.len() / fanout;
+        let end = (shard + 1) * data.len() / fanout;
+        let mut sketch = KLL::init_kll_with_seed(KLL_K, seed ^ shard as u64);
+        for value in &data[start..end] {
+            sketch.update(value);
+        }
+        shards.push(sketch);
+    }
+    shards
+}
+
+fn merge_kll_tree(mut shards: Vec<KLL<i64>>) -> KLL<i64> {
+    while shards.len() > 1 {
+        let mut merged = Vec::with_capacity(shards.len().div_ceil(2));
+        let mut iter = shards.into_iter();
+        while let Some(mut left) = iter.next() {
+            if let Some(right) = iter.next() {
+                left.merge(&right);
+            }
+            merged.push(left);
+        }
+        shards = merged;
+    }
+    shards.pop().unwrap()
+}
+
+fn merge_kll_left(mut sketches: Vec<KLL<i64>>) -> KLL<i64> {
+    let mut merged = sketches.remove(0);
+    for sketch in sketches {
+        merged.merge(&sketch);
+    }
+    merged
+}
+
+#[derive(Clone, Copy)]
+struct OrderedScore {
+    quantile_mean: f64,
+    tail_max: f64,
+    cdf_max: f64,
+}
+
+fn score_q(sketch: &UnivMonQ, truth: &Truth) -> OrderedScore {
+    let query = sketch.prepare_queries();
+    let errors: Vec<_> = QUANTILES
+        .iter()
+        .zip(query.quantiles(&QUANTILES))
+        .map(|(&q, estimate)| truth.quantile_rank_error(q, estimate.unwrap().round() as i64))
+        .collect();
+    OrderedScore {
+        quantile_mean: errors.iter().sum::<f64>() / errors.len() as f64,
+        tail_max: errors
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index <= 2 || *index >= QUANTILES.len() - 3)
+            .map(|(_, error)| *error)
+            .fold(0.0, f64::max),
+        cdf_max: truth
+            .probes
+            .iter()
+            .map(|&(value, exact)| {
+                let estimate = query.rank(value as f64).unwrap() as f64 / truth.n as f64;
+                (estimate - exact).abs()
+            })
+            .fold(0.0, f64::max),
+    }
+}
+
+fn score_kll(sketch: &KLL<i64>, truth: &Truth) -> OrderedScore {
+    let cdf = sketch.cdf();
+    let errors: Vec<_> = QUANTILES
+        .iter()
+        .map(|&q| truth.quantile_rank_error(q, cdf.query(q).round() as i64))
+        .collect();
+    OrderedScore {
+        quantile_mean: errors.iter().sum::<f64>() / errors.len() as f64,
+        tail_max: errors
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index <= 2 || *index >= QUANTILES.len() - 3)
+            .map(|(_, error)| *error)
+            .fold(0.0, f64::max),
+        cdf_max: truth
+            .probes
+            .iter()
+            .map(|&(value, exact)| (cdf.quantile(value as f64) - exact).abs())
+            .fold(0.0, f64::max),
+    }
+}
+
+struct UniversalRankScore {
+    fixed: f64,
+    maximum: f64,
+}
+
+fn score_universal_rank(sketch: &UnivMonQ, truth: &Truth) -> UniversalRankScore {
+    let query = sketch.prepare_queries();
+    let errors: Vec<_> = truth
+        .probes
+        .iter()
+        .map(|&(value, exact)| {
+            let estimate =
+                query.estimate_rank_universal(value as f64).unwrap() as f64 / truth.n as f64;
+            (estimate - exact).abs()
+        })
+        .collect();
+    UniversalRankScore {
+        fixed: errors[errors.len() / 2],
+        maximum: errors.into_iter().fold(0.0, f64::max),
+    }
+}
+
+fn cdf_drift_q(left: &UnivMonQ, right: &UnivMonQ, truth: &Truth) -> f64 {
+    let left = left.prepare_queries();
+    let right = right.prepare_queries();
+    truth
+        .probes
+        .iter()
+        .map(|&(value, _)| {
+            let a = left.rank(value as f64).unwrap() as f64 / truth.n as f64;
+            let b = right.rank(value as f64).unwrap() as f64 / truth.n as f64;
+            (a - b).abs()
+        })
+        .fold(0.0, f64::max)
+}
+
+fn worst_cdf_q(sketch: &UnivMonQ, truth: &Truth) -> (i64, f64, f64, f64) {
+    let query = sketch.prepare_queries();
+    truth
+        .probes
+        .iter()
+        .map(|&(value, exact)| {
+            let estimate = query.rank(value as f64).unwrap() as f64 / truth.n as f64;
+            (value, exact, estimate, (estimate - exact).abs())
+        })
+        .max_by(|left, right| left.3.total_cmp(&right.3))
+        .unwrap()
+}
+
+fn cdf_drift_kll(left: &KLL<i64>, right: &KLL<i64>, truth: &Truth) -> f64 {
+    let left = left.cdf();
+    let right = right.cdf();
+    truth
+        .probes
+        .iter()
+        .map(|&(value, _)| (left.quantile(value as f64) - right.quantile(value as f64)).abs())
+        .fold(0.0, f64::max)
+}
+
+struct Truth {
+    n: usize,
+    sorted: Vec<i64>,
+    probes: Vec<(i64, f64)>,
+}
+
+impl Truth {
+    fn new(data: &[i64]) -> Self {
+        let mut sorted = data.to_vec();
+        sorted.sort_unstable();
+        let probes = (0..=1_000)
+            .map(|index| sorted[index * (sorted.len() - 1) / 1_000])
+            .map(|value| {
+                let rank =
+                    sorted.partition_point(|item| *item <= value) as f64 / sorted.len() as f64;
+                (value, rank)
+            })
+            .collect();
+        Self {
+            n: sorted.len(),
+            sorted,
+            probes,
+        }
+    }
+
+    fn quantile_rank_error(&self, q: f64, estimate: i64) -> f64 {
+        let target = (q * self.n as f64).ceil().max(1.0) as usize;
+        let lower = self.sorted.partition_point(|item| *item < estimate);
+        let upper = self.sorted.partition_point(|item| *item <= estimate);
+        if target < lower {
+            (lower - target) as f64 / self.n as f64
+        } else {
+            target.saturating_sub(upper) as f64 / self.n as f64
+        }
+    }
+}
+
+fn percentile(values: &[f64], q: f64) -> f64 {
+    let mut values = values.to_vec();
+    values.sort_unstable_by(f64::total_cmp);
+    values[((q * values.len() as f64).ceil() as usize)
+        .saturating_sub(1)
+        .min(values.len() - 1)]
+}
+
+fn trial_seed(workload: usize, trial: usize) -> u64 {
+    0x2026_0804_u64 ^ ((workload as u64) << 32) ^ trial as u64
+}
+
+#[derive(Clone, Copy)]
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        mix64(self.0)
+    }
+
+    fn unit(&mut self) -> f64 {
+        ((self.next() >> 11) as f64 + 0.5) / (1_u64 << 53) as f64
+    }
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn uniform(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| (rng.next() % 1_000_001) as i64 - 500_000)
+        .collect()
+}
+
+fn exponential(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| (-rng.unit().ln() * 100_000.0).round() as i64)
+        .collect()
+}
+
+fn bimodal(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|index| {
+            let center = if index % 2 == 0 {
+                -1_000_000.0
+            } else {
+                1_000_000.0
+            };
+            let radius = (-2.0 * rng.unit().ln()).sqrt();
+            let angle = std::f64::consts::TAU * rng.unit();
+            (center + 20_000.0 * radius * angle.cos()).round() as i64
+        })
+        .collect()
+}
+
+fn zipf(n: usize, seed: u64) -> Vec<i64> {
+    let domain = 20_000_usize;
+    let mut cdf = Vec::with_capacity(domain);
+    let mut total = 0.0;
+    for rank in 1..=domain {
+        total += 1.0 / (rank as f64).powf(1.1);
+        cdf.push(total);
+    }
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| {
+            let target = rng.unit() * total;
+            (cdf.partition_point(|value| *value < target) + 1) as i64
+        })
+        .collect()
+}
+
+fn elephants(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|index| match index % 25 {
+            0..=3 => 0,
+            4..=6 => 1_000,
+            7..=8 => 100_000,
+            9 => 1_000_000,
+            _ => 100 + (rng.next() % 999_901) as i64,
+        })
+        .collect()
+}

--- a/examples/compare_univmon_q.rs
+++ b/examples/compare_univmon_q.rs
@@ -139,7 +139,6 @@ fn main() {
     let exact_l1 = N as f64;
     let exact_f0 = exact.len() as f64;
     let exact_f2 = exact.values().map(|&f| (f as f64).powi(2)).sum::<f64>();
-    let exact_f3 = exact.values().map(|&f| (f as f64).powi(3)).sum::<f64>();
     let exact_entropy_bits = exact
         .values()
         .map(|&f| {
@@ -259,21 +258,18 @@ fn main() {
     let regular_l1 = regular.calc_l1();
     let regular_card = regular.calc_card();
     let regular_f2 = regular.calc_l2().powi(2);
-    let regular_f3 = regular.calc_g_sum(|frequency| frequency.powi(3), false);
     let regular_entropy = regular.calc_entropy();
     let regular_frequency = univmon_frequency(&regular, 0, false);
     let regular_hh = univmon_heavy_hitters(&regular, false, TOP_K);
     let fast_l1 = fast.calc_l1();
     let fast_card = fast.calc_card();
     let fast_f2 = fast.calc_l2().powi(2);
-    let fast_f3 = fast.calc_g_sum(|frequency| frequency.powi(3), false);
     let fast_entropy = fast.calc_entropy();
     let fast_frequency = univmon_frequency(&fast, 0, true);
     let fast_hh = univmon_heavy_hitters(&fast, true, TOP_K);
     let q_l1 = q_ordered_sketch.count() as f64;
     let q_card = q_base_sketch.estimate_distinct();
     let q_f2 = q_base_sketch.estimate_f2();
-    let q_f3 = q_base_sketch.estimate_f3();
     let q_entropy_bits = q_base_sketch.estimate_entropy() / std::f64::consts::LN_2;
     let q_frequency = q_ordered_sketch.estimate_frequency(0.0) as f64;
     let q_hh: Vec<_> = q_ordered_sketch
@@ -288,7 +284,6 @@ fn main() {
         .into_iter()
         .map(|(key, count)| (key as u64, count))
         .collect();
-    let q_memory_f3 = q_memory_matched_sketch.estimate_f3();
 
     let q_prepare_query = average_query(|| q_ordered_sketch.prepare_queries(), QUERY_REPEATS);
     let q_memory_prepare_query =
@@ -327,16 +322,6 @@ fn main() {
     let fast_f2_query = average_query(|| fast.calc_l2(), QUERY_REPEATS);
     let q_f2_query = average_query(|| q_ordered_sketch.estimate_f2(), QUERY_REPEATS);
     let q_memory_f2_query = average_query(|| q_memory_matched_sketch.estimate_f2(), QUERY_REPEATS);
-    let regular_f3_query = average_query(
-        || regular.calc_g_sum(|frequency| frequency.powi(3), false),
-        QUERY_REPEATS,
-    );
-    let fast_f3_query = average_query(
-        || fast.calc_g_sum(|frequency| frequency.powi(3), false),
-        QUERY_REPEATS,
-    );
-    let q_f3_query = average_query(|| q_ordered_sketch.estimate_f3(), QUERY_REPEATS);
-    let q_memory_f3_query = average_query(|| q_memory_matched_sketch.estimate_f3(), QUERY_REPEATS);
     let regular_entropy_query = average_query(|| regular.calc_entropy(), QUERY_REPEATS);
     let fast_entropy_query = average_query(|| fast.calc_entropy(), QUERY_REPEATS);
     let q_entropy_query = average_query(|| q_ordered_sketch.estimate_entropy(), QUERY_REPEATS);
@@ -385,9 +370,6 @@ fn main() {
     let q_prepared_f2_query = average_query(|| q_prepared.estimate_f2(), QUERY_REPEATS);
     let q_memory_prepared_f2_query =
         average_query(|| q_memory_prepared.estimate_f2(), QUERY_REPEATS);
-    let q_prepared_f3_query = average_query(|| q_prepared.estimate_f3(), QUERY_REPEATS);
-    let q_memory_prepared_f3_query =
-        average_query(|| q_memory_prepared.estimate_f3(), QUERY_REPEATS);
     let q_prepared_entropy_query = average_query(|| q_prepared.estimate_entropy(), QUERY_REPEATS);
     let q_memory_prepared_entropy_query =
         average_query(|| q_memory_prepared.estimate_entropy(), QUERY_REPEATS);
@@ -415,7 +397,7 @@ fn main() {
         "workload: n={N}, domain={DOMAIN}, levels={LEVELS}, width={WIDTH}, depth={DEPTH}, candidates={CANDIDATES}"
     );
     println!(
-        "exact: L1={exact_l1:.0}, freq(0)={}, F0={exact_f0:.0}, F2={exact_f2:.0}, F3={exact_f3:.0}, entropy={exact_entropy_bits:.6} bits",
+        "exact: L1={exact_l1:.0}, freq(0)={}, F0={exact_f0:.0}, F2={exact_f2:.0}, entropy={exact_entropy_bits:.6} bits",
         exact[&0]
     );
     println!(
@@ -504,13 +486,6 @@ fn main() {
         latency(q_memory_f2_query)
     );
     println!(
-        "  F3/custom-g     {:>11}  {:>16}  {:>18}  {:>16}",
-        latency(regular_f3_query),
-        latency(fast_f3_query),
-        latency(q_f3_query),
-        latency(q_memory_f3_query)
-    );
-    println!(
         "  entropy         {:>11}  {:>16}  {:>18}  {:>16}",
         latency(regular_entropy_query),
         latency(fast_entropy_query),
@@ -571,11 +546,6 @@ fn main() {
         latency(q_memory_prepared_f2_query)
     );
     println!(
-        "  F3/custom-g                    {:>11}        {:>11}",
-        latency(q_prepared_f3_query),
-        latency(q_memory_prepared_f3_query)
-    );
-    println!(
         "  entropy                        {:>11}        {:>11}",
         latency(q_prepared_entropy_query),
         latency(q_memory_prepared_entropy_query)
@@ -603,42 +573,38 @@ fn main() {
     println!();
     println!("accuracy (relative error):");
     println!(
-        "  UnivMon insert       L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, F3={:.4}, H={:.4}, HH-recall={:.2}",
+        "  UnivMon insert       L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, H={:.4}, HH-recall={:.2}",
         relative_error(regular_l1, exact_l1),
         relative_error(regular_frequency, exact[&0] as f64),
         relative_error(regular_card, exact_f0),
         relative_error(regular_f2, exact_f2),
-        relative_error(regular_f3, exact_f3),
         relative_error(regular_entropy, exact_entropy_bits),
         heavy_hitter_recall(&regular_hh, &exact_top),
     );
     println!(
-        "  UnivMon fast_insert  L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, F3={:.4}, H={:.4}, HH-recall={:.2}",
+        "  UnivMon fast_insert  L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, H={:.4}, HH-recall={:.2}",
         relative_error(fast_l1, exact_l1),
         relative_error(fast_frequency, exact[&0] as f64),
         relative_error(fast_card, exact_f0),
         relative_error(fast_f2, exact_f2),
-        relative_error(fast_f3, exact_f3),
         relative_error(fast_entropy, exact_entropy_bits),
         heavy_hitter_recall(&fast_hh, &exact_top),
     );
     println!(
-        "  UnivMon-Q universal  L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, F3={:.4}, H={:.4}, HH-recall={:.2}",
+        "  UnivMon-Q universal  L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, H={:.4}, HH-recall={:.2}",
         relative_error(q_l1, exact_l1),
         relative_error(q_frequency, exact[&0] as f64),
         relative_error(q_card, exact_f0),
         relative_error(q_f2, exact_f2),
-        relative_error(q_f3, exact_f3),
         relative_error(q_entropy_bits, exact_entropy_bits),
         heavy_hitter_recall(&q_hh, &exact_top),
     );
     println!(
-        "  UnivMon-Q mem-match L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, F3={:.4}, H={:.4}, HH-recall={:.2}",
+        "  UnivMon-Q mem-match L1={:.4}, freq={:.4}, F0={:.4}, F2={:.4}, H={:.4}, HH-recall={:.2}",
         relative_error(q_memory_l1, exact_l1),
         relative_error(q_memory_frequency, exact[&0] as f64),
         relative_error(q_memory_matched_sketch.estimate_distinct(), exact_f0),
         relative_error(q_memory_matched_sketch.estimate_f2(), exact_f2),
-        relative_error(q_memory_f3, exact_f3),
         relative_error(
             q_memory_matched_sketch.estimate_entropy() / std::f64::consts::LN_2,
             exact_entropy_bits

--- a/examples/compare_univmon_q_bundle.rs
+++ b/examples/compare_univmon_q_bundle.rs
@@ -1,0 +1,1127 @@
+//! Task-complete UnivMon-Q versus specialized-sketch bundle comparison.
+//!
+//! Run with:
+//!
+//!   cargo run --release --example compare_univmon_q_bundle -- 200000
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::hint::black_box;
+use std::mem::size_of;
+use std::time::{Duration, Instant};
+
+use asap_sketchlib::{KLL, UnivMonQ, UnivMonQConfig};
+
+const LEVELS: usize = 12;
+const DEPTH: usize = 5;
+const ORDERED_SAMPLES: usize = 1_024;
+const BUNDLE_WIDTH: usize = 4_096;
+const BUNDLE_CANDIDATES: usize = 256;
+const BUNDLE_RESERVOIR: usize = 1_024;
+const BUNDLE_KLL_K: usize = 200;
+const TOP_K: usize = 20;
+const UPDATE_REPEATS: usize = 5;
+const MERGE_REPEATS: usize = 7;
+const QUERY_REPEATS: u32 = 100;
+const QUANTILES: [f64; 7] = [0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999];
+type Generator = fn(usize, u64) -> Vec<i64>;
+
+fn main() {
+    let n = std::env::args()
+        .nth(1)
+        .map(|value| value.parse().expect("n must be a positive integer"))
+        .unwrap_or(200_000);
+    assert!(n > 0, "n must be a positive integer");
+    let seed = 0x2026_0804_u64;
+    let q_matched = UnivMonQConfig {
+        levels: LEVELS,
+        width: 256,
+        width_halving_period: 3,
+        depth: DEPTH,
+        counter_bits: 32,
+        candidates: 128,
+        ordered_samples: ORDERED_SAMPLES,
+        hash_seed: 5,
+    };
+    let q_quality = UnivMonQConfig {
+        width: 1_024,
+        candidates: 256,
+        ..q_matched
+    };
+
+    println!("UnivMon-Q versus task-complete specialized bundle");
+    println!("n={n} per workload; accuracy is scored after a 50/50 merge");
+    println!(
+        "bundle: HLL(p=14) + {DEPTH}x{BUNDLE_WIDTH} CountSketch(i32) + SpaceSaving({BUNDLE_CANDIDATES}) + occurrence bottom-k({BUNDLE_RESERVOIR}) + KLL(k={BUNDLE_KLL_K}) + exact count/extrema"
+    );
+    println!(
+        "Q-matched: width={}, candidates={}; Q-quality: width={}, candidates={}; both use {} ordered samples",
+        q_matched.width,
+        q_matched.candidates,
+        q_quality.width,
+        q_quality.candidates,
+        q_matched.ordered_samples
+    );
+
+    let generators: [(&str, Generator); 5] = [
+        ("uniform", uniform),
+        ("normal", normal),
+        ("exponential", exponential),
+        ("zipf", zipf),
+        ("elephants", elephants),
+    ];
+
+    let mut saved = None;
+    for (offset, (workload, generator)) in generators.into_iter().enumerate() {
+        let workload_seed = seed.wrapping_add(offset as u64);
+        let data = generator(n, workload_seed);
+        let truth = Truth::new(&data);
+
+        println!();
+        println!(
+            "[{workload}] distinct={}, range=[{}, {}], entropy={:.3}",
+            truth.frequencies.len(),
+            truth.min,
+            truth.max,
+            truth.entropy
+        );
+        println!(
+            "  {:<13} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9}",
+            "construction",
+            "ns/up",
+            "KiB",
+            "merge-us",
+            "point",
+            "F0-rel",
+            "F2-rel",
+            "H-rel",
+            "HH-mass"
+        );
+
+        let (q_matched_one, q_matched_update) = timed_q(&data, q_matched);
+        let (q_matched_merged, q_matched_merge) = merged_q(&data, q_matched);
+        let q_matched_score = score_q(&q_matched_merged, &truth);
+        print_score(
+            "Q-matched",
+            q_matched_update,
+            q_matched_one.estimated_memory_bytes(),
+            q_matched_merge,
+            &q_matched_score,
+        );
+
+        let (q_quality_one, q_quality_update) = timed_q(&data, q_quality);
+        let (q_quality_merged, q_quality_merge) = merged_q(&data, q_quality);
+        let q_quality_score = score_q(&q_quality_merged, &truth);
+        print_score(
+            "Q-quality",
+            q_quality_update,
+            q_quality_one.estimated_memory_bytes(),
+            q_quality_merge,
+            &q_quality_score,
+        );
+
+        let (bundle_one, bundle_update) = timed_bundle(&data, workload_seed);
+        let (bundle_merged, bundle_merge) = merged_bundle(&data, workload_seed);
+        let bundle_score = score_bundle(&bundle_merged, &truth);
+        print_score(
+            "bundle",
+            bundle_update,
+            bundle_one.estimated_memory_bytes(),
+            bundle_merge,
+            &bundle_score,
+        );
+
+        println!(
+            "  ordered error: {:<13} rank-mean={:.5}, CDF-max={:.5}, value/range={:.5}",
+            "Q-matched",
+            q_matched_score.rank_mean,
+            q_matched_score.cdf_max,
+            q_matched_score.value_range
+        );
+        println!(
+            "                 {:<13} rank-mean={:.5}, CDF-max={:.5}, value/range={:.5}",
+            "Q-quality",
+            q_quality_score.rank_mean,
+            q_quality_score.cdf_max,
+            q_quality_score.value_range
+        );
+        println!(
+            "                 {:<13} rank-mean={:.5}, CDF-max={:.5}, value/range={:.5}",
+            "bundle", bundle_score.rank_mean, bundle_score.cdf_max, bundle_score.value_range
+        );
+
+        if workload == "elephants" {
+            saved = Some((truth, q_matched_one, q_quality_one, bundle_one));
+        }
+    }
+
+    let (truth, q_matched, q_quality, bundle) = saved.expect("elephants workload is present");
+    println!();
+    println!(
+        "query latency on elephants (mean of {QUERY_REPEATS} release queries; per-metric rows use prepared views):"
+    );
+    print_query_latency(&truth, &q_matched, &q_quality, &bundle);
+    println!();
+    println!("Notes:");
+    println!("  Count and min/max are exact for all three constructions.");
+    println!("  point = RMSE over present and absent keys, normalized by exact sqrt(F2).");
+    println!("  HH-mass = true mass captured by returned keys / exact top-{TOP_K} mass.");
+    println!(
+        "  value/range normalizes quantile value error by max-min, avoiding zero-value artifacts."
+    );
+    println!(
+        "  The bundle is a straightforward reference, not a fused/hash-sharing implementation."
+    );
+    println!("  prepare and all-task batch include materializing the query view.");
+}
+
+fn print_score(name: &str, update: Duration, memory: usize, merge: Duration, score: &Score) {
+    println!(
+        "  {name:<13} {:>9.1} {:>9.1} {:>9.1} {:>9.5} {:>9.4} {:>9.4} {:>9.4} {:>9.4}",
+        update.as_nanos() as f64 / score.n as f64,
+        memory as f64 / 1024.0,
+        merge.as_secs_f64() * 1e6,
+        score.point,
+        score.f0,
+        score.f2,
+        score.entropy,
+        score.hh_mass
+    );
+}
+
+fn timed_q(data: &[i64], config: UnivMonQConfig) -> (UnivMonQ, Duration) {
+    let mut times = Vec::with_capacity(UPDATE_REPEATS);
+    let mut retained = None;
+    for _ in 0..UPDATE_REPEATS {
+        let mut sketch = UnivMonQ::new(config).unwrap();
+        let start = Instant::now();
+        for value in data {
+            sketch.add(value);
+        }
+        times.push(start.elapsed());
+        retained = Some(sketch);
+    }
+    (retained.unwrap(), median(times))
+}
+
+fn timed_bundle(data: &[i64], seed: u64) -> (SpecializedBundle, Duration) {
+    let mut times = Vec::with_capacity(UPDATE_REPEATS);
+    let mut retained = None;
+    for repeat in 0..UPDATE_REPEATS {
+        let mut sketch = SpecializedBundle::new(seed, repeat as u64);
+        let start = Instant::now();
+        for value in data {
+            sketch.update(*value);
+        }
+        times.push(start.elapsed());
+        retained = Some(sketch);
+    }
+    (retained.unwrap(), median(times))
+}
+
+fn merged_q(data: &[i64], config: UnivMonQConfig) -> (UnivMonQ, Duration) {
+    let midpoint = data.len() / 2;
+    let mut left = UnivMonQ::new(config).unwrap();
+    let mut right = UnivMonQ::new(config).unwrap();
+    for value in &data[..midpoint] {
+        left.add(value);
+    }
+    for value in &data[midpoint..] {
+        right.add(value);
+    }
+    let mut times = Vec::with_capacity(MERGE_REPEATS);
+    for _ in 0..MERGE_REPEATS {
+        let mut merged = left.clone();
+        let start = Instant::now();
+        merged.merge(&right).unwrap();
+        times.push(start.elapsed());
+        black_box(merged.count());
+    }
+    let mut merged = left;
+    merged.merge(&right).unwrap();
+    (merged, median(times))
+}
+
+fn merged_bundle(data: &[i64], seed: u64) -> (SpecializedBundle, Duration) {
+    let midpoint = data.len() / 2;
+    let mut left = SpecializedBundle::new(seed, 1);
+    let mut right = SpecializedBundle::new(seed, 2);
+    for value in &data[..midpoint] {
+        left.update(*value);
+    }
+    for value in &data[midpoint..] {
+        right.update(*value);
+    }
+    let mut times = Vec::with_capacity(MERGE_REPEATS);
+    for _ in 0..MERGE_REPEATS {
+        let mut merged = left.clone();
+        let start = Instant::now();
+        merged.merge(&right);
+        times.push(start.elapsed());
+        black_box(merged.count);
+    }
+    let mut merged = left;
+    merged.merge(&right);
+    (merged, median(times))
+}
+
+fn median(mut values: Vec<Duration>) -> Duration {
+    values.sort_unstable();
+    values[values.len() / 2]
+}
+
+#[derive(Debug)]
+struct Score {
+    n: usize,
+    point: f64,
+    f0: f64,
+    f2: f64,
+    entropy: f64,
+    hh_mass: f64,
+    rank_mean: f64,
+    cdf_max: f64,
+    value_range: f64,
+}
+
+fn score_q(sketch: &UnivMonQ, truth: &Truth) -> Score {
+    let query = sketch.prepare_queries();
+    assert_eq!(query.count(), truth.n as u64);
+    assert_eq!(query.min(), Some(truth.min as f64));
+    assert_eq!(query.max(), Some(truth.max as f64));
+    let points: Vec<u64> = truth
+        .point_queries
+        .iter()
+        .map(|(key, _)| query.estimate_frequency(*key as f64))
+        .collect();
+    let heavy: Vec<(i64, u64)> = query
+        .heavy_hitters(TOP_K)
+        .into_iter()
+        .map(|(key, frequency)| (key as i64, frequency))
+        .collect();
+    let quantiles: Vec<i64> = query
+        .quantiles(&QUANTILES)
+        .into_iter()
+        .map(|value| value.unwrap() as i64)
+        .collect();
+    let ranks: Vec<(i64, f64)> = truth
+        .cdf_probes
+        .iter()
+        .map(|value| {
+            (
+                *value,
+                query.rank(*value as f64).unwrap() as f64 / truth.n as f64,
+            )
+        })
+        .collect();
+    truth.score(
+        &points,
+        query.estimate_distinct(),
+        query.estimate_f2(),
+        query.estimate_entropy(),
+        &heavy,
+        &quantiles,
+        &ranks,
+    )
+}
+
+fn score_bundle(sketch: &SpecializedBundle, truth: &Truth) -> Score {
+    assert_eq!(sketch.count, truth.n as u64);
+    assert_eq!(sketch.min, Some(truth.min));
+    assert_eq!(sketch.max, Some(truth.max));
+    let points: Vec<u64> = truth
+        .point_queries
+        .iter()
+        .map(|(key, _)| sketch.frequency(*key))
+        .collect();
+    let cdf = sketch.kll.cdf();
+    let quantiles: Vec<i64> = QUANTILES
+        .iter()
+        .map(|q| cdf.query(*q).round() as i64)
+        .collect();
+    let ranks: Vec<(i64, f64)> = truth
+        .cdf_probes
+        .iter()
+        .map(|value| {
+            (
+                *value,
+                sketch.kll.rank(*value as f64) as f64 / truth.n as f64,
+            )
+        })
+        .collect();
+    truth.score(
+        &points,
+        sketch.hll.estimate(),
+        sketch.frequencies.estimate_f2(),
+        sketch.estimate_entropy(),
+        &sketch.heavy_hitters.top(TOP_K),
+        &quantiles,
+        &ranks,
+    )
+}
+
+struct Truth {
+    n: usize,
+    frequencies: HashMap<i64, u64>,
+    sorted: Vec<i64>,
+    point_queries: Vec<(i64, u64)>,
+    cdf_probes: Vec<i64>,
+    top_mass: f64,
+    min: i64,
+    max: i64,
+    f0: f64,
+    f2: f64,
+    entropy: f64,
+}
+
+impl Truth {
+    fn new(data: &[i64]) -> Self {
+        let mut frequencies = HashMap::<i64, u64>::new();
+        for value in data {
+            *frequencies.entry(*value).or_default() += 1;
+        }
+        let mut sorted = data.to_vec();
+        sorted.sort_unstable();
+        let n = data.len() as f64;
+        let f2 = frequencies.values().map(|f| (*f as f64).powi(2)).sum();
+        let entropy = frequencies
+            .values()
+            .map(|f| {
+                let p = *f as f64 / n;
+                -p * p.ln()
+            })
+            .sum();
+        let mut counts: Vec<u64> = frequencies.values().copied().collect();
+        counts.sort_unstable_by(|left, right| right.cmp(left));
+        let top_mass = counts.iter().take(TOP_K).sum::<u64>() as f64;
+        let mut point_queries: Vec<_> = frequencies
+            .iter()
+            .map(|(key, frequency)| (*key, *frequency))
+            .collect();
+        point_queries.sort_unstable_by_key(|(key, _)| mix64(*key as u64 ^ 0x0050_4f49_4e54));
+        point_queries.truncate(256);
+        let mut absent = 0_u64;
+        while point_queries.len() < 512 {
+            absent = mix64(absent ^ 0x4142_5345_4e54);
+            let key = absent as i64;
+            if !frequencies.contains_key(&key) {
+                point_queries.push((key, 0));
+            }
+        }
+        let cdf_probes = (0..=100)
+            .map(|index| sorted[(index * (data.len() - 1)) / 100])
+            .collect();
+        Self {
+            n: data.len(),
+            f0: frequencies.len() as f64,
+            min: sorted[0],
+            max: sorted[sorted.len() - 1],
+            frequencies,
+            sorted,
+            point_queries,
+            cdf_probes,
+            top_mass,
+            f2,
+            entropy,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn score(
+        &self,
+        points: &[u64],
+        f0: f64,
+        f2: f64,
+        entropy: f64,
+        heavy: &[(i64, u64)],
+        quantiles: &[i64],
+        ranks: &[(i64, f64)],
+    ) -> Score {
+        let point_mse = self
+            .point_queries
+            .iter()
+            .zip(points)
+            .map(|((_, exact), estimate)| (*estimate as f64 - *exact as f64).powi(2))
+            .sum::<f64>()
+            / points.len() as f64;
+        let keys: HashSet<i64> = heavy.iter().map(|entry| entry.0).collect();
+        let captured: u64 = keys
+            .iter()
+            .map(|key| self.frequencies.get(key).copied().unwrap_or(0))
+            .sum();
+        let rank_mean = QUANTILES
+            .iter()
+            .zip(quantiles)
+            .map(|(q, estimate)| self.quantile_rank_error(*q, *estimate))
+            .sum::<f64>()
+            / QUANTILES.len() as f64;
+        let range = (i128::from(self.max) - i128::from(self.min))
+            .unsigned_abs()
+            .max(1) as f64;
+        let value_range = QUANTILES
+            .iter()
+            .zip(quantiles)
+            .map(|(q, estimate)| {
+                let exact =
+                    self.sorted[((q * (self.n - 1) as f64).round() as usize).min(self.n - 1)];
+                (i128::from(*estimate) - i128::from(exact)).unsigned_abs() as f64 / range
+            })
+            .sum::<f64>()
+            / QUANTILES.len() as f64;
+        let cdf_max = ranks
+            .iter()
+            .map(|(value, estimate)| {
+                let exact =
+                    self.sorted.partition_point(|item| *item <= *value) as f64 / self.n as f64;
+                (estimate - exact).abs()
+            })
+            .fold(0.0, f64::max);
+        Score {
+            n: self.n,
+            point: point_mse.sqrt() / self.f2.sqrt().max(1.0),
+            f0: relative_error(f0, self.f0),
+            f2: relative_error(f2, self.f2),
+            entropy: relative_error(entropy, self.entropy),
+            hh_mass: (captured as f64 / self.top_mass.max(1.0)).min(1.0),
+            rank_mean,
+            cdf_max,
+            value_range,
+        }
+    }
+
+    fn quantile_rank_error(&self, q: f64, estimate: i64) -> f64 {
+        let target = (q * self.n as f64).ceil().max(1.0) as usize;
+        let lower = self.sorted.partition_point(|item| *item < estimate);
+        let upper = self.sorted.partition_point(|item| *item <= estimate);
+        if target < lower {
+            (lower - target) as f64 / self.n as f64
+        } else {
+            target.saturating_sub(upper) as f64 / self.n as f64
+        }
+    }
+}
+
+fn relative_error(estimate: f64, exact: f64) -> f64 {
+    (estimate - exact).abs() / exact.abs().max(1.0)
+}
+
+#[derive(Clone)]
+struct SpecializedBundle {
+    hll: HyperLogLog,
+    frequencies: FrequencyCountSketch,
+    heavy_hitters: SpaceSaving,
+    reservoir: OccurrenceBottomK,
+    kll: KLL<i64>,
+    count: u64,
+    min: Option<i64>,
+    max: Option<i64>,
+}
+
+impl SpecializedBundle {
+    fn new(seed: u64, stream_id: u64) -> Self {
+        Self {
+            hll: HyperLogLog::new(14, seed ^ 0x0048_4c4c),
+            frequencies: FrequencyCountSketch::new(BUNDLE_WIDTH, DEPTH, seed ^ 0x4353),
+            heavy_hitters: SpaceSaving::new(BUNDLE_CANDIDATES),
+            reservoir: OccurrenceBottomK::new(BUNDLE_RESERVOIR, seed ^ 0x0052_4553, stream_id),
+            kll: KLL::init_kll_with_seed(BUNDLE_KLL_K as i32, seed ^ stream_id ^ 0x004b_4c4c),
+            count: 0,
+            min: None,
+            max: None,
+        }
+    }
+
+    fn update(&mut self, value: i64) {
+        self.count += 1;
+        self.min = Some(self.min.map_or(value, |old| old.min(value)));
+        self.max = Some(self.max.map_or(value, |old| old.max(value)));
+        self.hll.update(value);
+        self.frequencies.update(value);
+        self.heavy_hitters.update(value);
+        self.reservoir.update(value);
+        self.kll.update(&value);
+    }
+
+    fn merge(&mut self, other: &Self) {
+        self.count += other.count;
+        self.min = match (self.min, other.min) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            (left, right) => left.or(right),
+        };
+        self.max = match (self.max, other.max) {
+            (Some(left), Some(right)) => Some(left.max(right)),
+            (left, right) => left.or(right),
+        };
+        self.hll.merge(&other.hll);
+        self.frequencies.merge(&other.frequencies);
+        self.heavy_hitters.merge(&other.heavy_hitters);
+        self.reservoir.merge(&other.reservoir);
+        self.kll.merge(&other.kll);
+    }
+
+    fn frequency(&self, value: i64) -> u64 {
+        self.frequencies.estimate(value).max(0) as u64
+    }
+
+    fn estimate_entropy(&self) -> f64 {
+        if self.reservoir.samples.is_empty() || self.count == 0 {
+            return 0.0;
+        }
+        let n = self.count as f64;
+        self.reservoir
+            .samples
+            .iter()
+            .map(|(_, value)| (n / self.frequency(*value).max(1) as f64).ln())
+            .sum::<f64>()
+            / self.reservoir.samples.len() as f64
+    }
+
+    fn estimated_memory_bytes(&self) -> usize {
+        self.hll.bytes()
+            + self.frequencies.bytes()
+            + self.heavy_hitters.bytes()
+            + self.reservoir.bytes()
+            + kll_reserved_bytes(BUNDLE_KLL_K, 8)
+            + 3 * size_of::<u64>()
+    }
+}
+
+#[derive(Clone)]
+struct HyperLogLog {
+    precision: u32,
+    registers: Vec<u8>,
+    seed: u64,
+}
+
+impl HyperLogLog {
+    fn new(precision: u32, seed: u64) -> Self {
+        Self {
+            precision,
+            registers: vec![0; 1 << precision],
+            seed,
+        }
+    }
+
+    fn update(&mut self, value: i64) {
+        let hash = mix64(value as u64 ^ self.seed);
+        let index = (hash >> (64 - self.precision)) as usize;
+        let rank = (hash << self.precision).leading_zeros() + 1;
+        self.registers[index] = self.registers[index].max(rank as u8);
+    }
+
+    fn merge(&mut self, other: &Self) {
+        assert_eq!(self.precision, other.precision);
+        assert_eq!(self.seed, other.seed);
+        for (left, right) in self.registers.iter_mut().zip(&other.registers) {
+            *left = (*left).max(*right);
+        }
+    }
+
+    fn estimate(&self) -> f64 {
+        let m = self.registers.len() as f64;
+        let alpha = 0.7213 / (1.0 + 1.079 / m);
+        let harmonic: f64 = self
+            .registers
+            .iter()
+            .map(|register| 2.0_f64.powi(-i32::from(*register)))
+            .sum();
+        let raw = alpha * m * m / harmonic;
+        let zeroes = self.registers.iter().filter(|value| **value == 0).count();
+        if raw <= 2.5 * m && zeroes > 0 {
+            m * (m / zeroes as f64).ln()
+        } else {
+            raw
+        }
+    }
+
+    fn bytes(&self) -> usize {
+        self.registers.capacity()
+    }
+}
+
+#[derive(Clone)]
+struct FrequencyCountSketch {
+    width: usize,
+    depth: usize,
+    seed: u64,
+    counters: Vec<i32>,
+}
+
+impl FrequencyCountSketch {
+    fn new(width: usize, depth: usize, seed: u64) -> Self {
+        Self {
+            width,
+            depth,
+            seed,
+            counters: vec![0; width * depth],
+        }
+    }
+
+    fn update(&mut self, value: i64) {
+        for row in 0..self.depth {
+            let hash = self.hash(value, row);
+            let bucket = hash as usize % self.width;
+            let sign = if hash >> 63 == 0 { 1 } else { -1 };
+            self.counters[row * self.width + bucket] += sign;
+        }
+    }
+
+    fn merge(&mut self, other: &Self) {
+        assert_eq!(
+            (self.width, self.depth, self.seed),
+            (other.width, other.depth, other.seed)
+        );
+        for (left, right) in self.counters.iter_mut().zip(&other.counters) {
+            *left = left.saturating_add(*right);
+        }
+    }
+
+    fn estimate(&self, value: i64) -> i64 {
+        let mut estimates = [0_i64; 64];
+        for (row, estimate) in estimates.iter_mut().enumerate().take(self.depth) {
+            let hash = self.hash(value, row);
+            let bucket = hash as usize % self.width;
+            let sign = if hash >> 63 == 0 { 1 } else { -1 };
+            *estimate = i64::from(sign * self.counters[row * self.width + bucket]);
+        }
+        estimates[..self.depth].sort_unstable();
+        estimates[self.depth / 2]
+    }
+
+    fn estimate_f2(&self) -> f64 {
+        let mut rows = Vec::with_capacity(self.depth);
+        for row in 0..self.depth {
+            let start = row * self.width;
+            rows.push(
+                self.counters[start..start + self.width]
+                    .iter()
+                    .map(|counter| f64::from(*counter).powi(2))
+                    .sum(),
+            );
+        }
+        rows.sort_unstable_by(f64::total_cmp);
+        rows[self.depth / 2]
+    }
+
+    fn hash(&self, value: i64, row: usize) -> u64 {
+        mix64(value as u64 ^ mix64(self.seed ^ row as u64))
+    }
+
+    fn bytes(&self) -> usize {
+        self.counters.capacity() * size_of::<i32>()
+    }
+}
+
+#[derive(Clone)]
+struct SpaceSaving {
+    capacity: usize,
+    counts: HashMap<i64, u64>,
+    heap: BinaryHeap<Reverse<(u64, i64)>>,
+}
+
+impl SpaceSaving {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            counts: HashMap::with_capacity(capacity),
+            heap: BinaryHeap::with_capacity(capacity * 4),
+        }
+    }
+
+    fn update(&mut self, value: i64) {
+        if let Some(count) = self.counts.get_mut(&value) {
+            *count += 1;
+            self.heap.push(Reverse((*count, value)));
+            self.compact();
+            return;
+        }
+        if self.counts.len() < self.capacity {
+            self.counts.insert(value, 1);
+            self.heap.push(Reverse((1, value)));
+            return;
+        }
+        let (minimum, evicted) = loop {
+            let Reverse((stored, candidate)) = self.heap.pop().unwrap();
+            if self.counts.get(&candidate) == Some(&stored) {
+                break (stored, candidate);
+            }
+        };
+        self.counts.remove(&evicted);
+        self.counts.insert(value, minimum + 1);
+        self.heap.push(Reverse((minimum + 1, value)));
+        self.compact();
+    }
+
+    fn merge(&mut self, other: &Self) {
+        let left_min = if self.counts.len() == self.capacity {
+            self.counts.values().copied().min().unwrap_or(0)
+        } else {
+            0
+        };
+        let right_min = if other.counts.len() == other.capacity {
+            other.counts.values().copied().min().unwrap_or(0)
+        } else {
+            0
+        };
+        let mut combined = HashMap::with_capacity(self.capacity * 2);
+        for (key, count) in &self.counts {
+            combined.insert(
+                *key,
+                count.saturating_add(other.counts.get(key).copied().unwrap_or(right_min)),
+            );
+        }
+        for (key, count) in &other.counts {
+            combined
+                .entry(*key)
+                .or_insert(count.saturating_add(left_min));
+        }
+        let mut retained: Vec<_> = combined.into_iter().collect();
+        retained.sort_unstable_by_key(|entry| Reverse(entry.1));
+        retained.truncate(self.capacity);
+        self.counts.clear();
+        self.heap.clear();
+        for (key, count) in retained {
+            self.counts.insert(key, count);
+            self.heap.push(Reverse((count, key)));
+        }
+    }
+
+    fn top(&self, k: usize) -> Vec<(i64, u64)> {
+        let mut values: Vec<_> = self
+            .counts
+            .iter()
+            .map(|(key, count)| (*key, *count))
+            .collect();
+        values.sort_unstable_by_key(|entry| Reverse(entry.1));
+        values.truncate(k);
+        values
+    }
+
+    fn compact(&mut self) {
+        if self.heap.len() < self.capacity * 4 {
+            return;
+        }
+        self.heap.clear();
+        self.heap.extend(
+            self.counts
+                .iter()
+                .map(|(key, count)| Reverse((*count, *key))),
+        );
+    }
+
+    fn bytes(&self) -> usize {
+        self.capacity * (24 + 4 * size_of::<Reverse<(u64, i64)>>())
+    }
+}
+
+#[derive(Clone)]
+struct OccurrenceBottomK {
+    capacity: usize,
+    samples: BinaryHeap<(u64, i64)>,
+    seed: u64,
+    stream_id: u64,
+    sequence: u64,
+}
+
+impl OccurrenceBottomK {
+    fn new(capacity: usize, seed: u64, stream_id: u64) -> Self {
+        Self {
+            capacity,
+            samples: BinaryHeap::with_capacity(capacity),
+            seed,
+            stream_id,
+            sequence: 0,
+        }
+    }
+
+    fn update(&mut self, value: i64) {
+        let priority = mix64(self.seed ^ mix64(self.stream_id) ^ mix64(self.sequence));
+        self.sequence += 1;
+        let item = (priority, value);
+        if self.samples.len() < self.capacity {
+            self.samples.push(item);
+        } else if self.samples.peek().is_some_and(|largest| item < *largest) {
+            self.samples.pop();
+            self.samples.push(item);
+        }
+    }
+
+    fn merge(&mut self, other: &Self) {
+        let mut combined: Vec<_> = self.samples.iter().chain(&other.samples).copied().collect();
+        combined.sort_unstable();
+        combined.truncate(self.capacity);
+        self.samples = BinaryHeap::from(combined);
+        self.sequence += other.sequence;
+    }
+
+    fn bytes(&self) -> usize {
+        self.samples.capacity() * size_of::<(u64, i64)>()
+    }
+}
+
+fn kll_reserved_bytes(k: usize, m: usize) -> usize {
+    let mut scale = 1.0;
+    let mut items = 0_usize;
+    for _ in 0..61 {
+        items += ((k as f64 * scale).ceil() as usize).max(m);
+        scale *= 2.0 / 3.0;
+    }
+    items * size_of::<i64>() + 62 * size_of::<usize>() + k * size_of::<i64>()
+}
+
+fn average_query<T>(mut query: impl FnMut() -> T, repeats: u32) -> Duration {
+    let start = Instant::now();
+    for _ in 0..repeats {
+        black_box(query());
+    }
+    start.elapsed() / repeats
+}
+
+fn latency(value: Duration) -> String {
+    if value.is_zero() {
+        "<1ns".to_owned()
+    } else {
+        format!("{value:?}")
+    }
+}
+
+fn print_query_latency(
+    truth: &Truth,
+    matched: &UnivMonQ,
+    quality: &UnivMonQ,
+    bundle: &SpecializedBundle,
+) {
+    let matched_view = matched.prepare_queries();
+    let quality_view = quality.prepare_queries();
+    let bundle_cdf = bundle.kll.cdf();
+    let probe = truth.cdf_probes[truth.cdf_probes.len() / 2];
+    let columns = |metric: &str, a: Duration, b: Duration, c: Duration| {
+        println!(
+            "  {metric:<16} {:>13} {:>13} {:>13}",
+            latency(a),
+            latency(b),
+            latency(c)
+        );
+    };
+    println!(
+        "  {:<16} {:>13} {:>13} {:>13}",
+        "metric", "Q-matched", "Q-quality", "bundle"
+    );
+    columns(
+        "prepare",
+        average_query(|| black_box(matched.prepare_queries()), QUERY_REPEATS),
+        average_query(|| black_box(quality.prepare_queries()), QUERY_REPEATS),
+        average_query(|| black_box(bundle.kll.cdf()), QUERY_REPEATS),
+    );
+    columns(
+        "count",
+        average_query(|| black_box(matched_view.count()), QUERY_REPEATS),
+        average_query(|| black_box(quality_view.count()), QUERY_REPEATS),
+        average_query(|| black_box(bundle.count), QUERY_REPEATS),
+    );
+    columns(
+        "min/max",
+        average_query(
+            || black_box((matched_view.min(), matched_view.max())),
+            QUERY_REPEATS,
+        ),
+        average_query(
+            || black_box((quality_view.min(), quality_view.max())),
+            QUERY_REPEATS,
+        ),
+        average_query(|| black_box((bundle.min, bundle.max)), QUERY_REPEATS),
+    );
+    columns(
+        "point frequency",
+        average_query(
+            || black_box(matched_view.estimate_frequency(probe as f64)),
+            QUERY_REPEATS,
+        ),
+        average_query(
+            || black_box(quality_view.estimate_frequency(probe as f64)),
+            QUERY_REPEATS,
+        ),
+        average_query(|| black_box(bundle.frequency(probe)), QUERY_REPEATS),
+    );
+    columns(
+        "F0",
+        average_query(
+            || black_box(matched_view.estimate_distinct()),
+            QUERY_REPEATS,
+        ),
+        average_query(
+            || black_box(quality_view.estimate_distinct()),
+            QUERY_REPEATS,
+        ),
+        average_query(|| black_box(bundle.hll.estimate()), QUERY_REPEATS),
+    );
+    columns(
+        "F2",
+        average_query(|| black_box(matched_view.estimate_f2()), QUERY_REPEATS),
+        average_query(|| black_box(quality_view.estimate_f2()), QUERY_REPEATS),
+        average_query(
+            || black_box(bundle.frequencies.estimate_f2()),
+            QUERY_REPEATS,
+        ),
+    );
+    columns(
+        "entropy",
+        average_query(|| black_box(matched_view.estimate_entropy()), QUERY_REPEATS),
+        average_query(|| black_box(quality_view.estimate_entropy()), QUERY_REPEATS),
+        average_query(|| black_box(bundle.estimate_entropy()), QUERY_REPEATS),
+    );
+    columns(
+        "top-20",
+        average_query(
+            || black_box(matched_view.heavy_hitters(TOP_K)),
+            QUERY_REPEATS,
+        ),
+        average_query(
+            || black_box(quality_view.heavy_hitters(TOP_K)),
+            QUERY_REPEATS,
+        ),
+        average_query(|| black_box(bundle.heavy_hitters.top(TOP_K)), QUERY_REPEATS),
+    );
+    columns(
+        "rank",
+        average_query(|| black_box(matched_view.rank(probe as f64)), QUERY_REPEATS),
+        average_query(|| black_box(quality_view.rank(probe as f64)), QUERY_REPEATS),
+        average_query(
+            || black_box(bundle_cdf.quantile(probe as f64)),
+            QUERY_REPEATS,
+        ),
+    );
+    columns(
+        "7 quantiles",
+        average_query(
+            || black_box(matched_view.quantiles(&QUANTILES)),
+            QUERY_REPEATS,
+        ),
+        average_query(
+            || black_box(quality_view.quantiles(&QUANTILES)),
+            QUERY_REPEATS,
+        ),
+        average_query(
+            || black_box(QUANTILES.map(|q| bundle_cdf.query(q))),
+            QUERY_REPEATS,
+        ),
+    );
+    columns(
+        "CDF",
+        average_query(|| black_box(matched_view.cdf()), QUERY_REPEATS),
+        average_query(|| black_box(quality_view.cdf()), QUERY_REPEATS),
+        average_query(|| black_box(&bundle_cdf), QUERY_REPEATS),
+    );
+    columns(
+        "all-task batch",
+        average_query(|| query_all_q(matched, truth), QUERY_REPEATS),
+        average_query(|| query_all_q(quality, truth), QUERY_REPEATS),
+        average_query(|| query_all_bundle(bundle, truth), QUERY_REPEATS),
+    );
+}
+
+fn query_all_q(sketch: &UnivMonQ, truth: &Truth) {
+    let query = sketch.prepare_queries();
+    black_box(query.count());
+    black_box((query.min(), query.max()));
+    black_box(query.estimate_frequency(truth.cdf_probes[50] as f64));
+    black_box(query.estimate_distinct());
+    black_box(query.estimate_f2());
+    black_box(query.estimate_entropy());
+    black_box(query.heavy_hitters(TOP_K));
+    black_box(query.rank(truth.cdf_probes[50] as f64));
+    black_box(query.quantiles(&QUANTILES));
+    black_box(query.cdf());
+}
+
+fn query_all_bundle(bundle: &SpecializedBundle, truth: &Truth) {
+    black_box(bundle.count);
+    black_box((bundle.min, bundle.max));
+    black_box(bundle.frequency(truth.cdf_probes[50]));
+    black_box(bundle.hll.estimate());
+    black_box(bundle.frequencies.estimate_f2());
+    black_box(bundle.estimate_entropy());
+    black_box(bundle.heavy_hitters.top(TOP_K));
+    black_box(bundle.kll.rank(truth.cdf_probes[50] as f64));
+    let cdf = bundle.kll.cdf();
+    black_box(QUANTILES.map(|q| cdf.query(q)));
+    black_box(cdf);
+}
+
+#[derive(Clone, Copy)]
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        mix64(self.0)
+    }
+
+    fn unit(&mut self) -> f64 {
+        ((self.next() >> 11) as f64 + 0.5) / (1_u64 << 53) as f64
+    }
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn uniform(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| (rng.next() % 1_000_001) as i64 - 500_000)
+        .collect()
+}
+
+fn normal(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    let mut values = Vec::with_capacity(n);
+    while values.len() < n {
+        let radius = (-2.0 * rng.unit().ln()).sqrt();
+        let angle = std::f64::consts::TAU * rng.unit();
+        values.push((100_000.0 * radius * angle.cos()).round() as i64);
+        if values.len() < n {
+            values.push((100_000.0 * radius * angle.sin()).round() as i64);
+        }
+    }
+    values
+}
+
+fn exponential(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| (-rng.unit().ln() * 100_000.0).round() as i64)
+        .collect()
+}
+
+fn zipf(n: usize, seed: u64) -> Vec<i64> {
+    let domain = 20_000_usize;
+    let mut cdf = Vec::with_capacity(domain);
+    let mut total = 0.0;
+    for rank in 1..=domain {
+        total += 1.0 / (rank as f64).powf(1.1);
+        cdf.push(total);
+    }
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| {
+            let target = rng.unit() * total;
+            (cdf.partition_point(|value| *value < target) + 1) as i64
+        })
+        .collect()
+}
+
+fn elephants(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|index| match index % 25 {
+            0..=3 => 0,
+            4..=6 => 1_000,
+            7..=8 => 100_000,
+            9 => 1_000_000,
+            _ => 100 + (rng.next() % 999_901) as i64,
+        })
+        .collect()
+}

--- a/examples/compare_univmon_rank_modes.rs
+++ b/examples/compare_univmon_rank_modes.rs
@@ -1,0 +1,1193 @@
+//! Compare two theory-oriented ordered-query extensions of UnivMon-Q.
+//!
+//! Mode 1 evaluates fixed ranks directly through the UnivMon recurrence.
+//! Mode 2 keeps the same UnivMon core and adds a mergeable bottom-k sample of
+//! stream occurrences. Every occurrence must have a globally unique ID.
+//!
+//! Run with:
+//!
+//!   cargo run --release --example compare_univmon_rank_modes -- 50000 5
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BinaryHeap, HashSet};
+use std::hint::black_box;
+use std::mem::size_of;
+use std::time::{Duration, Instant};
+
+use asap_sketchlib::{UnivMonQ, UnivMonQConfig};
+
+const OCCURRENCE_SIZES: [usize; 2] = [1_024, 4_096];
+const HEAVY_SIGMAS: [f64; 4] = [1.0, 2.0, 4.0, 8.0];
+const QUANTILES: [f64; 13] = [
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.995, 0.999,
+];
+const MERGE_FANOUT: usize = 8;
+type Generator = fn(usize, u64) -> Vec<i64>;
+
+fn main() {
+    let n: usize = std::env::args()
+        .nth(1)
+        .map(|value| value.parse().expect("n must be positive"))
+        .unwrap_or(50_000);
+    let trials: usize = std::env::args()
+        .nth(2)
+        .map(|value| value.parse().expect("trials must be positive"))
+        .unwrap_or(5);
+    assert!(n > 0 && trials > 0);
+
+    let workloads: [(&str, Generator); 5] = [
+        ("uniform", uniform),
+        ("exponential", exponential),
+        ("bimodal", bimodal),
+        ("zipf", zipf),
+        ("elephants", elephants),
+    ];
+
+    println!("UnivMon ordered-query mode comparison: n={n}, trials={trials}");
+    println!("Errors are normalized rank errors; p95 is across trials.");
+    println!(
+        "UM quantiles invert 2049 fixed value thresholds (not an arbitrary-domain guarantee)."
+    );
+    println!();
+
+    for capacity in OCCURRENCE_SIZES {
+        let epsilon = (f64::ln(2.0 / 0.01) / (2.0 * capacity as f64)).sqrt();
+        println!(
+            "Occurrence sample {capacity}: finite-sample Hoeffding/DKW target at delta=0.01 is {:.3}%",
+            epsilon * 100.0
+        );
+    }
+
+    println!();
+    println!("accuracy and resource comparison");
+    println!(
+        "  {:<12} {:<10} {:>8} {:>10} {:>11} {:>11} {:>11} {:>11} {:>11}",
+        "workload",
+        "mode",
+        "KiB",
+        "update-ns",
+        "fixed-p95",
+        "CDF-p95",
+        "Qmean-p95",
+        "Qtail-p95",
+        "query-us"
+    );
+
+    for (workload_index, (name, generator)) in workloads.iter().enumerate() {
+        let mut pure_scores = Vec::with_capacity(trials);
+        let mut pure_update = Vec::with_capacity(trials);
+        let mut pure_query = Vec::with_capacity(trials);
+        let mut pure_memory = 0;
+        let mut occurrence_scores = vec![Vec::with_capacity(trials); OCCURRENCE_SIZES.len()];
+        let mut occurrence_update = vec![Vec::with_capacity(trials); OCCURRENCE_SIZES.len()];
+        let mut occurrence_query = vec![Vec::with_capacity(trials); OCCURRENCE_SIZES.len()];
+        let mut occurrence_memory = vec![0; OCCURRENCE_SIZES.len()];
+
+        for trial in 0..trials {
+            let seed = trial_seed(workload_index, trial);
+            let data = generator(n, seed);
+            let truth = Truth::new(&data);
+            let config = config(trial);
+
+            let pure = build_pure(&data, config, 1);
+            pure_memory = pure.estimated_memory_bytes();
+            pure_scores.push(score_pure(&pure, &truth));
+            pure_query.push(benchmark_pure_queries(&pure, &truth));
+
+            for (index, &capacity) in OCCURRENCE_SIZES.iter().enumerate() {
+                let (core, sample) = build_occurrence(&data, config, capacity, seed, 1);
+                occurrence_memory[index] =
+                    core.estimated_memory_bytes() + sample.estimated_memory_bytes();
+                occurrence_scores[index].push(score_occurrence(&sample, &truth));
+                occurrence_query[index].push(benchmark_occurrence_queries(&sample, &truth));
+            }
+
+            // Alternate measurement order across trials to reduce warm-cache
+            // bias between the core-only and core-plus-sampler modes.
+            if trial % 2 == 0 {
+                pure_update.push(benchmark_pure_updates(&data, config));
+                for (index, &capacity) in OCCURRENCE_SIZES.iter().enumerate() {
+                    occurrence_update[index]
+                        .push(benchmark_occurrence_updates(&data, config, capacity, seed));
+                }
+            } else {
+                for (index, &capacity) in OCCURRENCE_SIZES.iter().enumerate().rev() {
+                    occurrence_update[index]
+                        .push(benchmark_occurrence_updates(&data, config, capacity, seed));
+                }
+                pure_update.push(benchmark_pure_updates(&data, config));
+            }
+        }
+
+        print_row(
+            name,
+            "UM-fixed",
+            pure_memory,
+            &pure_update,
+            &pure_scores,
+            &pure_query,
+        );
+        for (index, &capacity) in OCCURRENCE_SIZES.iter().enumerate() {
+            print_row(
+                name,
+                &format!("occ-{capacity}"),
+                occurrence_memory[index],
+                &occurrence_update[index],
+                &occurrence_scores[index],
+                &occurrence_query[index],
+            );
+        }
+    }
+
+    println!();
+    println!("core-assisted occurrence-1024 sweep");
+    println!("Heavy threshold = sigma * sqrt(estimated F2 / CountSketch width).");
+    println!(
+        "  {:<12} {:<10} {:>9} {:>11} {:>11} {:>11} {:>11} {:>11}",
+        "workload", "mode", "heavies", "fixed-p95", "CDF-p95", "Qmean-p95", "cold-us", "warm-us"
+    );
+    for (workload_index, (name, generator)) in workloads.iter().enumerate() {
+        let mut raw_scores = Vec::with_capacity(trials);
+        let mut raw_queries = Vec::with_capacity(trials);
+        let mut assisted_scores = vec![Vec::with_capacity(trials); HEAVY_SIGMAS.len()];
+        let mut assisted_queries = vec![Vec::with_capacity(trials); HEAVY_SIGMAS.len()];
+        let mut heavy_counts = vec![Vec::with_capacity(trials); HEAVY_SIGMAS.len()];
+        let mut adaptive_scores = Vec::with_capacity(trials);
+        let mut adaptive_queries = Vec::with_capacity(trials);
+        let mut adaptive_warm_queries = Vec::with_capacity(trials);
+        let mut adaptive_heavies = Vec::with_capacity(trials);
+        for trial in 0..trials {
+            let seed = trial_seed(workload_index, trial);
+            let data = generator(n, seed);
+            let truth = Truth::new(&data);
+            let (core, sample) = build_occurrence(&data, config(trial), 1_024, seed, 1);
+            raw_scores.push(score_occurrence(&sample, &truth));
+            raw_queries.push(benchmark_occurrence_queries(&sample, &truth));
+            for (index, &sigma) in HEAVY_SIGMAS.iter().enumerate() {
+                let query = AssistedOccurrenceQuery::new(&core, &sample, sigma);
+                heavy_counts[index].push(query.heavy_count as f64);
+                assisted_scores[index].push(score_assisted(&query, &truth));
+                assisted_queries[index]
+                    .push(benchmark_assisted_queries(&core, &sample, &truth, sigma));
+            }
+            let adaptive = AssistedOccurrenceQuery::new_adaptive(&core, &sample);
+            adaptive_heavies.push(adaptive.heavy_count as f64);
+            adaptive_scores.push(score_assisted(&adaptive, &truth));
+            adaptive_queries.push(benchmark_adaptive_queries(&core, &sample, &truth));
+            adaptive_warm_queries.push(benchmark_adaptive_warm_queries(&core, &sample, &truth));
+        }
+        print_assisted_row(name, "raw", &raw_scores, &raw_queries, None, None);
+        for (index, &sigma) in HEAVY_SIGMAS.iter().enumerate() {
+            print_assisted_row(
+                name,
+                &format!("sigma-{sigma:.0}"),
+                &assisted_scores[index],
+                &assisted_queries[index],
+                Some(percentile(&heavy_counts[index], 0.5)),
+                None,
+            );
+        }
+        print_assisted_row(
+            name,
+            "adaptive",
+            &adaptive_scores,
+            &adaptive_queries,
+            Some(percentile(&adaptive_heavies, 0.5)),
+            Some(&adaptive_warm_queries),
+        );
+    }
+
+    println!();
+    println!("merge comparison: one pass versus {MERGE_FANOUT} shards");
+    println!(
+        "  {:<12} {:<10} {:>13} {:>14} {:>15}",
+        "workload", "mode", "CDF-drift-p95", "Q-drift-p95", "sample-identical"
+    );
+    for (workload_index, (name, generator)) in workloads.iter().enumerate() {
+        let mut pure_cdf = Vec::with_capacity(trials);
+        let mut pure_quantile = Vec::with_capacity(trials);
+        let mut occurrence_cdf = vec![Vec::with_capacity(trials); OCCURRENCE_SIZES.len()];
+        let mut occurrence_quantile = vec![Vec::with_capacity(trials); OCCURRENCE_SIZES.len()];
+        let mut adaptive_cdf = Vec::with_capacity(trials);
+        let mut adaptive_quantile = Vec::with_capacity(trials);
+        let mut identical = vec![true; OCCURRENCE_SIZES.len()];
+        for trial in 0..trials {
+            let seed = trial_seed(workload_index, trial);
+            let data = generator(n, seed);
+            let truth = Truth::new(&data);
+            let config = config(trial);
+            let pure_one = build_pure(&data, config, 1);
+            let pure_merged = build_pure(&data, config, MERGE_FANOUT);
+            let (cdf_drift, quantile_drift) = pure_drift(&pure_one, &pure_merged, &truth);
+            pure_cdf.push(cdf_drift);
+            pure_quantile.push(quantile_drift);
+
+            for (index, &capacity) in OCCURRENCE_SIZES.iter().enumerate() {
+                let (one_core, one) = build_occurrence(&data, config, capacity, seed, 1);
+                let (merged_core, merged) =
+                    build_occurrence(&data, config, capacity, seed, MERGE_FANOUT);
+                identical[index] &= one.sorted_records() == merged.sorted_records();
+                let (cdf_drift, quantile_drift) = occurrence_drift(&one, &merged, &truth);
+                occurrence_cdf[index].push(cdf_drift);
+                occurrence_quantile[index].push(quantile_drift);
+                if capacity == 1_024 {
+                    let one_query = AssistedOccurrenceQuery::new_adaptive(&one_core, &one);
+                    let merged_query = AssistedOccurrenceQuery::new_adaptive(&merged_core, &merged);
+                    let (cdf_drift, quantile_drift) =
+                        assisted_drift(&one_query, &merged_query, &truth);
+                    adaptive_cdf.push(cdf_drift);
+                    adaptive_quantile.push(quantile_drift);
+                }
+            }
+        }
+        println!(
+            "  {name:<12} {:<10} {:>13.5} {:>14.5} {:>15}",
+            "UM-fixed",
+            percentile(&pure_cdf, 0.95),
+            percentile(&pure_quantile, 0.95),
+            "n/a"
+        );
+        for (index, &capacity) in OCCURRENCE_SIZES.iter().enumerate() {
+            println!(
+                "  {name:<12} {:<10} {:>13.5} {:>14.5} {:>15}",
+                format!("occ-{capacity}"),
+                percentile(&occurrence_cdf[index], 0.95),
+                percentile(&occurrence_quantile[index], 0.95),
+                identical[index]
+            );
+        }
+        println!(
+            "  {name:<12} {:<10} {:>13.5} {:>14.5} {:>15}",
+            "adaptive",
+            percentile(&adaptive_cdf, 0.95),
+            percentile(&adaptive_quantile, 0.95),
+            identical[0]
+        );
+    }
+}
+
+fn print_assisted_row(
+    workload: &str,
+    mode: &str,
+    scores: &[Score],
+    queries: &[Duration],
+    heavies: Option<f64>,
+    warm_queries: Option<&[Duration]>,
+) {
+    let fixed: Vec<_> = scores.iter().map(|score| score.fixed_mean).collect();
+    let cdf: Vec<_> = scores.iter().map(|score| score.cdf_max).collect();
+    let quantile: Vec<_> = scores.iter().map(|score| score.quantile_mean).collect();
+    let query_us: Vec<_> = queries
+        .iter()
+        .map(|duration| duration.as_secs_f64() * 1e6)
+        .collect();
+    let heavy_label = heavies.map_or_else(|| "-".to_owned(), |value| format!("{value:.0}"));
+    let warm_label = warm_queries.map_or_else(
+        || "-".to_owned(),
+        |durations| {
+            let values: Vec<_> = durations
+                .iter()
+                .map(|duration| duration.as_secs_f64() * 1e6)
+                .collect();
+            format!("{:.1}", percentile(&values, 0.5))
+        },
+    );
+    println!(
+        "  {workload:<12} {mode:<10} {heavy_label:>9} {:>11.5} {:>11.5} {:>11.5} {:>11.1} {warm_label:>11}",
+        percentile(&fixed, 0.95),
+        percentile(&cdf, 0.95),
+        percentile(&quantile, 0.95),
+        percentile(&query_us, 0.5),
+    );
+}
+
+fn print_row(
+    workload: &str,
+    mode: &str,
+    memory: usize,
+    updates: &[f64],
+    scores: &[Score],
+    queries: &[Duration],
+) {
+    let fixed: Vec<_> = scores.iter().map(|score| score.fixed_mean).collect();
+    let cdf: Vec<_> = scores.iter().map(|score| score.cdf_max).collect();
+    let quantile: Vec<_> = scores.iter().map(|score| score.quantile_mean).collect();
+    let tail: Vec<_> = scores.iter().map(|score| score.tail_max).collect();
+    let query_us: Vec<_> = queries
+        .iter()
+        .map(|duration| duration.as_secs_f64() * 1e6)
+        .collect();
+    println!(
+        "  {workload:<12} {mode:<10} {:>8.1} {:>10.1} {:>11.5} {:>11.5} {:>11.5} {:>11.5} {:>11.1}",
+        memory as f64 / 1024.0,
+        percentile(updates, 0.5),
+        percentile(&fixed, 0.95),
+        percentile(&cdf, 0.95),
+        percentile(&quantile, 0.95),
+        percentile(&tail, 0.95),
+        percentile(&query_us, 0.5),
+    );
+}
+
+fn config(trial: usize) -> UnivMonQConfig {
+    UnivMonQConfig {
+        levels: 12,
+        width: 1_024,
+        width_halving_period: 3,
+        depth: 5,
+        counter_bits: 32,
+        candidates: 256,
+        ordered_samples: 0,
+        hash_seed: 5 + trial,
+    }
+}
+
+fn build_pure(data: &[i64], config: UnivMonQConfig, fanout: usize) -> UnivMonQ {
+    let fanout = fanout.min(data.len()).max(1);
+    let mut shards = Vec::with_capacity(fanout);
+    for shard in 0..fanout {
+        let start = shard * data.len() / fanout;
+        let end = (shard + 1) * data.len() / fanout;
+        let mut sketch = UnivMonQ::new(config).unwrap();
+        for value in &data[start..end] {
+            sketch.add(value);
+        }
+        shards.push(sketch);
+    }
+    merge_cores(shards)
+}
+
+fn build_occurrence(
+    data: &[i64],
+    config: UnivMonQConfig,
+    capacity: usize,
+    seed: u64,
+    fanout: usize,
+) -> (UnivMonQ, OccurrenceBottomK) {
+    let fanout = fanout.min(data.len()).max(1);
+    let mut shards = Vec::with_capacity(fanout);
+    for shard in 0..fanout {
+        let start = shard * data.len() / fanout;
+        let end = (shard + 1) * data.len() / fanout;
+        let mut core = UnivMonQ::new(config).unwrap();
+        let mut sample = OccurrenceBottomK::new(capacity, seed);
+        for (offset, &value) in data[start..end].iter().enumerate() {
+            core.add(&value);
+            sample.update(value, (start + offset) as u64);
+        }
+        shards.push((core, sample));
+    }
+    while shards.len() > 1 {
+        let mut merged = Vec::with_capacity(shards.len().div_ceil(2));
+        let mut iter = shards.into_iter();
+        while let Some((mut left_core, mut left_sample)) = iter.next() {
+            if let Some((right_core, right_sample)) = iter.next() {
+                left_core.merge(&right_core).unwrap();
+                left_sample.merge(&right_sample).unwrap();
+            }
+            merged.push((left_core, left_sample));
+        }
+        shards = merged;
+    }
+    shards.pop().unwrap()
+}
+
+fn merge_cores(mut sketches: Vec<UnivMonQ>) -> UnivMonQ {
+    while sketches.len() > 1 {
+        let mut merged = Vec::with_capacity(sketches.len().div_ceil(2));
+        let mut iter = sketches.into_iter();
+        while let Some(mut left) = iter.next() {
+            if let Some(right) = iter.next() {
+                left.merge(&right).unwrap();
+            }
+            merged.push(left);
+        }
+        sketches = merged;
+    }
+    sketches.pop().unwrap()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Occurrence {
+    priority: u64,
+    id: u64,
+    value: i64,
+}
+
+impl Ord for Occurrence {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.priority, self.id).cmp(&(other.priority, other.id))
+    }
+}
+
+impl PartialOrd for Occurrence {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct OccurrenceBottomK {
+    capacity: usize,
+    seed: u64,
+    count: u64,
+    heap: BinaryHeap<Occurrence>,
+}
+
+impl OccurrenceBottomK {
+    fn new(capacity: usize, seed: u64) -> Self {
+        assert!(capacity > 0);
+        Self {
+            capacity,
+            seed,
+            count: 0,
+            heap: BinaryHeap::with_capacity(capacity),
+        }
+    }
+
+    fn update(&mut self, value: i64, id: u64) {
+        self.count = self.count.saturating_add(1);
+        self.retain(Occurrence {
+            priority: mix64(id ^ self.seed),
+            id,
+            value,
+        });
+    }
+
+    fn retain(&mut self, occurrence: Occurrence) {
+        if self.heap.len() < self.capacity {
+            self.heap.push(occurrence);
+        } else if self
+            .heap
+            .peek()
+            .is_some_and(|largest| occurrence < *largest)
+        {
+            self.heap.pop();
+            self.heap.push(occurrence);
+        }
+    }
+
+    fn merge(&mut self, other: &Self) -> Result<(), &'static str> {
+        if self.capacity != other.capacity || self.seed != other.seed {
+            return Err("occurrence samples have different configurations");
+        }
+        self.count = self.count.saturating_add(other.count);
+        for &occurrence in &other.heap {
+            self.retain(occurrence);
+        }
+        Ok(())
+    }
+
+    fn prepare(&self) -> OccurrenceQuery {
+        let mut values: Vec<_> = self.heap.iter().map(|item| item.value).collect();
+        values.sort_unstable();
+        OccurrenceQuery { values }
+    }
+
+    fn sorted_records(&self) -> Vec<Occurrence> {
+        let mut records = self.heap.clone().into_vec();
+        records.sort_unstable();
+        records
+    }
+
+    fn estimated_memory_bytes(&self) -> usize {
+        self.capacity * size_of::<Occurrence>()
+    }
+}
+
+struct OccurrenceQuery {
+    values: Vec<i64>,
+}
+
+impl OccurrenceQuery {
+    fn rank_fraction(&self, value: i64) -> f64 {
+        self.values.partition_point(|item| *item <= value) as f64 / self.values.len() as f64
+    }
+
+    fn quantile(&self, q: f64) -> i64 {
+        let index = ((q * self.values.len() as f64).ceil() as usize)
+            .saturating_sub(1)
+            .min(self.values.len() - 1);
+        self.values[index]
+    }
+}
+
+/// Query-time post-stratification using high-confidence heavy values recovered
+/// by the existing UnivMon core. No additional update-time state is required.
+struct AssistedOccurrenceQuery {
+    points: Vec<(i64, f64)>,
+    min: i64,
+    max: i64,
+    heavy_count: usize,
+}
+
+impl AssistedOccurrenceQuery {
+    fn new(core: &UnivMonQ, sample: &OccurrenceBottomK, sigma: f64) -> Self {
+        let core_query = core.prepare_queries();
+        let count = core.count() as f64;
+        let f2 = core_query.estimate_f2();
+        Self::from_prepared(core, sample, &core_query, sigma, f2, count)
+    }
+
+    fn new_adaptive(core: &UnivMonQ, sample: &OccurrenceBottomK) -> Self {
+        let core_query = core.prepare_queries();
+        Self::new_adaptive_from_prepared(core, sample, &core_query)
+    }
+
+    fn new_adaptive_from_prepared(
+        core: &UnivMonQ,
+        sample: &OccurrenceBottomK,
+        core_query: &asap_sketchlib::UnivMonQQuery<'_>,
+    ) -> Self {
+        let count = core.count() as f64;
+        let f2 = core_query.estimate_f2();
+        let concentration = f2 / count.powi(2);
+        let sigma = if concentration >= 1.0 / sample.capacity as f64 {
+            1.0
+        } else {
+            f64::INFINITY
+        };
+        Self::from_prepared(core, sample, core_query, sigma, f2, count)
+    }
+
+    fn from_prepared(
+        core: &UnivMonQ,
+        sample: &OccurrenceBottomK,
+        core_query: &asap_sketchlib::UnivMonQQuery<'_>,
+        sigma: f64,
+        f2: f64,
+        count: f64,
+    ) -> Self {
+        let frequency_error_scale = (f2 / core.config().width as f64).sqrt();
+        let threshold = sigma * frequency_error_scale;
+        let mut heavy: BTreeMap<i64, f64> = core_query
+            .heavy_hitters(64)
+            .into_iter()
+            .filter(|(_, frequency)| *frequency as f64 >= threshold)
+            .map(|(value, frequency)| (value.round() as i64, frequency as f64))
+            .collect();
+
+        // Estimated heavy frequencies share the exact total-mass constraint.
+        // Scaling is needed only if CountSketch overestimates collectively.
+        let estimated_heavy_total: f64 = heavy.values().sum();
+        if estimated_heavy_total > count {
+            let scale = count / estimated_heavy_total;
+            for frequency in heavy.values_mut() {
+                *frequency *= scale;
+            }
+        }
+        let heavy_total: f64 = heavy.values().sum();
+        let residual_total = (count - heavy_total).max(0.0);
+        let heavy_values: HashSet<_> = heavy.keys().copied().collect();
+        let mut residual_values: Vec<_> = sample
+            .heap
+            .iter()
+            .filter(|occurrence| !heavy_values.contains(&occurrence.value))
+            .map(|occurrence| occurrence.value)
+            .collect();
+        residual_values.sort_unstable();
+
+        // If sampling happens to retain no residual occurrence, retaining the
+        // raw empirical distribution is safer than inventing its placement.
+        if residual_values.is_empty() && residual_total > 0.0 {
+            heavy.clear();
+            residual_values = sample.heap.iter().map(|item| item.value).collect();
+            residual_values.sort_unstable();
+        }
+
+        let residual_total = if heavy.is_empty() {
+            count
+        } else {
+            residual_total
+        };
+        let residual_weight = if residual_values.is_empty() {
+            0.0
+        } else {
+            residual_total / residual_values.len() as f64
+        };
+        let heavy_count = heavy.len();
+        let mut weighted_values: Vec<(i64, f64)> = heavy.into_iter().collect();
+        let mut residual = residual_values.into_iter().peekable();
+        while let Some(value) = residual.next() {
+            let mut copies = 1_usize;
+            while residual.peek() == Some(&value) {
+                residual.next();
+                copies += 1;
+            }
+            weighted_values.push((value, residual_weight * copies as f64));
+        }
+        let min = core.min().unwrap().round() as i64;
+        let max = core.max().unwrap().round() as i64;
+        weighted_values.push((min, 0.0));
+        weighted_values.push((max, 0.0));
+        weighted_values.sort_unstable_by_key(|point| point.0);
+        let mut combined: Vec<(i64, f64)> = Vec::with_capacity(weighted_values.len());
+        for (value, weight) in weighted_values {
+            if let Some(last) = combined.last_mut().filter(|last| last.0 == value) {
+                last.1 += weight;
+            } else {
+                combined.push((value, weight));
+            }
+        }
+        let mut running = 0.0;
+        let mut points: Vec<_> = combined
+            .into_iter()
+            .map(|(value, weight)| {
+                running += weight;
+                (value, (running / count).clamp(0.0, 1.0))
+            })
+            .collect();
+        if let Some(last) = points.last_mut() {
+            last.1 = 1.0;
+        }
+        Self {
+            points,
+            min,
+            max,
+            heavy_count,
+        }
+    }
+
+    fn rank_fraction(&self, value: i64) -> f64 {
+        let index = self.points.partition_point(|point| point.0 <= value);
+        if index == 0 {
+            0.0
+        } else {
+            self.points[index - 1].1
+        }
+    }
+
+    fn quantile(&self, q: f64) -> i64 {
+        if q == 0.0 {
+            return self.min;
+        }
+        if q == 1.0 {
+            return self.max;
+        }
+        let index = self.points.partition_point(|point| point.1 < q);
+        self.points[index.min(self.points.len() - 1)].0
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Score {
+    fixed_mean: f64,
+    cdf_max: f64,
+    quantile_mean: f64,
+    tail_max: f64,
+}
+
+fn score_pure(sketch: &UnivMonQ, truth: &Truth) -> Score {
+    let query = sketch.prepare_queries();
+    let fixed_errors: Vec<_> = truth
+        .probes
+        .iter()
+        .map(|&(value, exact)| {
+            let estimate = query.estimate_rank_universal(value as f64).unwrap() as f64
+                / truth.sorted.len() as f64;
+            (estimate - exact).abs()
+        })
+        .collect();
+    let grid = fixed_value_grid(truth, 2_049);
+    let mut estimated_cdf: Vec<_> = grid
+        .into_iter()
+        .map(|value| {
+            let rank = query.estimate_rank_universal(value as f64).unwrap() as f64
+                / truth.sorted.len() as f64;
+            (value, rank)
+        })
+        .collect();
+    isotonicize(&mut estimated_cdf);
+    let quantile_errors = quantile_errors_from_cdf(&estimated_cdf, truth);
+    Score {
+        fixed_mean: fixed_errors.iter().sum::<f64>() / fixed_errors.len() as f64,
+        cdf_max: fixed_errors.into_iter().fold(0.0, f64::max),
+        quantile_mean: quantile_errors.iter().sum::<f64>() / quantile_errors.len() as f64,
+        tail_max: tail_max(&quantile_errors),
+    }
+}
+
+fn score_occurrence(sample: &OccurrenceBottomK, truth: &Truth) -> Score {
+    let query = sample.prepare();
+    let fixed_errors: Vec<_> = truth
+        .probes
+        .iter()
+        .map(|&(value, exact)| (query.rank_fraction(value) - exact).abs())
+        .collect();
+    let quantile_errors: Vec<_> = QUANTILES
+        .iter()
+        .map(|&q| truth.quantile_rank_error(q, query.quantile(q)))
+        .collect();
+    Score {
+        fixed_mean: fixed_errors.iter().sum::<f64>() / fixed_errors.len() as f64,
+        cdf_max: fixed_errors.into_iter().fold(0.0, f64::max),
+        quantile_mean: quantile_errors.iter().sum::<f64>() / quantile_errors.len() as f64,
+        tail_max: tail_max(&quantile_errors),
+    }
+}
+
+fn score_assisted(query: &AssistedOccurrenceQuery, truth: &Truth) -> Score {
+    let fixed_errors: Vec<_> = truth
+        .probes
+        .iter()
+        .map(|&(value, exact)| (query.rank_fraction(value) - exact).abs())
+        .collect();
+    let quantile_errors: Vec<_> = QUANTILES
+        .iter()
+        .map(|&q| truth.quantile_rank_error(q, query.quantile(q)))
+        .collect();
+    Score {
+        fixed_mean: fixed_errors.iter().sum::<f64>() / fixed_errors.len() as f64,
+        cdf_max: fixed_errors.into_iter().fold(0.0, f64::max),
+        quantile_mean: quantile_errors.iter().sum::<f64>() / quantile_errors.len() as f64,
+        tail_max: tail_max(&quantile_errors),
+    }
+}
+
+fn benchmark_pure_queries(sketch: &UnivMonQ, truth: &Truth) -> Duration {
+    benchmark(|| {
+        let query = black_box(sketch).prepare_queries();
+        for &(value, _) in &truth.probes {
+            black_box(query.estimate_rank_universal(black_box(value as f64)));
+        }
+        for value in fixed_value_grid(truth, 2_049) {
+            black_box(query.estimate_rank_universal(black_box(value as f64)));
+        }
+    })
+}
+
+fn benchmark_pure_updates(data: &[i64], config: UnivMonQConfig) -> f64 {
+    let mut samples = Vec::with_capacity(3);
+    for _ in 0..3 {
+        let started = Instant::now();
+        let sketch = build_pure(black_box(data), config, 1);
+        let elapsed = started.elapsed();
+        black_box(sketch.count());
+        samples.push(elapsed.as_nanos() as f64 / data.len() as f64);
+    }
+    percentile(&samples, 0.5)
+}
+
+fn benchmark_occurrence_updates(
+    data: &[i64],
+    config: UnivMonQConfig,
+    capacity: usize,
+    seed: u64,
+) -> f64 {
+    let mut samples = Vec::with_capacity(3);
+    for _ in 0..3 {
+        let started = Instant::now();
+        let (core, sample) = build_occurrence(black_box(data), config, capacity, seed, 1);
+        let elapsed = started.elapsed();
+        black_box((core.count(), sample.heap.len()));
+        samples.push(elapsed.as_nanos() as f64 / data.len() as f64);
+    }
+    percentile(&samples, 0.5)
+}
+
+fn benchmark_occurrence_queries(sample: &OccurrenceBottomK, truth: &Truth) -> Duration {
+    benchmark(|| {
+        let query = black_box(sample).prepare();
+        for &(value, _) in &truth.probes {
+            black_box(query.rank_fraction(black_box(value)));
+        }
+        for q in QUANTILES {
+            black_box(query.quantile(black_box(q)));
+        }
+    })
+}
+
+fn benchmark_assisted_queries(
+    core: &UnivMonQ,
+    sample: &OccurrenceBottomK,
+    truth: &Truth,
+    sigma: f64,
+) -> Duration {
+    benchmark(|| {
+        let query = AssistedOccurrenceQuery::new(black_box(core), black_box(sample), sigma);
+        for &(value, _) in &truth.probes {
+            black_box(query.rank_fraction(black_box(value)));
+        }
+        for q in QUANTILES {
+            black_box(query.quantile(black_box(q)));
+        }
+    })
+}
+
+fn benchmark_adaptive_queries(
+    core: &UnivMonQ,
+    sample: &OccurrenceBottomK,
+    truth: &Truth,
+) -> Duration {
+    benchmark(|| {
+        let query = AssistedOccurrenceQuery::new_adaptive(black_box(core), black_box(sample));
+        for &(value, _) in &truth.probes {
+            black_box(query.rank_fraction(black_box(value)));
+        }
+        for q in QUANTILES {
+            black_box(query.quantile(black_box(q)));
+        }
+    })
+}
+
+fn benchmark_adaptive_warm_queries(
+    core: &UnivMonQ,
+    sample: &OccurrenceBottomK,
+    truth: &Truth,
+) -> Duration {
+    let core_query = core.prepare_queries();
+    benchmark(|| {
+        let query = AssistedOccurrenceQuery::new_adaptive_from_prepared(
+            black_box(core),
+            black_box(sample),
+            black_box(&core_query),
+        );
+        for &(value, _) in &truth.probes {
+            black_box(query.rank_fraction(black_box(value)));
+        }
+        for q in QUANTILES {
+            black_box(query.quantile(black_box(q)));
+        }
+    })
+}
+
+fn benchmark(mut operation: impl FnMut()) -> Duration {
+    let mut elapsed = Vec::with_capacity(5);
+    for _ in 0..5 {
+        let started = Instant::now();
+        operation();
+        elapsed.push(started.elapsed());
+    }
+    elapsed.sort_unstable();
+    elapsed[elapsed.len() / 2]
+}
+
+fn pure_drift(left: &UnivMonQ, right: &UnivMonQ, truth: &Truth) -> (f64, f64) {
+    let left_query = left.prepare_queries();
+    let right_query = right.prepare_queries();
+    let cdf = truth
+        .probes
+        .iter()
+        .map(|&(value, _)| {
+            let left = left_query.estimate_rank_universal(value as f64).unwrap() as f64;
+            let right = right_query.estimate_rank_universal(value as f64).unwrap() as f64;
+            (left - right).abs() / truth.sorted.len() as f64
+        })
+        .fold(0.0, f64::max);
+    let left_cdf = universal_grid(&left_query, truth);
+    let right_cdf = universal_grid(&right_query, truth);
+    let quantile = QUANTILES
+        .iter()
+        .map(|&q| {
+            let left = invert_cdf(&left_cdf, q);
+            let right = invert_cdf(&right_cdf, q);
+            truth.rank_interval_distance(left, right)
+        })
+        .fold(0.0, f64::max);
+    (cdf, quantile)
+}
+
+fn occurrence_drift(
+    left: &OccurrenceBottomK,
+    right: &OccurrenceBottomK,
+    truth: &Truth,
+) -> (f64, f64) {
+    let left = left.prepare();
+    let right = right.prepare();
+    let cdf = truth
+        .probes
+        .iter()
+        .map(|&(value, _)| (left.rank_fraction(value) - right.rank_fraction(value)).abs())
+        .fold(0.0, f64::max);
+    let quantile = QUANTILES
+        .iter()
+        .map(|&q| truth.rank_interval_distance(left.quantile(q), right.quantile(q)))
+        .fold(0.0, f64::max);
+    (cdf, quantile)
+}
+
+fn assisted_drift(
+    left: &AssistedOccurrenceQuery,
+    right: &AssistedOccurrenceQuery,
+    truth: &Truth,
+) -> (f64, f64) {
+    let cdf = truth
+        .probes
+        .iter()
+        .map(|&(value, _)| (left.rank_fraction(value) - right.rank_fraction(value)).abs())
+        .fold(0.0, f64::max);
+    let quantile = QUANTILES
+        .iter()
+        .map(|&q| truth.rank_interval_distance(left.quantile(q), right.quantile(q)))
+        .fold(0.0, f64::max);
+    (cdf, quantile)
+}
+
+fn universal_grid(query: &asap_sketchlib::UnivMonQQuery<'_>, truth: &Truth) -> Vec<(i64, f64)> {
+    let mut points: Vec<_> = fixed_value_grid(truth, 2_049)
+        .into_iter()
+        .map(|value| {
+            (
+                value,
+                query.estimate_rank_universal(value as f64).unwrap() as f64
+                    / truth.sorted.len() as f64,
+            )
+        })
+        .collect();
+    isotonicize(&mut points);
+    points
+}
+
+fn quantile_errors_from_cdf(cdf: &[(i64, f64)], truth: &Truth) -> Vec<f64> {
+    QUANTILES
+        .iter()
+        .map(|&q| truth.quantile_rank_error(q, invert_cdf(cdf, q)))
+        .collect()
+}
+
+fn invert_cdf(cdf: &[(i64, f64)], q: f64) -> i64 {
+    let index = cdf.partition_point(|point| point.1 < q);
+    cdf[index.min(cdf.len() - 1)].0
+}
+
+fn fixed_value_grid(truth: &Truth, points: usize) -> Vec<i64> {
+    let min = truth.sorted[0] as i128;
+    let span = truth.sorted[truth.sorted.len() - 1] as i128 - min;
+    (0..points)
+        .map(|index| (min + span * index as i128 / (points - 1) as i128) as i64)
+        .collect()
+}
+
+fn isotonicize(points: &mut [(i64, f64)]) {
+    #[derive(Clone, Copy)]
+    struct Block {
+        start: usize,
+        end: usize,
+        sum: f64,
+        count: usize,
+    }
+    let mut blocks: Vec<Block> = Vec::new();
+    for (index, &(_, rank)) in points.iter().enumerate() {
+        blocks.push(Block {
+            start: index,
+            end: index + 1,
+            sum: rank,
+            count: 1,
+        });
+        while blocks.len() >= 2 {
+            let right = blocks[blocks.len() - 1];
+            let left = blocks[blocks.len() - 2];
+            if left.sum / left.count as f64 <= right.sum / right.count as f64 {
+                break;
+            }
+            blocks.pop();
+            blocks.pop();
+            blocks.push(Block {
+                start: left.start,
+                end: right.end,
+                sum: left.sum + right.sum,
+                count: left.count + right.count,
+            });
+        }
+    }
+    for block in blocks {
+        let rank = (block.sum / block.count as f64).clamp(0.0, 1.0);
+        for point in &mut points[block.start..block.end] {
+            point.1 = rank;
+        }
+    }
+}
+
+fn tail_max(errors: &[f64]) -> f64 {
+    errors
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index <= 2 || *index >= errors.len() - 3)
+        .map(|(_, &error)| error)
+        .fold(0.0, f64::max)
+}
+
+struct Truth {
+    sorted: Vec<i64>,
+    probes: Vec<(i64, f64)>,
+}
+
+impl Truth {
+    fn new(data: &[i64]) -> Self {
+        let mut sorted = data.to_vec();
+        sorted.sort_unstable();
+        let mut probes: Vec<_> = (0..=1_000)
+            .map(|index| sorted[index * (sorted.len() - 1) / 1_000])
+            .map(|value| {
+                let rank =
+                    sorted.partition_point(|item| *item <= value) as f64 / sorted.len() as f64;
+                (value, rank)
+            })
+            .collect();
+        probes.dedup_by_key(|point| point.0);
+        Self { sorted, probes }
+    }
+
+    fn quantile_rank_error(&self, q: f64, estimate: i64) -> f64 {
+        let target = (q * self.sorted.len() as f64).ceil().max(1.0) as usize;
+        let lower = self.sorted.partition_point(|item| *item < estimate);
+        let upper = self.sorted.partition_point(|item| *item <= estimate);
+        if target < lower {
+            (lower - target) as f64 / self.sorted.len() as f64
+        } else {
+            target.saturating_sub(upper) as f64 / self.sorted.len() as f64
+        }
+    }
+
+    fn rank_interval_distance(&self, left: i64, right: i64) -> f64 {
+        let left_rank = self.sorted.partition_point(|item| *item <= left);
+        let right_rank = self.sorted.partition_point(|item| *item <= right);
+        left_rank.abs_diff(right_rank) as f64 / self.sorted.len() as f64
+    }
+}
+
+fn percentile(values: &[f64], q: f64) -> f64 {
+    let mut values = values.to_vec();
+    values.sort_unstable_by(f64::total_cmp);
+    values[((q * values.len() as f64).ceil() as usize)
+        .saturating_sub(1)
+        .min(values.len() - 1)]
+}
+
+fn trial_seed(workload: usize, trial: usize) -> u64 {
+    0x2026_0804_u64 ^ ((workload as u64) << 32) ^ trial as u64
+}
+
+#[derive(Clone, Copy)]
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        mix64(self.0)
+    }
+
+    fn unit(&mut self) -> f64 {
+        ((self.next() >> 11) as f64 + 0.5) / (1_u64 << 53) as f64
+    }
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn uniform(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| (rng.next() % 1_000_001) as i64 - 500_000)
+        .collect()
+}
+
+fn exponential(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| (-rng.unit().ln() * 100_000.0).round() as i64)
+        .collect()
+}
+
+fn bimodal(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|index| {
+            let center = if index % 2 == 0 {
+                -1_000_000.0
+            } else {
+                1_000_000.0
+            };
+            let radius = (-2.0 * rng.unit().ln()).sqrt();
+            let angle = std::f64::consts::TAU * rng.unit();
+            (center + 20_000.0 * radius * angle.cos()).round() as i64
+        })
+        .collect()
+}
+
+fn zipf(n: usize, seed: u64) -> Vec<i64> {
+    let domain = 20_000_usize;
+    let mut cdf = Vec::with_capacity(domain);
+    let mut total = 0.0;
+    for rank in 1..=domain {
+        total += 1.0 / (rank as f64).powf(1.1);
+        cdf.push(total);
+    }
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|_| {
+            let target = rng.unit() * total;
+            (cdf.partition_point(|value| *value < target) + 1) as i64
+        })
+        .collect()
+}
+
+fn elephants(n: usize, seed: u64) -> Vec<i64> {
+    let mut rng = Rng(seed);
+    (0..n)
+        .map(|index| match index % 25 {
+            0..=3 => 0,
+            4..=6 => 1_000,
+            7..=8 => 100_000,
+            9 => 1_000_000,
+            _ => 100 + (rng.next() % 999_901) as i64,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn occurrence_sample_is_exact_below_capacity() {
+        let mut sample = OccurrenceBottomK::new(8, 7);
+        for (id, value) in [9, 1, 5, 5].into_iter().enumerate() {
+            sample.update(value, id as u64);
+        }
+        let query = sample.prepare();
+        assert_eq!(query.values, vec![1, 5, 5, 9]);
+        assert_eq!(query.rank_fraction(5), 0.75);
+        assert_eq!(query.quantile(0.5), 5);
+    }
+
+    #[test]
+    fn occurrence_merge_matches_one_pass_exactly() {
+        let data: Vec<_> = (0..10_000).map(|index| (index * 17 % 991) as i64).collect();
+        let config = config(0);
+        let (_, one) = build_occurrence(&data, config, 256, 99, 1);
+        let (_, merged) = build_occurrence(&data, config, 256, 99, 16);
+        assert_eq!(one.count, merged.count);
+        assert_eq!(one.sorted_records(), merged.sorted_records());
+    }
+
+    #[test]
+    fn adaptive_assistance_is_raw_on_a_diffuse_stream() {
+        let data: Vec<_> = (0..10_000).map(i64::from).collect();
+        let (core, sample) = build_occurrence(&data, config(0), 256, 99, 1);
+        let raw = sample.prepare();
+        let assisted = AssistedOccurrenceQuery::new_adaptive(&core, &sample);
+        assert_eq!(assisted.heavy_count, 0);
+        for value in [0, 100, 1_000, 5_000, 9_999] {
+            assert_eq!(assisted.rank_fraction(value), raw.rank_fraction(value));
+        }
+        for q in [0.01, 0.5, 0.99] {
+            assert_eq!(assisted.quantile(q), raw.quantile(q));
+        }
+    }
+
+    #[test]
+    fn adaptive_assistance_uses_core_on_a_concentrated_stream() {
+        let data: Vec<_> = (0..10_000)
+            .map(|index| if index < 5_000 { 0 } else { index as i64 })
+            .collect();
+        let (core, sample) = build_occurrence(&data, config(0), 256, 99, 1);
+        let assisted = AssistedOccurrenceQuery::new_adaptive(&core, &sample);
+        assert!(assisted.heavy_count >= 1);
+        assert_eq!(assisted.quantile(0.25), 0);
+    }
+}

--- a/examples/evaluate_univmon_q_entropy.rs
+++ b/examples/evaluate_univmon_q_entropy.rs
@@ -1,0 +1,431 @@
+//! Stress evaluation for experimental UnivMon-Q entropy estimators.
+//!
+//! Run with:
+//!
+//!   cargo run --release --example evaluate_univmon_q_entropy -- 200000 8 50000
+
+use std::fmt;
+use std::mem::size_of;
+
+use asap_sketchlib::{UnivMonQ, UnivMonQConfig};
+
+const SHARDS: usize = 8;
+
+fn main() {
+    let n = argument(1, 200_000);
+    let trials = argument(2, 8);
+    let domain = argument(3, 50_000);
+    assert!(n > 0 && trials > 0 && domain > 1);
+
+    let workloads = workloads(domain);
+    let profiles = profiles(n);
+    let mut results = vec![vec![Vec::<ResultRow>::new(); workloads.len()]; profiles.len()];
+
+    println!("UnivMon-Q entropy stress evaluation");
+    println!(
+        "n={n}, trials={trials}, max_domain={domain}, workloads={}, shards={SHARDS}",
+        workloads.len()
+    );
+    for profile in &profiles {
+        let empty = UnivMonQ::new(profile.config).unwrap();
+        println!(
+            "profile={}: {:.3} MiB, width={}, halve/{}, candidates={}, samples={}",
+            profile.name,
+            empty.estimated_memory_bytes() as f64 / (1024.0 * 1024.0),
+            profile.config.width,
+            profile.config.width_halving_period,
+            profile.config.candidates,
+            profile.config.ordered_samples,
+        );
+    }
+
+    for (workload_index, workload) in workloads.iter().enumerate() {
+        for trial in 0..trials {
+            let data = workload.generate(n, seed(workload_index, trial));
+            let truth = exact_entropy(&data, workload.domain());
+            for (profile_index, profile) in profiles.iter().enumerate() {
+                let mut shards = build_shards(&data, profile.config, seed(profile_index, trial));
+                let left = merge_left(shards.clone());
+                let merged = merge_tree(&mut shards);
+                let query = merged.prepare_queries();
+                assert_eq!(query.estimate_l1(), n as f64);
+                assert!(query.estimate_entropy().is_finite());
+                assert_eq!(
+                    query.estimate_entropy().to_bits(),
+                    left.prepare_queries().estimate_entropy().to_bits(),
+                    "merge-order entropy mismatch for {} / {}",
+                    profile.name,
+                    workload.name
+                );
+                results[profile_index][workload_index].push(ResultRow::new(
+                    truth,
+                    query.estimate_entropy_universal(),
+                    query.estimate_entropy_occurrence(),
+                    query.estimate_entropy(),
+                ));
+            }
+        }
+        eprintln!("completed {}", workload.name);
+    }
+
+    println!();
+    println!(
+        "{:>14} {:>20} {:>8} {:>9} {:>9} {:>9} {:>9} {:>7}",
+        "profile", "workload", "H", "U p95", "O p95", "A p95", "A abs", "O uses"
+    );
+    for (profile_index, profile) in profiles.iter().enumerate() {
+        for (workload_index, workload) in workloads.iter().enumerate() {
+            let summary = Summary::new(&results[profile_index][workload_index]);
+            println!(
+                "{:>14} {:>20} {:>8.4} {:>8.2}% {:>8.2}% {:>8.2}% {:>9.5} {:>3}/{:<3}",
+                profile.name,
+                workload.name,
+                summary.truth,
+                100.0 * summary.universal_p95,
+                100.0 * summary.occurrence_p95,
+                100.0 * summary.adaptive_p95,
+                summary.adaptive_abs_p95,
+                summary.occurrence_uses,
+                trials,
+            );
+        }
+    }
+
+    println!();
+    println!("worst adaptive cases");
+    for (profile_index, profile) in profiles.iter().enumerate() {
+        let mut worst: Vec<_> = workloads
+            .iter()
+            .enumerate()
+            .map(|(index, workload)| {
+                (
+                    Summary::new(&results[profile_index][index]).adaptive_p95,
+                    &workload.name,
+                )
+            })
+            .collect();
+        worst.sort_unstable_by(|left, right| right.0.total_cmp(&left.0));
+        println!(
+            "  {:>14}: {}",
+            profile.name,
+            worst
+                .iter()
+                .take(3)
+                .map(|(error, name)| format!("{name}={:.2}%", 100.0 * error))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+}
+
+fn argument(index: usize, default: usize) -> usize {
+    std::env::args()
+        .nth(index)
+        .map(|value| value.parse().expect("arguments must be positive integers"))
+        .unwrap_or(default)
+}
+
+#[derive(Clone)]
+struct Profile {
+    name: &'static str,
+    config: UnivMonQConfig,
+}
+
+fn profiles(n: usize) -> Vec<Profile> {
+    let compact = UnivMonQConfig {
+        levels: 12,
+        width: 4_096,
+        width_halving_period: 3,
+        depth: 5,
+        counter_bits: 32,
+        candidates: 256,
+        ordered_samples: 4_096,
+        hash_seed: 5,
+    }
+    .with_window_bound(n as u64, 1e-9)
+    .unwrap();
+    let mut small_sample = compact;
+    small_sample.ordered_samples = 512;
+    let mut large_sample = compact;
+    large_sample.ordered_samples = 16_384;
+    let mut equal_memory = compact;
+    equal_memory.width_halving_period = 0;
+    let target = compact.levels * compact.depth * compact.width * size_of::<i64>();
+    equal_memory.candidates = largest_candidate_budget(equal_memory, target);
+    vec![
+        Profile {
+            name: "compact-k512",
+            config: small_sample,
+        },
+        Profile {
+            name: "compact-k4096",
+            config: compact,
+        },
+        Profile {
+            name: "compact-k16k",
+            config: large_sample,
+        },
+        Profile {
+            name: "equal-memory",
+            config: equal_memory,
+        },
+    ]
+}
+
+fn largest_candidate_budget(config: UnivMonQConfig, target: usize) -> usize {
+    let memory = |candidates| {
+        let mut candidate = config;
+        candidate.candidates = candidates;
+        UnivMonQ::new(candidate).unwrap().estimated_memory_bytes()
+    };
+    let mut low = config.candidates;
+    let mut high = low * 2;
+    assert!(memory(low) <= target);
+    while memory(high) <= target {
+        low = high;
+        high *= 2;
+    }
+    while low + 1 < high {
+        let middle = low + (high - low) / 2;
+        if memory(middle) <= target {
+            low = middle;
+        } else {
+            high = middle;
+        }
+    }
+    low
+}
+
+#[derive(Clone)]
+struct Workload {
+    name: String,
+    kind: WorkloadKind,
+}
+
+#[derive(Clone)]
+enum WorkloadKind {
+    Uniform(usize),
+    Zipf(Vec<f64>),
+    HeadTail { head_mass: f64, domain: usize },
+}
+
+impl Workload {
+    fn domain(&self) -> usize {
+        match &self.kind {
+            WorkloadKind::Uniform(domain) | WorkloadKind::HeadTail { domain, .. } => *domain,
+            WorkloadKind::Zipf(cdf) => cdf.len(),
+        }
+    }
+
+    fn generate(&self, n: usize, seed: u64) -> Vec<usize> {
+        let mut rng = SplitMix64(seed);
+        match &self.kind {
+            WorkloadKind::Uniform(domain) => (0..n).map(|_| rng.next() as usize % domain).collect(),
+            WorkloadKind::Zipf(cdf) => (0..n)
+                .map(|_| {
+                    let draw = rng.unit();
+                    cdf.partition_point(|probability| *probability < draw)
+                        .min(cdf.len() - 1)
+                })
+                .collect(),
+            WorkloadKind::HeadTail { head_mass, domain } => (0..n)
+                .map(|_| {
+                    if rng.unit() < *head_mass {
+                        0
+                    } else {
+                        1 + rng.next() as usize % (domain - 1)
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+impl fmt::Display for Workload {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.name)
+    }
+}
+
+fn workloads(domain: usize) -> Vec<Workload> {
+    let mut result = Vec::new();
+    for support in [100, 1_000, 10_000, domain] {
+        let support = support.min(domain);
+        result.push(Workload {
+            name: format!("uniform-{support}"),
+            kind: WorkloadKind::Uniform(support),
+        });
+    }
+    for alpha in [0.5, 0.75, 0.9, 1.0, 1.1, 1.3, 1.6, 2.0, 2.5] {
+        result.push(Workload {
+            name: format!("zipf-{alpha:.2}"),
+            kind: WorkloadKind::Zipf(zipf_cdf(domain, alpha)),
+        });
+    }
+    for head_mass in [0.5, 0.9, 0.99, 0.999, 0.9999] {
+        result.push(Workload {
+            name: format!("head-{head_mass:.4}"),
+            kind: WorkloadKind::HeadTail { head_mass, domain },
+        });
+    }
+    result
+}
+
+fn zipf_cdf(domain: usize, alpha: f64) -> Vec<f64> {
+    let normalization: f64 = (1..=domain).map(|rank| (rank as f64).powf(-alpha)).sum();
+    let mut running = 0.0;
+    let mut cdf: Vec<f64> = (1..=domain)
+        .map(|rank| {
+            running += (rank as f64).powf(-alpha) / normalization;
+            running
+        })
+        .collect();
+    *cdf.last_mut().unwrap() = 1.0;
+    cdf
+}
+
+fn exact_entropy(data: &[usize], domain: usize) -> f64 {
+    let mut counts = vec![0_u64; domain];
+    for &value in data {
+        counts[value] += 1;
+    }
+    let total = data.len() as f64;
+    counts
+        .into_iter()
+        .filter(|count| *count > 0)
+        .map(|count| {
+            let probability = count as f64 / total;
+            -probability * probability.ln()
+        })
+        .sum()
+}
+
+fn build_shards(data: &[usize], config: UnivMonQConfig, seed: u64) -> Vec<UnivMonQ> {
+    (0..SHARDS)
+        .map(|shard| {
+            let start = shard * data.len() / SHARDS;
+            let end = (shard + 1) * data.len() / SHARDS;
+            let mut sketch =
+                UnivMonQ::new_with_source_id(config, seed ^ (shard as u64 + 1)).unwrap();
+            for &value in &data[start..end] {
+                sketch.add(&value);
+            }
+            sketch
+        })
+        .collect()
+}
+
+fn merge_left(mut sketches: Vec<UnivMonQ>) -> UnivMonQ {
+    let mut result = sketches.remove(0);
+    for sketch in sketches {
+        result.merge(&sketch).unwrap();
+    }
+    result
+}
+
+fn merge_tree(sketches: &mut Vec<UnivMonQ>) -> UnivMonQ {
+    while sketches.len() > 1 {
+        let mut merged = Vec::with_capacity(sketches.len().div_ceil(2));
+        let mut iter = std::mem::take(sketches).into_iter();
+        while let Some(mut left) = iter.next() {
+            if let Some(right) = iter.next() {
+                left.merge(&right).unwrap();
+            }
+            merged.push(left);
+        }
+        *sketches = merged;
+    }
+    sketches.pop().unwrap()
+}
+
+#[derive(Clone, Copy)]
+struct ResultRow {
+    truth: f64,
+    universal_rel: f64,
+    occurrence_rel: f64,
+    adaptive_rel: f64,
+    adaptive_abs: f64,
+    used_occurrence: bool,
+}
+
+impl ResultRow {
+    fn new(truth: f64, universal: f64, occurrence: Option<f64>, adaptive: f64) -> Self {
+        let occurrence = occurrence.unwrap_or(universal);
+        Self {
+            truth,
+            universal_rel: relative_error(universal, truth),
+            occurrence_rel: relative_error(occurrence, truth),
+            adaptive_rel: relative_error(adaptive, truth),
+            adaptive_abs: (adaptive - truth).abs(),
+            used_occurrence: adaptive.to_bits() == occurrence.to_bits()
+                && adaptive.to_bits() != universal.to_bits(),
+        }
+    }
+}
+
+struct Summary {
+    truth: f64,
+    universal_p95: f64,
+    occurrence_p95: f64,
+    adaptive_p95: f64,
+    adaptive_abs_p95: f64,
+    occurrence_uses: usize,
+}
+
+impl Summary {
+    fn new(rows: &[ResultRow]) -> Self {
+        Self {
+            truth: percentile(&rows.iter().map(|row| row.truth).collect::<Vec<_>>(), 0.5),
+            universal_p95: percentile(
+                &rows.iter().map(|row| row.universal_rel).collect::<Vec<_>>(),
+                0.95,
+            ),
+            occurrence_p95: percentile(
+                &rows
+                    .iter()
+                    .map(|row| row.occurrence_rel)
+                    .collect::<Vec<_>>(),
+                0.95,
+            ),
+            adaptive_p95: percentile(
+                &rows.iter().map(|row| row.adaptive_rel).collect::<Vec<_>>(),
+                0.95,
+            ),
+            adaptive_abs_p95: percentile(
+                &rows.iter().map(|row| row.adaptive_abs).collect::<Vec<_>>(),
+                0.95,
+            ),
+            occurrence_uses: rows.iter().filter(|row| row.used_occurrence).count(),
+        }
+    }
+}
+
+fn relative_error(estimate: f64, truth: f64) -> f64 {
+    (estimate - truth).abs() / truth.max(1e-12)
+}
+
+fn percentile(values: &[f64], quantile: f64) -> f64 {
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable_by(f64::total_cmp);
+    sorted[((sorted.len() - 1) as f64 * quantile).ceil() as usize]
+}
+
+fn seed(workload: usize, trial: usize) -> u64 {
+    0x2026_0809_5eed_0000 ^ (workload as u64) << 16 ^ trial as u64
+}
+
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+
+    fn unit(&mut self) -> f64 {
+        (self.next() >> 11) as f64 * (1.0 / (1_u64 << 53) as f64)
+    }
+}

--- a/examples/evaluate_univmon_q_skew.rs
+++ b/examples/evaluate_univmon_q_skew.rs
@@ -7,6 +7,7 @@
 //! Run with:
 //!
 //!   cargo run --release --example evaluate_univmon_q_skew -- 1000000 5 100000 256
+//!   cargo run --release --example evaluate_univmon_q_skew -- 1000000 5 100000 256 all equal-memory
 
 use std::collections::HashSet;
 use std::hint::black_box;
@@ -32,13 +33,24 @@ fn main() {
     let trials: usize = argument(2, 5, "trials");
     let domain: usize = argument(3, 100_000, "domain");
     let candidates: usize = argument(4, 256, "candidates");
-    let skew_filter = std::env::args()
-        .nth(5)
-        .map(|value| value.parse::<usize>().expect("skew index must be 0..6"));
+    let skew_filter = std::env::args().nth(5).and_then(|value| {
+        (value != "all").then(|| {
+            value
+                .parse::<usize>()
+                .expect("skew index must be 0..6 or `all`")
+        })
+    });
+    let profile = std::env::args()
+        .nth(6)
+        .unwrap_or_else(|| "compact".to_string());
     assert!(n > 0 && trials > 0 && domain > 1 && candidates > 0);
     assert!(skew_filter.is_none_or(|index| index < SKEWS.len()));
+    assert!(
+        matches!(profile.as_str(), "compact" | "equal-memory"),
+        "profile must be `compact` or `equal-memory`"
+    );
 
-    let base_config = UnivMonQConfig {
+    let mut base_config = UnivMonQConfig {
         levels: 12,
         width: 4_096,
         width_halving_period: 3,
@@ -50,9 +62,20 @@ fn main() {
     }
     .with_window_bound(n as u64, 1e-9)
     .expect("the evaluation window must fit within 63 levels");
+    let um_candidates = candidates;
+    let um_counter_bytes =
+        base_config.levels * base_config.depth * base_config.width * size_of::<i64>();
+    if profile == "equal-memory" {
+        base_config.width_halving_period = 0;
+        base_config.candidates = largest_candidate_budget(base_config, um_counter_bytes);
+    }
+    let q_reserved_bytes = UnivMonQ::new(base_config)
+        .expect("evaluation config must be valid")
+        .estimated_memory_bytes();
 
     println!("UnivMon versus UnivMon-Q large synthetic skew evaluation");
     println!("n={n}, trials={trials}, domain={domain}, shards={SHARDS}");
+    println!("profile={profile}");
     println!(
         "config: levels={}, width={}, halve/{} levels, depth={}, candidates={}, ordered_samples={}",
         base_config.levels,
@@ -61,6 +84,11 @@ fn main() {
         base_config.depth,
         base_config.candidates,
         base_config.ordered_samples,
+    );
+    println!(
+        "memory budget: Q reserved={:.3} MiB; UM counters={:.3} MiB before heap metadata (UM candidates={um_candidates})",
+        q_reserved_bytes as f64 / (1024.0 * 1024.0),
+        um_counter_bytes as f64 / (1024.0 * 1024.0),
     );
     println!("errors are relative except point nRMSE and normalized rank errors");
 
@@ -76,7 +104,7 @@ fn main() {
             let seed = trial_seed(skew_index, trial);
             let data = sampler.generate(n, seed);
             let truth = Truth::new(&data, domain);
-            let result = evaluate_trial(&data, &truth, base_config, seed);
+            let result = evaluate_trial(&data, &truth, base_config, um_candidates, seed);
             eprintln!(
                 "completed alpha={skew:.1} trial={}/{}: UM/Q {:.1}/{:.1} ns/update, Q CDF max={:.5}",
                 trial + 1,
@@ -224,13 +252,48 @@ fn argument(index: usize, default: usize, name: &str) -> usize {
         .unwrap_or(default)
 }
 
-fn evaluate_trial(data: &[i64], truth: &Truth, config: UnivMonQConfig, seed: u64) -> TrialResult {
+fn largest_candidate_budget(config: UnivMonQConfig, target_bytes: usize) -> usize {
+    let mut low = config.candidates;
+    let mut high = config.candidates;
+    assert!(
+        estimated_q_memory(config, low) <= target_bytes,
+        "initial UnivMon-Q configuration exceeds the equal-memory target"
+    );
+    while estimated_q_memory(config, high) <= target_bytes {
+        low = high;
+        high = high.checked_mul(2).expect("candidate search overflowed");
+    }
+    while low + 1 < high {
+        let middle = low + (high - low) / 2;
+        if estimated_q_memory(config, middle) <= target_bytes {
+            low = middle;
+        } else {
+            high = middle;
+        }
+    }
+    low
+}
+
+fn estimated_q_memory(mut config: UnivMonQConfig, candidates: usize) -> usize {
+    config.candidates = candidates;
+    UnivMonQ::new(config)
+        .expect("candidate search must preserve a valid config")
+        .estimated_memory_bytes()
+}
+
+fn evaluate_trial(
+    data: &[i64],
+    truth: &Truth,
+    config: UnivMonQConfig,
+    um_candidates: usize,
+    seed: u64,
+) -> TrialResult {
     let update_start = Instant::now();
     let q_shards = build_shards(data, config, seed);
     let q_update_time = update_start.elapsed();
 
     let update_start = Instant::now();
-    let um_shards = build_um_shards(data, config);
+    let um_shards = build_um_shards(data, config, um_candidates);
     let um_update_time = update_start.elapsed();
 
     let mut q_tree_input = q_shards.clone();
@@ -303,8 +366,8 @@ fn evaluate_trial(data: &[i64], truth: &Truth, config: UnivMonQConfig, seed: u64
     }
 }
 
-fn new_univmon(config: UnivMonQConfig) -> UnivMon {
-    UnivMon::init_univmon(config.candidates, config.depth, config.width, config.levels)
+fn new_univmon(config: UnivMonQConfig, candidates: usize) -> UnivMon {
+    UnivMon::init_univmon(candidates, config.depth, config.width, config.levels)
 }
 
 fn build_shards(data: &[i64], config: UnivMonQConfig, seed: u64) -> Vec<UnivMonQ> {
@@ -345,12 +408,12 @@ fn merge_left(mut sketches: Vec<UnivMonQ>) -> UnivMonQ {
     result
 }
 
-fn build_um_shards(data: &[i64], config: UnivMonQConfig) -> Vec<UnivMon> {
+fn build_um_shards(data: &[i64], config: UnivMonQConfig, candidates: usize) -> Vec<UnivMon> {
     (0..SHARDS)
         .map(|shard| {
             let start = shard * data.len() / SHARDS;
             let end = (shard + 1) * data.len() / SHARDS;
-            let mut sketch = new_univmon(config);
+            let mut sketch = new_univmon(config, candidates);
             for &value in &data[start..end] {
                 sketch.fast_insert(&DataInput::U64(value as u64), 1);
             }
@@ -476,7 +539,7 @@ fn score(sketch: &UnivMonQ, truth: &Truth) -> Accuracy {
         .iter()
         .filter_map(|key| truth.counts.get(*key))
         .sum();
-    let l1 = query.estimate_g_sum(|frequency| frequency);
+    let l1 = query.estimate_l1();
 
     let estimated_entropy = query.estimate_entropy();
     Accuracy {

--- a/examples/evaluate_univmon_q_skew.rs
+++ b/examples/evaluate_univmon_q_skew.rs
@@ -1,0 +1,946 @@
+//! Large synthetic skew sweep for the experimental UnivMon-Q sketch.
+//!
+//! The evaluator checks all advertised query families against exact answers,
+//! verifies merge-order and native-wire behavior, and measures update, merge,
+//! prepared-query construction, and warm batch-query latency.
+//!
+//! Run with:
+//!
+//!   cargo run --release --example evaluate_univmon_q_skew -- 1000000 5 100000 256
+
+use std::collections::HashSet;
+use std::hint::black_box;
+use std::mem::size_of;
+use std::time::{Duration, Instant};
+
+use asap_sketchlib::{
+    BOTTOM_LAYER_FINDER, DataInput, HeapItem, UnivMon, UnivMonQ, UnivMonQConfig, hash64_seeded,
+};
+
+const SKEWS: [f64; 7] = [0.0, 0.5, 0.9, 1.1, 1.3, 1.6, 2.0];
+const QUANTILES: [f64; 13] = [
+    0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.995, 0.999,
+];
+const SHARDS: usize = 8;
+const TOP_K: usize = 20;
+const PREPARE_REPEATS: usize = 9;
+const WARM_QUERY_REPEATS: usize = 200;
+const UM_QUERY_REPEATS: usize = 9;
+
+fn main() {
+    let n: usize = argument(1, 1_000_000, "n");
+    let trials: usize = argument(2, 5, "trials");
+    let domain: usize = argument(3, 100_000, "domain");
+    let candidates: usize = argument(4, 256, "candidates");
+    let skew_filter = std::env::args()
+        .nth(5)
+        .map(|value| value.parse::<usize>().expect("skew index must be 0..6"));
+    assert!(n > 0 && trials > 0 && domain > 1 && candidates > 0);
+    assert!(skew_filter.is_none_or(|index| index < SKEWS.len()));
+
+    let base_config = UnivMonQConfig {
+        levels: 12,
+        width: 4_096,
+        width_halving_period: 3,
+        depth: 5,
+        counter_bits: 32,
+        candidates,
+        ordered_samples: 4_096,
+        hash_seed: 5,
+    }
+    .with_window_bound(n as u64, 1e-9)
+    .expect("the evaluation window must fit within 63 levels");
+
+    println!("UnivMon versus UnivMon-Q large synthetic skew evaluation");
+    println!("n={n}, trials={trials}, domain={domain}, shards={SHARDS}");
+    println!(
+        "config: levels={}, width={}, halve/{} levels, depth={}, candidates={}, ordered_samples={}",
+        base_config.levels,
+        base_config.width,
+        base_config.width_halving_period,
+        base_config.depth,
+        base_config.candidates,
+        base_config.ordered_samples,
+    );
+    println!("errors are relative except point nRMSE and normalized rank errors");
+
+    let mut summaries = Vec::with_capacity(SKEWS.len());
+    for (skew_index, skew) in SKEWS
+        .into_iter()
+        .enumerate()
+        .filter(|(index, _)| skew_filter.is_none_or(|filter| *index == filter))
+    {
+        let sampler = ZipfSampler::new(domain, skew);
+        let mut results = Vec::with_capacity(trials);
+        for trial in 0..trials {
+            let seed = trial_seed(skew_index, trial);
+            let data = sampler.generate(n, seed);
+            let truth = Truth::new(&data, domain);
+            let result = evaluate_trial(&data, &truth, base_config, seed);
+            eprintln!(
+                "completed alpha={skew:.1} trial={}/{}: UM/Q {:.1}/{:.1} ns/update, Q CDF max={:.5}",
+                trial + 1,
+                trials,
+                result.um_update_ns,
+                result.q_update_ns,
+                result.q_accuracy.cdf_max,
+            );
+            results.push(result);
+        }
+        summaries.push(Summary::new(skew, &results));
+    }
+
+    println!();
+    println!("shared-metric correctness after an 8-way merge (p95 across trials; UM/Q)");
+    println!(
+        "  {:>5} {:>9} {:>17} {:>17} {:>17} {:>17} {:>17}",
+        "alpha", "distinct", "point nRMSE", "F0 rel", "F2 rel", "H rel", "L1 rel"
+    );
+    for summary in &summaries {
+        println!(
+            "  {:>5.1} {:>9.0} {:>8.5}/{:<8.5} {:>8.5}/{:<8.5} {:>8.5}/{:<8.5} {:>8.5}/{:<8.5} {:>8.5}/{:<8.5}",
+            summary.skew,
+            summary.distinct_p50,
+            summary.um_point_p95,
+            summary.point_p95,
+            summary.um_f0_p95,
+            summary.f0_p95,
+            summary.um_f2_p95,
+            summary.f2_p95,
+            summary.um_entropy_p95,
+            summary.entropy_p95,
+            summary.um_l1_p95,
+            summary.l1_p95,
+        );
+    }
+
+    println!();
+    println!("ordered and heavy-hitter correctness after an 8-way merge");
+    println!(
+        "  {:>5} {:>17} {:>15} {:>15} {:>13} {:>15}",
+        "alpha", "HH mass UM/Q", "Q rank mean", "Q tail max", "CDF max", "violations UM/Q"
+    );
+    for summary in &summaries {
+        println!(
+            "  {:>5.1} {:>8.5}/{:<8.5} {:>7.5}/{:<7.5} {:>7.5}/{:<7.5} {:>6.5}/{:<6.5} {:>7}/{:<7}",
+            summary.skew,
+            summary.um_hh_mass_p05,
+            summary.hh_mass_p05,
+            summary.quantile_p50,
+            summary.quantile_p95,
+            summary.tail_p50,
+            summary.tail_p95,
+            summary.cdf_p50,
+            summary.cdf_p95,
+            summary.um_violations,
+            summary.q_violations,
+        );
+    }
+
+    println!();
+    println!("entropy-error context (entropy is measured in nats)");
+    println!(
+        "  {:>5} {:>17} {:>19} {:>19}",
+        "alpha", "exact H p50", "absolute UM/Q", "relative UM/Q"
+    );
+    for summary in &summaries {
+        println!(
+            "  {:>5.1} {:>17.5} {:>9.5}/{:<9.5} {:>9.5}/{:<9.5}",
+            summary.skew,
+            summary.entropy_exact_p50,
+            summary.um_entropy_abs_p95,
+            summary.entropy_abs_p95,
+            summary.um_entropy_p95,
+            summary.entropy_p95,
+        );
+    }
+
+    println!();
+    println!("performance (median / p95 across trials; UM-terminal/Q)");
+    println!(
+        "  {:>5} {:>19} {:>19} {:>19} {:>19} {:>19}",
+        "alpha", "UM update m/p95", "Q update m/p95", "merge UM/Q", "query UM/Q", "wire KiB UM/Q"
+    );
+    for summary in &summaries {
+        println!(
+            "  {:>5.1} {:>8.1}/{:<8.1} {:>8.1}/{:<8.1} {:>8.1}/{:<8.1} {:>8.1}/{:<8.1} {:>8.1}/{:<8.1}",
+            summary.skew,
+            summary.um_update_p50,
+            summary.um_update_p95,
+            summary.update_p50,
+            summary.update_p95,
+            summary.um_merge_p50_us,
+            summary.merge_p50_us,
+            summary.um_query_p50_us,
+            summary.prepare_p50_us + summary.warm_p50_ns / 1_000.0,
+            summary.um_wire_kib,
+            summary.q_wire_kib,
+        );
+    }
+
+    println!();
+    println!("additional performance context");
+    println!(
+        "  Q reserved memory={:.3} MiB; UnivMon counters alone={:.3} MiB before heap metadata.",
+        summaries[0].memory_mib,
+        (base_config.levels * base_config.depth * base_config.width * size_of::<i64>()) as f64
+            / (1024.0 * 1024.0),
+    );
+    println!(
+        "  Q prepared warm all-task batch={:.2}–{:.2} us median.",
+        summaries
+            .iter()
+            .map(|summary| summary.warm_p50_ns / 1_000.0)
+            .fold(f64::INFINITY, f64::min),
+        summaries
+            .iter()
+            .map(|summary| summary.warm_p50_ns / 1_000.0)
+            .fold(0.0, f64::max),
+    );
+    println!("  UnivMon uses terminal-only `fast_insert`; cumulative-layer `insert` is excluded.");
+
+    let q_violations: usize = summaries.iter().map(|summary| summary.q_violations).sum();
+    let um_violations: usize = summaries.iter().map(|summary| summary.um_violations).sum();
+    let um_warnings: usize = summaries.iter().map(|summary| summary.um_warnings).sum();
+    println!();
+    println!("verification checks: UnivMon={um_violations}, UnivMon-Q={q_violations} violation(s)");
+    println!("  UnivMon merge-order heavy-hitter tie warnings: {um_warnings}.");
+    println!(
+        "  Checks cover exact counts, finite estimates, Q extrema and monotone ordered queries,"
+    );
+    println!("  merge-order query equivalence, and native MessagePack round-trip equivalence.");
+    println!("  HH mass is true mass covered by returned keys / exact top-{TOP_K} mass.");
+    println!("  Q tail max covers p0.1/p0.5/p1/p99/p99.5/p99.9 rank error.");
+}
+
+fn argument(index: usize, default: usize, name: &str) -> usize {
+    std::env::args()
+        .nth(index)
+        .map(|value| {
+            value
+                .parse()
+                .unwrap_or_else(|_| panic!("{name} must be positive"))
+        })
+        .unwrap_or(default)
+}
+
+fn evaluate_trial(data: &[i64], truth: &Truth, config: UnivMonQConfig, seed: u64) -> TrialResult {
+    let update_start = Instant::now();
+    let q_shards = build_shards(data, config, seed);
+    let q_update_time = update_start.elapsed();
+
+    let update_start = Instant::now();
+    let um_shards = build_um_shards(data, config);
+    let um_update_time = update_start.elapsed();
+
+    let mut q_tree_input = q_shards.clone();
+    let merge_start = Instant::now();
+    let q_merged_tree = merge_tree(&mut q_tree_input);
+    let q_merge_time = merge_start.elapsed();
+    let q_merged_left = merge_left(q_shards);
+
+    let mut um_tree_input = um_shards.clone();
+    let merge_start = Instant::now();
+    let um_merged_tree = merge_um_tree(&mut um_tree_input);
+    let um_merge_time = merge_start.elapsed();
+    let um_merged_left = merge_um_left(um_shards);
+
+    let q_accuracy = score(&q_merged_tree, truth);
+    let um_accuracy = score_um(&um_merged_tree, truth);
+    let mut q_violations = validate(&q_merged_tree, truth);
+    let mut um_violations = validate_um(&um_merged_tree, truth);
+    let mut um_warnings = 0;
+    if !equivalent_queries(&q_merged_tree, &q_merged_left, truth) {
+        q_violations += 1;
+    }
+    let um_merge_mismatches = um_query_mismatches(&um_merged_tree, &um_merged_left, truth);
+    if !um_merge_mismatches.is_empty() {
+        if um_merge_mismatches == ["heavy hitters"] {
+            eprintln!(
+                "UM merge-order heavy-hitter tie warning seed={seed:#x}: identity set differs"
+            );
+            um_warnings += 1;
+        } else {
+            eprintln!("UM merge-order mismatch seed={seed:#x}: {um_merge_mismatches:?}");
+            um_violations += 1;
+        }
+    }
+
+    let q_wire = q_merged_tree.serialize_to_bytes().unwrap();
+    let q_decoded = UnivMonQ::deserialize_from_bytes(&q_wire).unwrap();
+    if !equivalent_queries(&q_merged_tree, &q_decoded, truth) {
+        q_violations += 1;
+    }
+    let um_wire = um_merged_tree.serialize_to_bytes().unwrap();
+    let um_decoded = UnivMon::deserialize_from_bytes(&um_wire).unwrap();
+    let um_wire_mismatches = um_query_mismatches(&um_merged_tree, &um_decoded, truth);
+    if !um_wire_mismatches.is_empty() {
+        eprintln!("UM wire mismatch seed={seed:#x}: {um_wire_mismatches:?}");
+        um_violations += 1;
+    }
+
+    let prepare_ns = benchmark_prepare(&q_merged_tree);
+    let warm_ns = benchmark_warm_queries(&q_merged_tree, truth);
+    let um_query_us = benchmark_um_queries(&um_merged_tree, truth) / 1_000.0;
+    TrialResult {
+        q_accuracy,
+        um_accuracy,
+        distinct: truth.distinct as f64,
+        entropy_exact: truth.entropy,
+        q_update_ns: q_update_time.as_secs_f64() * 1e9 / data.len() as f64,
+        um_update_ns: um_update_time.as_secs_f64() * 1e9 / data.len() as f64,
+        q_merge_us: q_merge_time.as_secs_f64() * 1e6,
+        um_merge_us: um_merge_time.as_secs_f64() * 1e6,
+        q_prepare_us: prepare_ns / 1_000.0,
+        q_warm_ns: warm_ns,
+        um_query_us,
+        q_memory_mib: q_merged_tree.estimated_memory_bytes() as f64 / (1024.0 * 1024.0),
+        q_wire_kib: q_wire.len() as f64 / 1024.0,
+        um_wire_kib: um_wire.len() as f64 / 1024.0,
+        q_violations,
+        um_violations,
+        um_warnings,
+    }
+}
+
+fn new_univmon(config: UnivMonQConfig) -> UnivMon {
+    UnivMon::init_univmon(config.candidates, config.depth, config.width, config.levels)
+}
+
+fn build_shards(data: &[i64], config: UnivMonQConfig, seed: u64) -> Vec<UnivMonQ> {
+    (0..SHARDS)
+        .map(|shard| {
+            let start = shard * data.len() / SHARDS;
+            let end = (shard + 1) * data.len() / SHARDS;
+            let mut sketch =
+                UnivMonQ::new_with_source_id(config, source_id(seed, shard + 1)).unwrap();
+            for value in &data[start..end] {
+                sketch.add(value);
+            }
+            sketch
+        })
+        .collect()
+}
+
+fn merge_tree(sketches: &mut Vec<UnivMonQ>) -> UnivMonQ {
+    while sketches.len() > 1 {
+        let mut merged = Vec::with_capacity(sketches.len().div_ceil(2));
+        let mut iter = std::mem::take(sketches).into_iter();
+        while let Some(mut left) = iter.next() {
+            if let Some(right) = iter.next() {
+                left.merge(&right).unwrap();
+            }
+            merged.push(left);
+        }
+        *sketches = merged;
+    }
+    sketches.pop().unwrap()
+}
+
+fn merge_left(mut sketches: Vec<UnivMonQ>) -> UnivMonQ {
+    let mut result = sketches.remove(0);
+    for sketch in sketches {
+        result.merge(&sketch).unwrap();
+    }
+    result
+}
+
+fn build_um_shards(data: &[i64], config: UnivMonQConfig) -> Vec<UnivMon> {
+    (0..SHARDS)
+        .map(|shard| {
+            let start = shard * data.len() / SHARDS;
+            let end = (shard + 1) * data.len() / SHARDS;
+            let mut sketch = new_univmon(config);
+            for &value in &data[start..end] {
+                sketch.fast_insert(&DataInput::U64(value as u64), 1);
+            }
+            sketch
+        })
+        .collect()
+}
+
+fn merge_um_tree(sketches: &mut Vec<UnivMon>) -> UnivMon {
+    while sketches.len() > 1 {
+        let mut merged = Vec::with_capacity(sketches.len().div_ceil(2));
+        let mut iter = std::mem::take(sketches).into_iter();
+        while let Some(mut left) = iter.next() {
+            if let Some(right) = iter.next() {
+                left.merge(&right);
+            }
+            merged.push(left);
+        }
+        *sketches = merged;
+    }
+    sketches.pop().unwrap()
+}
+
+fn merge_um_left(mut sketches: Vec<UnivMon>) -> UnivMon {
+    let mut result = sketches.remove(0);
+    for sketch in sketches {
+        result.merge(&sketch);
+    }
+    result
+}
+
+fn benchmark_prepare(sketch: &UnivMonQ) -> f64 {
+    let mut durations = Vec::with_capacity(PREPARE_REPEATS);
+    for _ in 0..PREPARE_REPEATS {
+        let start = Instant::now();
+        black_box(sketch.prepare_queries());
+        durations.push(start.elapsed());
+    }
+    duration_percentile(&durations, 0.5).as_secs_f64() * 1e9
+}
+
+fn benchmark_warm_queries(sketch: &UnivMonQ, truth: &Truth) -> f64 {
+    let query = sketch.prepare_queries();
+    let probe = truth.domain / 2;
+    let start = Instant::now();
+    for _ in 0..WARM_QUERY_REPEATS {
+        black_box(query.count());
+        black_box((query.min(), query.max()));
+        black_box(query.estimate_frequency(black_box(probe as f64)));
+        black_box(query.estimate_distinct());
+        black_box(query.estimate_f2());
+        black_box(query.estimate_entropy());
+        black_box(query.estimate_g_sum(|frequency| frequency));
+        black_box(query.heavy_hitters(TOP_K));
+        black_box(query.rank(black_box(probe as f64)));
+        black_box(query.quantiles(&QUANTILES));
+        black_box(query.cdf());
+    }
+    start.elapsed().as_secs_f64() * 1e9 / WARM_QUERY_REPEATS as f64
+}
+
+fn benchmark_um_queries(sketch: &UnivMon, truth: &Truth) -> f64 {
+    let mut durations = Vec::with_capacity(UM_QUERY_REPEATS);
+    for _ in 0..UM_QUERY_REPEATS {
+        let start = Instant::now();
+        black_box(sketch.bucket_size);
+        black_box(univmon_frequency(sketch, truth.domain / 2));
+        black_box(sketch.calc_card());
+        black_box(sketch.calc_l2());
+        black_box(sketch.calc_entropy());
+        black_box(sketch.calc_l1());
+        black_box(univmon_heavy_hitters(sketch, TOP_K));
+        durations.push(start.elapsed());
+    }
+    duration_percentile(&durations, 0.5).as_secs_f64() * 1e9
+}
+
+#[derive(Clone, Copy)]
+struct Accuracy {
+    point_nrmse: f64,
+    f0_rel: f64,
+    f2_rel: f64,
+    entropy_rel: f64,
+    entropy_abs: f64,
+    l1_rel: f64,
+    hh_mass: f64,
+    quantile_mean: f64,
+    tail_max: f64,
+    cdf_max: f64,
+}
+
+fn score(sketch: &UnivMonQ, truth: &Truth) -> Accuracy {
+    let query = sketch.prepare_queries();
+    let mut squared_error = 0.0;
+    let mut point_count = 0;
+    for key in 1..=truth.domain {
+        let estimate = query.estimate_frequency(key as f64) as f64;
+        squared_error += (estimate - truth.counts[key] as f64).powi(2);
+        point_count += 1;
+    }
+    for key in truth.domain + 1..=truth.domain + 256 {
+        squared_error += (query.estimate_frequency(key as f64) as f64).powi(2);
+        point_count += 1;
+    }
+
+    let quantile_errors: Vec<f64> = QUANTILES
+        .iter()
+        .zip(query.quantiles(&QUANTILES))
+        .map(|(&q, estimate)| truth.quantile_rank_error(q, estimate.unwrap().round() as usize))
+        .collect();
+    let cdf_max = (1..=truth.domain)
+        .map(|value| {
+            let estimate = query.rank(value as f64).unwrap() as f64 / truth.n as f64;
+            (estimate - truth.cdf(value)).abs()
+        })
+        .fold(0.0, f64::max);
+    let heavy_keys: HashSet<usize> = query
+        .heavy_hitters(TOP_K)
+        .into_iter()
+        .map(|(value, _)| value.round() as usize)
+        .collect();
+    let captured_mass: u64 = heavy_keys
+        .iter()
+        .filter_map(|key| truth.counts.get(*key))
+        .sum();
+    let l1 = query.estimate_g_sum(|frequency| frequency);
+
+    let estimated_entropy = query.estimate_entropy();
+    Accuracy {
+        point_nrmse: (squared_error / point_count as f64).sqrt() / truth.f2.sqrt().max(1.0),
+        f0_rel: relative_error(query.estimate_distinct(), truth.distinct as f64),
+        f2_rel: relative_error(query.estimate_f2(), truth.f2),
+        entropy_rel: relative_error(estimated_entropy, truth.entropy),
+        entropy_abs: (estimated_entropy - truth.entropy).abs(),
+        l1_rel: relative_error(l1, truth.n as f64),
+        hh_mass: (captured_mass as f64 / truth.top_mass.max(1) as f64).min(1.0),
+        quantile_mean: quantile_errors.iter().sum::<f64>() / quantile_errors.len() as f64,
+        tail_max: quantile_errors
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| matches!(index, 0 | 1 | 2 | 10 | 11 | 12))
+            .map(|(_, error)| *error)
+            .fold(0.0, f64::max),
+        cdf_max,
+    }
+}
+
+fn score_um(sketch: &UnivMon, truth: &Truth) -> Accuracy {
+    let mut squared_error = 0.0;
+    let mut point_count = 0;
+    for key in 1..=truth.domain {
+        let estimate = univmon_frequency(sketch, key);
+        squared_error += (estimate - truth.counts[key] as f64).powi(2);
+        point_count += 1;
+    }
+    for key in truth.domain + 1..=truth.domain + 256 {
+        squared_error += univmon_frequency(sketch, key).powi(2);
+        point_count += 1;
+    }
+    let heavy_keys: HashSet<usize> = univmon_heavy_hitters(sketch, TOP_K)
+        .into_iter()
+        .map(|(value, _)| value)
+        .collect();
+    let captured_mass: u64 = heavy_keys
+        .iter()
+        .filter_map(|key| truth.counts.get(*key))
+        .sum();
+    let entropy = sketch.calc_entropy() * std::f64::consts::LN_2;
+    Accuracy {
+        point_nrmse: (squared_error / point_count as f64).sqrt() / truth.f2.sqrt().max(1.0),
+        f0_rel: relative_error(sketch.calc_card(), truth.distinct as f64),
+        f2_rel: relative_error(sketch.calc_l2().powi(2), truth.f2),
+        entropy_rel: relative_error(entropy, truth.entropy),
+        entropy_abs: (entropy - truth.entropy).abs(),
+        l1_rel: relative_error(sketch.calc_l1(), truth.n as f64),
+        hh_mass: (captured_mass as f64 / truth.top_mass.max(1) as f64).min(1.0),
+        quantile_mean: 0.0,
+        tail_max: 0.0,
+        cdf_max: 0.0,
+    }
+}
+
+fn univmon_frequency(sketch: &UnivMon, value: usize) -> f64 {
+    let input = DataInput::U64(value as u64);
+    let hash = hash64_seeded(BOTTOM_LAYER_FINDER, &input);
+    let mut terminal = sketch.layer_size - 1;
+    for level in 1..sketch.layer_size {
+        if ((hash >> level) & 1) == 0 {
+            terminal = level - 1;
+            break;
+        }
+    }
+    sketch.l2_sketch_layers[terminal].estimate(&input).max(0.0)
+}
+
+fn univmon_heavy_hitters(sketch: &UnivMon, k: usize) -> Vec<(usize, u64)> {
+    let mut keys = HashSet::new();
+    for heap in sketch.hh_layers.iter() {
+        for item in heap.heap() {
+            if let HeapItem::U64(value) = item.key {
+                keys.insert(value as usize);
+            }
+        }
+    }
+    let mut recovered: Vec<_> = keys
+        .into_iter()
+        .map(|key| (key, univmon_frequency(sketch, key).round() as u64))
+        .collect();
+    recovered.sort_unstable_by(|left, right| right.1.cmp(&left.1).then(left.0.cmp(&right.0)));
+    recovered.truncate(k);
+    recovered
+}
+
+fn validate(sketch: &UnivMonQ, truth: &Truth) -> usize {
+    let query = sketch.prepare_queries();
+    let mut violations = 0;
+    violations += usize::from(query.count() != truth.n as u64);
+    violations += usize::from(query.min() != Some(truth.min as f64));
+    violations += usize::from(query.max() != Some(truth.max as f64));
+    violations += usize::from(!query.estimate_distinct().is_finite());
+    violations += usize::from(!query.estimate_f2().is_finite());
+    violations += usize::from(!query.estimate_entropy().is_finite());
+    violations += usize::from(query.estimate_distinct() < 0.0);
+    violations += usize::from(query.estimate_distinct() > truth.n as f64);
+    violations += usize::from(query.estimate_f2() < 0.0);
+
+    let cdf = query.cdf();
+    violations += usize::from(cdf.is_empty());
+    violations += cdf
+        .windows(2)
+        .filter(|pair| {
+            !pair[0].value.total_cmp(&pair[1].value).is_lt() || pair[0].rank > pair[1].rank
+        })
+        .count();
+    violations += cdf
+        .iter()
+        .filter(|point| !point.rank.is_finite() || !(0.0..=1.0).contains(&point.rank))
+        .count();
+    let quantiles = query.quantiles(&QUANTILES);
+    violations += quantiles
+        .windows(2)
+        .filter(|pair| {
+            pair[0]
+                .zip(pair[1])
+                .is_some_and(|(left, right)| left > right)
+        })
+        .count();
+    violations
+}
+
+fn validate_um(sketch: &UnivMon, truth: &Truth) -> usize {
+    let estimates = [
+        sketch.calc_card(),
+        sketch.calc_l2(),
+        sketch.calc_entropy(),
+        sketch.calc_l1(),
+    ];
+    usize::from(sketch.bucket_size != truth.n)
+        + estimates.iter().filter(|value| !value.is_finite()).count()
+        + estimates.iter().filter(|&&value| value < 0.0).count()
+}
+
+fn equivalent_queries(left: &UnivMonQ, right: &UnivMonQ, truth: &Truth) -> bool {
+    let left = left.prepare_queries();
+    let right = right.prepare_queries();
+    left.count() == right.count()
+        && left.min().map(f64::to_bits) == right.min().map(f64::to_bits)
+        && left.max().map(f64::to_bits) == right.max().map(f64::to_bits)
+        && left.estimate_distinct().to_bits() == right.estimate_distinct().to_bits()
+        && left.estimate_f2().to_bits() == right.estimate_f2().to_bits()
+        && left.estimate_entropy().to_bits() == right.estimate_entropy().to_bits()
+        && left.heavy_hitters(TOP_K) == right.heavy_hitters(TOP_K)
+        && left.quantiles(&QUANTILES) == right.quantiles(&QUANTILES)
+        && (0..=100).all(|index| {
+            let value = 1 + index * (truth.domain - 1) / 100;
+            left.rank(value as f64) == right.rank(value as f64)
+        })
+        && left.cdf().len() == right.cdf().len()
+        && left.cdf().iter().zip(right.cdf()).all(|(left, right)| {
+            left.value.to_bits() == right.value.to_bits()
+                && left.rank.to_bits() == right.rank.to_bits()
+        })
+}
+
+fn um_query_mismatches(left: &UnivMon, right: &UnivMon, truth: &Truth) -> Vec<&'static str> {
+    let mut mismatches = Vec::new();
+    if left.bucket_size != right.bucket_size {
+        mismatches.push("count");
+    }
+    if left.calc_card().to_bits() != right.calc_card().to_bits() {
+        mismatches.push("F0");
+    }
+    if left.calc_l2().to_bits() != right.calc_l2().to_bits() {
+        mismatches.push("F2");
+    }
+    if left.calc_entropy().to_bits() != right.calc_entropy().to_bits() {
+        mismatches.push("entropy");
+    }
+    if left.calc_l1().to_bits() != right.calc_l1().to_bits() {
+        mismatches.push("L1");
+    }
+    if univmon_heavy_hitters(left, TOP_K) != univmon_heavy_hitters(right, TOP_K) {
+        mismatches.push("heavy hitters");
+    }
+    if !(0..=100).all(|index| {
+        let value = 1 + index * (truth.domain - 1) / 100;
+        univmon_frequency(left, value).to_bits() == univmon_frequency(right, value).to_bits()
+    }) {
+        mismatches.push("point frequency");
+    }
+    mismatches
+}
+
+struct Truth {
+    n: usize,
+    domain: usize,
+    counts: Vec<u64>,
+    cumulative: Vec<u64>,
+    distinct: usize,
+    min: usize,
+    max: usize,
+    f2: f64,
+    entropy: f64,
+    top_mass: u64,
+}
+
+impl Truth {
+    fn new(data: &[i64], domain: usize) -> Self {
+        let mut counts = vec![0_u64; domain + 1];
+        for &value in data {
+            counts[value as usize] += 1;
+        }
+        let mut cumulative = vec![0_u64; domain + 1];
+        for key in 1..=domain {
+            cumulative[key] = cumulative[key - 1] + counts[key];
+        }
+        let distinct = counts.iter().filter(|&&count| count > 0).count();
+        let min = counts.iter().position(|&count| count > 0).unwrap();
+        let max = counts.iter().rposition(|&count| count > 0).unwrap();
+        let f2 = counts.iter().map(|&count| (count as f64).powi(2)).sum();
+        let entropy = counts
+            .iter()
+            .filter(|&&count| count > 0)
+            .map(|&count| {
+                let probability = count as f64 / data.len() as f64;
+                -probability * probability.ln()
+            })
+            .sum();
+        let mut frequencies = counts.clone();
+        frequencies.sort_unstable_by(|left, right| right.cmp(left));
+        let top_mass = frequencies.into_iter().take(TOP_K).sum();
+        Self {
+            n: data.len(),
+            domain,
+            counts,
+            cumulative,
+            distinct,
+            min,
+            max,
+            f2,
+            entropy,
+            top_mass,
+        }
+    }
+
+    fn cdf(&self, value: usize) -> f64 {
+        self.cumulative[value.min(self.domain)] as f64 / self.n as f64
+    }
+
+    fn quantile_rank_error(&self, q: f64, estimate: usize) -> f64 {
+        let target = (q * self.n as f64).ceil().max(1.0) as u64;
+        let below = self.cumulative[estimate.saturating_sub(1).min(self.domain)];
+        let at_or_below = self.cumulative[estimate.min(self.domain)];
+        if target < below {
+            (below - target) as f64 / self.n as f64
+        } else if target > at_or_below {
+            (target - at_or_below) as f64 / self.n as f64
+        } else {
+            0.0
+        }
+    }
+}
+
+struct TrialResult {
+    q_accuracy: Accuracy,
+    um_accuracy: Accuracy,
+    distinct: f64,
+    entropy_exact: f64,
+    q_update_ns: f64,
+    um_update_ns: f64,
+    q_merge_us: f64,
+    um_merge_us: f64,
+    q_prepare_us: f64,
+    q_warm_ns: f64,
+    um_query_us: f64,
+    q_memory_mib: f64,
+    q_wire_kib: f64,
+    um_wire_kib: f64,
+    q_violations: usize,
+    um_violations: usize,
+    um_warnings: usize,
+}
+
+struct Summary {
+    skew: f64,
+    distinct_p50: f64,
+    point_p95: f64,
+    f0_p95: f64,
+    f2_p95: f64,
+    entropy_p95: f64,
+    entropy_exact_p50: f64,
+    entropy_abs_p95: f64,
+    l1_p95: f64,
+    hh_mass_p05: f64,
+    um_point_p95: f64,
+    um_f0_p95: f64,
+    um_f2_p95: f64,
+    um_entropy_p95: f64,
+    um_entropy_abs_p95: f64,
+    um_l1_p95: f64,
+    um_hh_mass_p05: f64,
+    quantile_p50: f64,
+    quantile_p95: f64,
+    tail_p50: f64,
+    tail_p95: f64,
+    cdf_p50: f64,
+    cdf_p95: f64,
+    update_p50: f64,
+    update_p95: f64,
+    merge_p50_us: f64,
+    prepare_p50_us: f64,
+    warm_p50_ns: f64,
+    memory_mib: f64,
+    q_wire_kib: f64,
+    um_update_p50: f64,
+    um_update_p95: f64,
+    um_merge_p50_us: f64,
+    um_query_p50_us: f64,
+    um_wire_kib: f64,
+    q_violations: usize,
+    um_violations: usize,
+    um_warnings: usize,
+}
+
+impl Summary {
+    fn new(skew: f64, results: &[TrialResult]) -> Self {
+        let values = |field: fn(&TrialResult) -> f64| results.iter().map(field).collect::<Vec<_>>();
+        let distinct = values(|result| result.distinct);
+        let point = values(|result| result.q_accuracy.point_nrmse);
+        let f0 = values(|result| result.q_accuracy.f0_rel);
+        let f2 = values(|result| result.q_accuracy.f2_rel);
+        let entropy = values(|result| result.q_accuracy.entropy_rel);
+        let entropy_exact = values(|result| result.entropy_exact);
+        let entropy_abs = values(|result| result.q_accuracy.entropy_abs);
+        let l1 = values(|result| result.q_accuracy.l1_rel);
+        let hh_mass = values(|result| result.q_accuracy.hh_mass);
+        let quantile = values(|result| result.q_accuracy.quantile_mean);
+        let tail = values(|result| result.q_accuracy.tail_max);
+        let cdf = values(|result| result.q_accuracy.cdf_max);
+        let update = values(|result| result.q_update_ns);
+        let merge = values(|result| result.q_merge_us);
+        let prepare = values(|result| result.q_prepare_us);
+        let warm = values(|result| result.q_warm_ns);
+        let um_point = values(|result| result.um_accuracy.point_nrmse);
+        let um_f0 = values(|result| result.um_accuracy.f0_rel);
+        let um_f2 = values(|result| result.um_accuracy.f2_rel);
+        let um_entropy = values(|result| result.um_accuracy.entropy_rel);
+        let um_entropy_abs = values(|result| result.um_accuracy.entropy_abs);
+        let um_l1 = values(|result| result.um_accuracy.l1_rel);
+        let um_hh_mass = values(|result| result.um_accuracy.hh_mass);
+        let um_update = values(|result| result.um_update_ns);
+        let um_merge = values(|result| result.um_merge_us);
+        let um_query = values(|result| result.um_query_us);
+        Self {
+            skew,
+            distinct_p50: percentile(&distinct, 0.5),
+            point_p95: percentile(&point, 0.95),
+            f0_p95: percentile(&f0, 0.95),
+            f2_p95: percentile(&f2, 0.95),
+            entropy_p95: percentile(&entropy, 0.95),
+            entropy_exact_p50: percentile(&entropy_exact, 0.5),
+            entropy_abs_p95: percentile(&entropy_abs, 0.95),
+            l1_p95: percentile(&l1, 0.95),
+            hh_mass_p05: percentile(&hh_mass, 0.05),
+            um_point_p95: percentile(&um_point, 0.95),
+            um_f0_p95: percentile(&um_f0, 0.95),
+            um_f2_p95: percentile(&um_f2, 0.95),
+            um_entropy_p95: percentile(&um_entropy, 0.95),
+            um_entropy_abs_p95: percentile(&um_entropy_abs, 0.95),
+            um_l1_p95: percentile(&um_l1, 0.95),
+            um_hh_mass_p05: percentile(&um_hh_mass, 0.05),
+            quantile_p50: percentile(&quantile, 0.5),
+            quantile_p95: percentile(&quantile, 0.95),
+            tail_p50: percentile(&tail, 0.5),
+            tail_p95: percentile(&tail, 0.95),
+            cdf_p50: percentile(&cdf, 0.5),
+            cdf_p95: percentile(&cdf, 0.95),
+            update_p50: percentile(&update, 0.5),
+            update_p95: percentile(&update, 0.95),
+            merge_p50_us: percentile(&merge, 0.5),
+            prepare_p50_us: percentile(&prepare, 0.5),
+            warm_p50_ns: percentile(&warm, 0.5),
+            memory_mib: percentile(&values(|result| result.q_memory_mib), 0.5),
+            q_wire_kib: percentile(&values(|result| result.q_wire_kib), 0.5),
+            um_update_p50: percentile(&um_update, 0.5),
+            um_update_p95: percentile(&um_update, 0.95),
+            um_merge_p50_us: percentile(&um_merge, 0.5),
+            um_query_p50_us: percentile(&um_query, 0.5),
+            um_wire_kib: percentile(&values(|result| result.um_wire_kib), 0.5),
+            q_violations: results.iter().map(|result| result.q_violations).sum(),
+            um_violations: results.iter().map(|result| result.um_violations).sum(),
+            um_warnings: results.iter().map(|result| result.um_warnings).sum(),
+        }
+    }
+}
+
+struct ZipfSampler {
+    cdf: Vec<f64>,
+    total: f64,
+}
+
+impl ZipfSampler {
+    fn new(domain: usize, skew: f64) -> Self {
+        let mut total = 0.0;
+        let mut cdf = Vec::with_capacity(domain);
+        for rank in 1..=domain {
+            total += 1.0 / (rank as f64).powf(skew);
+            cdf.push(total);
+        }
+        Self { cdf, total }
+    }
+
+    fn generate(&self, n: usize, seed: u64) -> Vec<i64> {
+        let mut rng = Rng(seed);
+        (0..n)
+            .map(|_| {
+                let target = rng.unit() * self.total;
+                (self.cdf.partition_point(|value| *value < target) + 1) as i64
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        mix64(self.0)
+    }
+
+    fn unit(&mut self) -> f64 {
+        ((self.next() >> 11) as f64 + 0.5) / (1_u64 << 53) as f64
+    }
+}
+
+fn source_id(seed: u64, shard: usize) -> u64 {
+    mix64(seed ^ (shard as u64).wrapping_mul(0xd6e8_feb8_6659_fd93))
+}
+
+fn trial_seed(skew: usize, trial: usize) -> u64 {
+    0x2026_0807_554d_5100_u64 ^ ((skew as u64) << 32) ^ trial as u64
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn relative_error(estimate: f64, exact: f64) -> f64 {
+    (estimate - exact).abs() / exact.abs().max(1.0)
+}
+
+fn percentile(values: &[f64], quantile: f64) -> f64 {
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable_by(f64::total_cmp);
+    let index = ((quantile * sorted.len() as f64).ceil() as usize)
+        .saturating_sub(1)
+        .min(sorted.len() - 1);
+    sorted[index]
+}
+
+fn duration_percentile(values: &[Duration], quantile: f64) -> Duration {
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let index = ((quantile * sorted.len() as f64).ceil() as usize)
+        .saturating_sub(1)
+        .min(sorted.len() - 1);
+    sorted[index]
+}

--- a/examples/quantile_univmon_q.rs
+++ b/examples/quantile_univmon_q.rs
@@ -21,7 +21,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("p99: {:.1}", quantiles[2].unwrap());
     println!("distinct: {:.0}", query.estimate_distinct());
     println!("F2: {:.0}", query.estimate_f2());
-    println!("F3: {:.0}", query.estimate_f3());
     println!("memory: {} KiB", sketch.estimated_memory_bytes() / 1024);
     Ok(())
 }

--- a/src/sketch_framework/mod.rs
+++ b/src/sketch_framework/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! - windowed analytics: [`ExponentialHistogram`], [`TumblingWindow`]
 //! - subpopulation and hierarchical queries: [`Hydra`]
-//! - universal multi-metric monitoring: [`UnivMon`], [`UnivMonQ`]
+//! - universal multi-metric monitoring: [`UnivMon`] and experimental [`UnivMonQ`]
 //! - batch update acceleration: [`NitroBatch`]
 //! - shared-hash or multi-sketch coordination: [`HashSketchEnsemble`]
 //! - runtime and parallel execution helpers: the `octo` family

--- a/src/sketch_framework/tumbling.rs
+++ b/src/sketch_framework/tumbling.rs
@@ -9,7 +9,7 @@
 //!
 //! Any type implementing [`TumblingWindowSketch`] can be used. Built-in
 //! implementations are provided for [`FoldCMS`], [`FoldCS`], [`KLL`], and
-//! [`UnivMonQ`].
+//! experimental [`UnivMonQ`].
 
 use crate::DataInput;
 use crate::fold_cms::FoldCMS;

--- a/src/sketch_framework/univmon.rs
+++ b/src/sketch_framework/univmon.rs
@@ -336,9 +336,9 @@ impl UnivMon {
         self.calc_g_sum_heuristic(g, is_card)
     }
 
-    /// Returns the estimated L1 norm.
+    /// Returns the exact L1 norm for the supported non-negative update stream.
     pub fn calc_l1(&self) -> f64 {
-        self.calc_g_sum(|x| x, false)
+        self.bucket_size as f64
     }
 
     /// Returns the estimated L2 norm.

--- a/src/sketch_framework/univmon_optimized.rs
+++ b/src/sketch_framework/univmon_optimized.rs
@@ -396,9 +396,9 @@ impl UnivMonPyramid {
         }
     }
 
-    /// Returns the estimated L1 norm.
+    /// Returns the exact L1 norm for the supported non-negative update stream.
     pub fn calc_l1(&self) -> f64 {
-        self.calc_g_sum(|x| x, false)
+        self.bucket_size as f64
     }
 
     /// Returns the estimated L2 norm.

--- a/src/sketch_framework/univmon_q.rs
+++ b/src/sketch_framework/univmon_q.rs
@@ -1,21 +1,23 @@
-//! UnivMon-Q: universal frequency measurements with ordered quantile queries.
+//! Experimental UnivMon-Q: universal frequency measurements with ordered quantile queries.
 //!
 //! Each numeric value is encoded into an order-preserving `u64` key. One
-//! 128-bit hash is split into independent fields for CountSketch rows, the
-//! Joltik terminal stratum, and a coordinated bottom-k priority. Updates touch
-//! one physical CountSketch layer. Query-time recursion reconstructs the
-//! logical UnivMon hierarchy, while a frequency-weighted bottom-k sample of
-//! the non-heavy residual supplies rank and quantile estimates.
+//! 128-bit key hash is split into independent fields for CountSketch rows and
+//! the Joltik terminal stratum. Updates touch one physical CountSketch layer.
+//! A separate coordinated bottom-k sample of stream occurrences is keyed by
+//! `(source_id, local_sequence)`. Query-time recursion reconstructs the
+//! logical UnivMon hierarchy; reliable heavy frequencies are combined with
+//! the residual occurrence sample for rank and quantile estimates.
 //!
 //! Provenance: adapted from the experimental `zaoxing/univmon-quantile`
 //! implementation and integrated with Sketchlib's numeric input, pluggable
 //! hashing, merge, and native MessagePack APIs.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BinaryHeap, HashMap};
+use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 
 use rmp_serde::decode::Error as RmpDecodeError;
 use rmp_serde::encode::Error as RmpEncodeError;
@@ -25,7 +27,9 @@ use crate::common::input::data_input_to_f64;
 use crate::common::numerical::NumericalValue;
 use crate::{DataInput, DefaultXxHasher, SketchHasher};
 
-const WIRE_VERSION: u8 = 1;
+const WIRE_VERSION: u8 = 2;
+const OCCURRENCE_HASH_SEED_DOMAIN: usize = usize::MAX / 3;
+static NEXT_SOURCE_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Memory, accuracy, and hashing controls for [`UnivMonQ`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -42,7 +46,7 @@ pub struct UnivMonQConfig {
     pub counter_bits: u8,
     /// Maximum candidate identities retained at each terminal stratum.
     pub candidates: usize,
-    /// Coordinated distinct-value samples retained for ordered queries.
+    /// Coordinated stream-occurrence samples retained for ordered queries.
     /// Set to zero when rank/CDF/quantile queries are not required.
     pub ordered_samples: usize,
     /// Seed index passed to [`SketchHasher::hash128_seeded`].
@@ -135,6 +139,16 @@ struct CandidateRecovery {
     by_terminal: Vec<Vec<RecoveredCandidate>>,
 }
 
+/// One retained stream occurrence. Splitting the 128-bit priority into two
+/// words keeps the record at 24 bytes instead of introducing `u128` alignment
+/// padding on common 64-bit targets.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+struct OrderedOccurrence {
+    priority_high: u64,
+    priority_low: u64,
+    key: u64,
+}
+
 /// Reusable, immutable query state prepared from a [`UnivMonQ`] sketch.
 ///
 /// Preparing the view reconstructs the logical UnivMon hierarchy and ordered
@@ -145,6 +159,7 @@ struct CandidateRecovery {
 pub struct UnivMonQQuery<'a, H: SketchHasher = DefaultXxHasher> {
     sketch: &'a UnivMonQ<H>,
     logical_heavy: Vec<Vec<RecoveredCandidate>>,
+    heavy_hitters: Vec<RecoveredCandidate>,
     cdf: Vec<UnivMonQPoint>,
 }
 
@@ -153,8 +168,6 @@ struct HashLayout {
     bucket_bits: u32,
     terminal_offset: u32,
     terminal_bits: u32,
-    priority_offset: u32,
-    priority_bits: u32,
 }
 
 impl HashLayout {
@@ -163,18 +176,16 @@ impl HashLayout {
         let row_bits = bucket_bits + 1;
         let terminal_offset = row_bits * config.depth as u32;
         let terminal_bits = config.levels as u32 - 1;
-        let priority_offset = terminal_offset + terminal_bits;
-        if config.depth > 64 || priority_offset > 96 {
+        let used_bits = terminal_offset + terminal_bits;
+        if config.depth > 64 || used_bits > 128 {
             return Err(UnivMonQError::new(
-                "hash layout needs at most 96 of 128 bits before sample priority",
+                "hash layout needs more than the available 128 hash bits",
             ));
         }
         Ok(Self {
             bucket_bits,
             terminal_offset,
             terminal_bits,
-            priority_offset,
-            priority_bits: 128 - priority_offset,
         })
     }
 
@@ -183,18 +194,6 @@ impl HashLayout {
         let mask = (1_u128 << self.terminal_bits) - 1;
         let field = (hash >> self.terminal_offset) & mask;
         (field.trailing_zeros() as usize).min(self.terminal_bits as usize)
-    }
-
-    #[inline(always)]
-    fn priority(self, hash: u128) -> u64 {
-        let bits = self.priority_bits.min(64);
-        let mask = if bits == 64 {
-            u128::from(u64::MAX)
-        } else {
-            (1_u128 << bits) - 1
-        };
-        let value = ((hash >> self.priority_offset) & mask) as u64;
-        value << (64 - bits)
     }
 }
 
@@ -414,6 +413,7 @@ struct Level {
     candidate_scores: HashMap<u64, u64>,
     candidate_heap: BinaryHeap<Reverse<(u64, u64)>>,
     candidate_capacity: usize,
+    ever_evicted: bool,
 }
 
 impl Level {
@@ -423,25 +423,31 @@ impl Level {
             candidate_scores: HashMap::with_capacity(candidates),
             candidate_heap: BinaryHeap::with_capacity(candidates),
             candidate_capacity: candidates,
+            ever_evicted: false,
         }
     }
 
     fn update(&mut self, key: u64, hash: u128, bucket_bits: u32) {
         self.sketch.update(hash, bucket_bits);
-        if let Some(score) = self.candidate_scores.get_mut(&key) {
-            *score = score.saturating_add(1);
+        let score = self.sketch.estimate(hash, bucket_bits).max(0) as u64;
+        if let Some(stored_score) = self.candidate_scores.get_mut(&key) {
+            *stored_score = score;
             return;
         }
         if self.candidate_scores.len() < self.candidate_capacity {
-            self.candidate_scores.insert(key, 1);
-            self.candidate_heap.push(Reverse((1, key)));
+            self.candidate_scores.insert(key, score);
+            self.candidate_heap.push(Reverse((score, key)));
             return;
         }
         if let Some((minimum, evicted)) = self.lightest_candidate() {
-            self.candidate_scores.remove(&evicted);
-            let score = minimum.saturating_add(1);
-            self.candidate_scores.insert(key, score);
-            self.candidate_heap.push(Reverse((score, key)));
+            self.ever_evicted = true;
+            if score > minimum {
+                self.candidate_scores.remove(&evicted);
+                self.candidate_scores.insert(key, score);
+                self.candidate_heap.push(Reverse((score, key)));
+            } else {
+                self.candidate_heap.push(Reverse((minimum, evicted)));
+            }
         }
     }
 
@@ -462,40 +468,25 @@ impl Level {
         }
     }
 
-    fn merge(&mut self, other: &Self) {
+    fn merge(&mut self, other: &Self, bucket_bits: u32, hash_key: impl Fn(u64) -> u128) {
         self.sketch.merge(&other.sketch);
-        let left_minimum = if self.candidate_scores.len() == self.candidate_capacity {
-            self.candidate_scores.values().copied().min().unwrap_or(0)
-        } else {
-            0
-        };
-        let right_minimum = if other.candidate_scores.len() == other.candidate_capacity {
-            other.candidate_scores.values().copied().min().unwrap_or(0)
-        } else {
-            0
-        };
-        let mut combined = HashMap::with_capacity(
-            (self.candidate_scores.len() + other.candidate_scores.len())
-                .min(2 * self.candidate_capacity),
-        );
-        for (&key, &left_count) in &self.candidate_scores {
-            let right_count = other
-                .candidate_scores
-                .get(&key)
-                .copied()
-                .unwrap_or(right_minimum);
-            combined.insert(key, left_count.saturating_add(right_count));
-        }
-        for (&key, &right_count) in &other.candidate_scores {
-            combined
-                .entry(key)
-                .or_insert_with(|| right_count.saturating_add(left_minimum));
-        }
-        let mut retained: Vec<(u64, u64)> = combined.into_iter().collect();
+        let mut combined: HashSet<u64> = self.candidate_scores.keys().copied().collect();
+        combined.extend(other.candidate_scores.keys().copied());
+        let combined_len = combined.len();
+        let mut retained: Vec<(u64, u64)> = combined
+            .into_iter()
+            .map(|key| {
+                let hash = hash_key(key);
+                let score = self.sketch.estimate(hash, bucket_bits).max(0) as u64;
+                (key, score)
+            })
+            .collect();
         retained.sort_unstable_by(|left, right| {
             right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0))
         });
         retained.truncate(self.candidate_capacity);
+        self.ever_evicted =
+            self.ever_evicted || other.ever_evicted || combined_len > self.candidate_capacity;
         self.candidate_scores.clear();
         self.candidate_heap.clear();
         for (key, count) in retained {
@@ -508,10 +499,11 @@ impl Level {
         self.sketch.clear();
         self.candidate_scores.clear();
         self.candidate_heap.clear();
+        self.ever_evicted = false;
     }
 }
 
-/// Mergeable universal sketch extended with rank, CDF, and quantile queries.
+/// Experimental mergeable universal sketch extended with rank, CDF, and quantile queries.
 ///
 /// `H` is the same pluggable hash abstraction used throughout Sketchlib. The
 /// default uses [`DefaultXxHasher`]. Values use `f64::total_cmp` ordering,
@@ -524,8 +516,9 @@ pub struct UnivMonQ<H: SketchHasher = DefaultXxHasher> {
     count: u64,
     min: Option<u64>,
     max: Option<u64>,
-    ordered_frequencies: HashMap<u64, u64>,
-    ordered_heap: BinaryHeap<(u64, u64)>,
+    source_id: u64,
+    next_sequence: u64,
+    ordered_heap: BinaryHeap<OrderedOccurrence>,
     hasher: PhantomData<H>,
 }
 
@@ -550,11 +543,39 @@ impl<'a, H: SketchHasher> UnivMonQQuery<'a, H> {
         self.sketch.estimate_frequency(value)
     }
 
+    /// Experimental fixed-threshold rank estimate from the UnivMon recurrence.
+    ///
+    /// Unlike [`Self::rank`], this does not use or require the ordered sample.
+    /// It evaluates the separable subset function
+    /// `g_x(key, frequency) = frequency * I[key <= x]` over the recovered
+    /// hierarchy. Individual thresholds inherit UnivMon's candidate-recovery
+    /// assumptions; estimates at different thresholds are not jointly forced
+    /// to be monotone.
+    pub fn estimate_rank_universal(&self, value: f64) -> Option<u64> {
+        if self.count() == 0 {
+            return None;
+        }
+        let key = float_to_ordered(value);
+        if key < self.sketch.min? {
+            return Some(0);
+        }
+        if key >= self.sketch.max? {
+            return Some(self.count());
+        }
+        Some(
+            estimate_keyed_sum_from(&self.logical_heavy, |candidate_key, frequency| {
+                if candidate_key <= key { frequency } else { 0.0 }
+            })
+            .round()
+            .clamp(0.0, self.count() as f64) as u64,
+        )
+    }
+
     /// Estimates `sum_x g(f_x)` using the prepared logical hierarchy.
     ///
     /// As with UnivMon's generic estimator, useful accuracy requires a
     /// frequency function compatible with the retained-heavy-item recurrence;
-    /// callers should normally use the provided F0/F2/F3/entropy methods.
+    /// callers should normally use the provided F0/F2/entropy methods.
     pub fn estimate_g_sum<F>(&self, g: F) -> f64
     where
         F: Fn(f64) -> f64,
@@ -570,12 +591,6 @@ impl<'a, H: SketchHasher> UnivMonQQuery<'a, H> {
     /// UnivMon estimate of the frequency vector's second moment.
     pub fn estimate_f2(&self) -> f64 {
         self.estimate_g_sum(|frequency| frequency * frequency)
-            .max(0.0)
-    }
-
-    /// UnivMon estimate of the frequency vector's third moment.
-    pub fn estimate_f3(&self) -> f64 {
-        self.estimate_g_sum(|frequency| frequency * frequency * frequency)
             .max(0.0)
     }
 
@@ -599,10 +614,8 @@ impl<'a, H: SketchHasher> UnivMonQQuery<'a, H> {
         if k == 0 || self.count() == 0 {
             return Vec::new();
         }
-        self.logical_heavy
-            .first()
-            .into_iter()
-            .flatten()
+        self.heavy_hitters
+            .iter()
             .take(k)
             .map(|candidate| {
                 (
@@ -679,6 +692,17 @@ impl<H: SketchHasher> Default for UnivMonQ<H> {
 impl<H: SketchHasher> UnivMonQ<H> {
     /// Creates an empty sketch using `H` and the supplied configuration.
     pub fn with_hasher(config: UnivMonQConfig) -> Result<Self, UnivMonQError> {
+        Self::with_hasher_and_source_id(config, allocate_source_id())
+    }
+
+    /// Creates an empty sketch with an explicit distributed source identity.
+    ///
+    /// Every concurrently mergeable source must use a different ID. Ordered
+    /// occurrence priorities are derived from `(source_id, local_sequence)`.
+    pub fn with_hasher_and_source_id(
+        config: UnivMonQConfig,
+        source_id: u64,
+    ) -> Result<Self, UnivMonQError> {
         validate_config(config)?;
         let hash_layout = HashLayout::new(config)?;
         let levels = (0..config.levels)
@@ -698,7 +722,8 @@ impl<H: SketchHasher> UnivMonQ<H> {
             count: 0,
             min: None,
             max: None,
-            ordered_frequencies: HashMap::with_capacity(config.ordered_samples),
+            source_id,
+            next_sequence: 0,
             ordered_heap: BinaryHeap::with_capacity(config.ordered_samples),
             hasher: PhantomData,
         })
@@ -707,6 +732,11 @@ impl<H: SketchHasher> UnivMonQ<H> {
     /// Returns the immutable configuration required by compatible merges.
     pub fn config(&self) -> UnivMonQConfig {
         self.config
+    }
+
+    /// Identity used to coordinate occurrence priorities from this source.
+    pub fn source_id(&self) -> u64 {
+        self.source_id
     }
 
     /// Adds one numeric value.
@@ -733,12 +763,20 @@ impl<H: SketchHasher> UnivMonQ<H> {
     fn update_value(&mut self, value: f64) {
         let key = float_to_ordered(value);
         let hash = self.hash_key(key);
+        let sequence = self.next_sequence;
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .expect("UnivMon-Q source sequence exhausted");
         self.count = self.count.saturating_add(1);
         self.min = Some(self.min.map_or(key, |old| old.min(key)));
         self.max = Some(self.max.map_or(key, |old| old.max(key)));
         let terminal = self.hash_layout.terminal_level(hash);
         self.levels[terminal].update(key, hash, self.hash_layout.bucket_bits);
-        self.update_ordered_sample(key, self.hash_layout.priority(hash));
+        if self.config.ordered_samples > 0 {
+            let occurrence = self.occurrence(key, sequence);
+            self.update_ordered_sample(occurrence);
+        }
     }
 
     /// Merges a shard built with the identical configuration and hash profile.
@@ -757,8 +795,12 @@ impl<H: SketchHasher> UnivMonQ<H> {
             (Some(left), Some(right)) => Some(left.max(right)),
             (left, right) => left.or(right),
         };
+        let hash_seed = self.config.hash_seed;
+        let bucket_bits = self.hash_layout.bucket_bits;
         for (left, right) in self.levels.iter_mut().zip(&other.levels) {
-            left.merge(right);
+            left.merge(right, bucket_bits, |key| {
+                H::hash128_seeded(hash_seed, &DataInput::U64(key))
+            });
         }
         self.merge_ordered_samples(other);
         Ok(())
@@ -769,7 +811,6 @@ impl<H: SketchHasher> UnivMonQ<H> {
         self.count = 0;
         self.min = None;
         self.max = None;
-        self.ordered_frequencies.clear();
         self.ordered_heap.clear();
         for level in &mut self.levels {
             level.clear();
@@ -810,6 +851,17 @@ impl<H: SketchHasher> UnivMonQ<H> {
         self.frequency_key(key).max(0) as u64
     }
 
+    /// Experimental fixed-threshold rank estimate from the UnivMon recurrence.
+    ///
+    /// This path is independent of `ordered_samples`. Prefer
+    /// [`Self::prepare_queries`] when evaluating more than one threshold.
+    pub fn estimate_rank_universal(&self, value: f64) -> Option<u64> {
+        if self.is_empty() {
+            return None;
+        }
+        self.prepare_queries().estimate_rank_universal(value)
+    }
+
     /// Reconstructs a reusable query snapshot.
     ///
     /// Use this when answering multiple universal metrics or ordered queries
@@ -818,9 +870,10 @@ impl<H: SketchHasher> UnivMonQ<H> {
     pub fn prepare_queries(&self) -> UnivMonQQuery<'_, H> {
         let recovery = self.recover_candidates();
         let logical_heavy = self.logical_heavy_sets_from(&recovery);
-        let global_heavy = self.global_heavy_candidates_from(&recovery);
+        let heavy_hitters = self.top_candidates_from(&recovery);
+        let ordered_heavy = self.assisted_ordered_heavy(&logical_heavy, &heavy_hitters);
         let cdf = self
-            .cdf_keys_from(&global_heavy)
+            .cdf_keys_from(&ordered_heavy)
             .into_iter()
             .map(|(value, rank)| UnivMonQPoint {
                 value: ordered_to_float(value),
@@ -830,6 +883,7 @@ impl<H: SketchHasher> UnivMonQ<H> {
         UnivMonQQuery {
             sketch: self,
             logical_heavy,
+            heavy_hitters,
             cdf,
         }
     }
@@ -861,12 +915,6 @@ impl<H: SketchHasher> UnivMonQ<H> {
             .max(0.0)
     }
 
-    /// UnivMon estimate of the frequency vector's third moment.
-    pub fn estimate_f3(&self) -> f64 {
-        self.estimate_g_sum(|frequency| frequency * frequency * frequency)
-            .max(0.0)
-    }
-
     /// Estimated Shannon entropy in nats.
     pub fn estimate_entropy(&self) -> f64 {
         if self.is_empty() {
@@ -888,10 +936,7 @@ impl<H: SketchHasher> UnivMonQ<H> {
             return Vec::new();
         }
         let recovery = self.recover_candidates();
-        self.logical_heavy_sets_from(&recovery)
-            .into_iter()
-            .next()
-            .unwrap_or_default()
+        self.top_candidates_from(&recovery)
             .into_iter()
             .take(k)
             .map(|candidate| {
@@ -980,9 +1025,9 @@ impl<H: SketchHasher> UnivMonQ<H> {
             * self.config.candidates
             * (size_of::<(u64, u64)>() + 2 * size_of::<usize>());
         let candidate_heaps = self.config.levels * self.config.candidates * size_of::<(u64, u64)>();
-        let ordered =
-            self.config.ordered_samples * (size_of::<(u64, u64)>() + size_of::<(u64, u64)>());
-        counters + candidates + candidate_heaps + ordered
+        let eviction_history = self.config.levels * size_of::<bool>();
+        let ordered = self.config.ordered_samples * size_of::<OrderedOccurrence>();
+        counters + candidates + candidate_heaps + eviction_history + ordered
     }
 
     fn cdf_keys(&self) -> Vec<(u64, f64)> {
@@ -990,7 +1035,9 @@ impl<H: SketchHasher> UnivMonQ<H> {
             return Vec::new();
         }
         let recovery = self.recover_candidates();
-        let heavy = self.global_heavy_candidates_from(&recovery);
+        let logical_heavy = self.logical_heavy_sets_from(&recovery);
+        let heavy_hitters = self.top_candidates_from(&recovery);
+        let heavy = self.assisted_ordered_heavy(&logical_heavy, &heavy_hitters);
         self.cdf_keys_from(&heavy)
     }
 
@@ -1008,19 +1055,33 @@ impl<H: SketchHasher> UnivMonQ<H> {
         }
         let heavy_total: f64 = heavy.values().sum();
         let residual_total = (self.count as f64 - heavy_total).max(0.0);
-        let sampled_residual_total: f64 = self
-            .ordered_frequencies
+        let mut residual_keys: Vec<u64> = self
+            .ordered_heap
             .iter()
-            .filter(|(key, _)| !heavy.contains_key(key))
-            .map(|(_, frequency)| *frequency as f64)
-            .sum();
+            .filter(|occurrence| !heavy.contains_key(&occurrence.key))
+            .map(|occurrence| occurrence.key)
+            .collect();
+        if residual_keys.is_empty() && residual_total > 0.0 {
+            heavy.clear();
+            residual_keys = self
+                .ordered_heap
+                .iter()
+                .map(|occurrence| occurrence.key)
+                .collect();
+        }
+        let residual_total = if heavy.is_empty() {
+            self.count as f64
+        } else {
+            (self.count as f64 - heavy.values().sum::<f64>()).max(0.0)
+        };
+        let residual_weight = if residual_keys.is_empty() {
+            0.0
+        } else {
+            residual_total / residual_keys.len() as f64
+        };
         let mut weights = heavy;
-        if sampled_residual_total > 0.0 {
-            for (&key, &frequency) in &self.ordered_frequencies {
-                weights
-                    .entry(key)
-                    .or_insert(residual_total * frequency as f64 / sampled_residual_total);
-            }
+        for key in residual_keys {
+            *weights.entry(key).or_insert(0.0) += residual_weight;
         }
         weights.entry(self.min.unwrap()).or_insert(0.0);
         weights.entry(self.max.unwrap()).or_insert(0.0);
@@ -1072,29 +1133,38 @@ impl<H: SketchHasher> UnivMonQ<H> {
         }
     }
 
-    fn global_heavy_candidates_from(&self, recovery: &CandidateRecovery) -> Vec<(u64, f64)> {
-        let mut candidates = Vec::with_capacity(self.config.levels * self.config.candidates);
-        for (terminal, level) in self.levels.iter().enumerate() {
-            let threshold = if level.candidate_scores.len() < self.config.candidates {
-                0.0
-            } else {
-                2.0 * (recovery.physical_f2[terminal] / self.config.candidates as f64).sqrt()
-            };
-            candidates.extend(
-                recovery.by_terminal[terminal]
-                    .iter()
-                    .filter(|candidate| candidate.frequency >= threshold)
-                    .map(|candidate| (candidate.key, candidate.frequency)),
-            );
-        }
+    fn top_candidates_from(&self, recovery: &CandidateRecovery) -> Vec<RecoveredCandidate> {
+        let mut candidates: Vec<_> = recovery.by_terminal.iter().flatten().copied().collect();
         candidates.sort_unstable_by(|left, right| {
             right
-                .1
-                .total_cmp(&left.1)
-                .then_with(|| left.0.cmp(&right.0))
+                .frequency
+                .total_cmp(&left.frequency)
+                .then_with(|| left.key.cmp(&right.key))
         });
         candidates.truncate(self.config.candidates);
         candidates
+    }
+
+    fn assisted_ordered_heavy(
+        &self,
+        logical_heavy: &[Vec<RecoveredCandidate>],
+        heavy_hitters: &[RecoveredCandidate],
+    ) -> Vec<(u64, f64)> {
+        if self.count == 0 || self.config.ordered_samples == 0 {
+            return Vec::new();
+        }
+        let f2 = estimate_g_sum_from(logical_heavy, |frequency| frequency * frequency).max(0.0);
+        let concentration = f2 / (self.count as f64).powi(2);
+        if concentration < 1.0 / self.config.ordered_samples as f64 {
+            return Vec::new();
+        }
+        let threshold = (f2 / self.config.width as f64).sqrt();
+        heavy_hitters
+            .iter()
+            .take(64)
+            .filter(|candidate| candidate.frequency >= threshold)
+            .map(|candidate| (candidate.key, candidate.frequency))
+            .collect()
     }
 
     fn logical_heavy_sets_from(
@@ -1105,12 +1175,11 @@ impl<H: SketchHasher> UnivMonQ<H> {
         let mut suffix = Vec::with_capacity(self.config.candidates * 2);
         let mut suffix_f2 = 0.0;
         let mut suffix_candidates = 0_usize;
-        let mut suffix_may_have_evicted = false;
+        let mut suffix_ever_evicted = false;
         for terminal in (0..self.levels.len()).rev() {
             suffix_f2 += recovery.physical_f2[terminal];
             suffix_candidates += recovery.by_terminal[terminal].len();
-            suffix_may_have_evicted |=
-                self.levels[terminal].candidate_scores.len() == self.config.candidates;
+            suffix_ever_evicted |= self.levels[terminal].ever_evicted;
             suffix.extend(recovery.by_terminal[terminal].iter().copied());
             suffix.sort_unstable_by(|left, right| {
                 right
@@ -1120,9 +1189,9 @@ impl<H: SketchHasher> UnivMonQ<H> {
             });
             suffix.truncate(self.config.candidates);
             let mut recovered = suffix.clone();
-            let complete = !suffix_may_have_evicted && suffix_candidates <= self.config.candidates;
+            let complete = !suffix_ever_evicted && suffix_candidates <= self.config.candidates;
             if !complete {
-                let threshold = (suffix_f2 / self.config.candidates as f64).sqrt();
+                let threshold = 2.0 * (suffix_f2 / self.config.candidates as f64).sqrt();
                 recovered.retain(|candidate| candidate.frequency >= threshold);
             }
             logical[terminal] = recovered;
@@ -1149,39 +1218,22 @@ impl<H: SketchHasher> UnivMonQ<H> {
             .map(|point| ordered_to_float(point.0))
     }
 
-    fn update_ordered_sample(&mut self, key: u64, priority: u64) {
+    fn update_ordered_sample(&mut self, occurrence: OrderedOccurrence) {
         let capacity = self.config.ordered_samples;
         if capacity == 0 {
             return;
         }
-        if self.ordered_frequencies.len() == capacity
-            && self
-                .ordered_heap
-                .peek()
-                .is_some_and(|largest| (priority, key) > *largest)
-        {
+        if self.ordered_heap.len() < capacity {
+            self.ordered_heap.push(occurrence);
             return;
         }
-        if let Some(count) = self.ordered_frequencies.get_mut(&key) {
-            *count = count.saturating_add(1);
-            return;
-        }
-        if self.ordered_frequencies.len() < capacity {
-            self.ordered_frequencies.insert(key, 1);
-            self.ordered_heap.push((priority, key));
-            return;
-        }
-        let replacement = self
+        if self
             .ordered_heap
             .peek()
-            .copied()
-            .filter(|largest| (priority, key) < *largest);
-        if let Some(largest) = replacement {
+            .is_some_and(|largest| occurrence < *largest)
+        {
             self.ordered_heap.pop();
-            let (_, evicted) = largest;
-            self.ordered_frequencies.remove(&evicted);
-            self.ordered_frequencies.insert(key, 1);
-            self.ordered_heap.push((priority, key));
+            self.ordered_heap.push(occurrence);
         }
     }
 
@@ -1190,27 +1242,22 @@ impl<H: SketchHasher> UnivMonQ<H> {
         if capacity == 0 {
             return;
         }
-        let mut combined = std::mem::take(&mut self.ordered_frequencies);
-        for (&key, &frequency) in &other.ordered_frequencies {
-            combined
-                .entry(key)
-                .and_modify(|left| *left = left.saturating_add(frequency))
-                .or_insert(frequency);
+        for &occurrence in &other.ordered_heap {
+            self.update_ordered_sample(occurrence);
         }
-        let mut retained: Vec<(u64, u64, u64)> = combined
-            .into_iter()
-            .map(|(key, frequency)| {
-                let priority = self.hash_layout.priority(self.hash_key(key));
-                (key, frequency, priority)
-            })
-            .collect();
-        retained.sort_unstable_by_key(|&(key, _, priority)| (priority, key));
-        retained.truncate(capacity);
-        self.ordered_frequencies = HashMap::with_capacity(capacity);
-        self.ordered_heap.clear();
-        for (key, frequency, priority) in retained {
-            self.ordered_frequencies.insert(key, frequency);
-            self.ordered_heap.push((priority, key));
+    }
+
+    #[inline(always)]
+    fn occurrence(&self, key: u64, sequence: u64) -> OrderedOccurrence {
+        let identity = (u128::from(self.source_id) << 64) | u128::from(sequence);
+        let priority = H::hash128_seeded(
+            self.config.hash_seed ^ OCCURRENCE_HASH_SEED_DOMAIN,
+            &DataInput::U128(identity),
+        );
+        OrderedOccurrence {
+            priority_high: (priority >> 64) as u64,
+            priority_low: priority as u64,
+            key,
         }
     }
 
@@ -1237,6 +1284,8 @@ impl<H: SketchHasher> UnivMonQ<H> {
 struct LevelWire {
     sketch: PackedCountSketch,
     candidates: Vec<(u64, u64)>,
+    #[serde(default)]
+    ever_evicted: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -1247,6 +1296,15 @@ struct UnivMonQWire {
     count: u64,
     min: Option<u64>,
     max: Option<u64>,
+    #[serde(default)]
+    source_id: u64,
+    #[serde(default)]
+    next_sequence: u64,
+    #[serde(default)]
+    ordered_occurrences: Vec<OrderedOccurrence>,
+    /// Version-1 distinct-key sample. It cannot be upgraded to an occurrence
+    /// sample without the discarded occurrence identities.
+    #[serde(default)]
     ordered_frequencies: Vec<(u64, u64)>,
 }
 
@@ -1254,6 +1312,17 @@ impl UnivMonQ<DefaultXxHasher> {
     /// Creates an empty sketch using Sketchlib's default XXH3 hasher.
     pub fn new(config: UnivMonQConfig) -> Result<Self, UnivMonQError> {
         Self::with_hasher(config)
+    }
+
+    /// Creates a sketch with an explicit ID for its update source.
+    ///
+    /// Use a stable, globally unique partition or shard ID when sketches may
+    /// be serialized or merged across processes.
+    pub fn new_with_source_id(
+        config: UnivMonQConfig,
+        source_id: u64,
+    ) -> Result<Self, UnivMonQError> {
+        Self::with_hasher_and_source_id(config, source_id)
     }
 
     /// Serializes the default-hasher sketch to native MessagePack bytes.
@@ -1270,14 +1339,11 @@ impl UnivMonQ<DefaultXxHasher> {
             levels.push(LevelWire {
                 sketch: level.sketch.clone(),
                 candidates,
+                ever_evicted: Some(level.ever_evicted),
             });
         }
-        let mut ordered_frequencies: Vec<(u64, u64)> = self
-            .ordered_frequencies
-            .iter()
-            .map(|(&key, &count)| (key, count))
-            .collect();
-        ordered_frequencies.sort_unstable();
+        let mut ordered_occurrences = self.ordered_heap.clone().into_vec();
+        ordered_occurrences.sort_unstable();
         let wire = UnivMonQWire {
             version: WIRE_VERSION,
             config: self.config,
@@ -1285,7 +1351,10 @@ impl UnivMonQ<DefaultXxHasher> {
             count: self.count,
             min: self.min,
             max: self.max,
-            ordered_frequencies,
+            source_id: self.source_id,
+            next_sequence: self.next_sequence,
+            ordered_occurrences,
+            ordered_frequencies: Vec::new(),
         };
         rmp_serde::to_vec_named(&wire)
     }
@@ -1293,13 +1362,19 @@ impl UnivMonQ<DefaultXxHasher> {
     /// Deserializes and validates native UnivMon-Q MessagePack state.
     pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
         let wire: UnivMonQWire = rmp_serde::from_slice(bytes)?;
-        if wire.version != WIRE_VERSION {
+        if wire.version != 1 && wire.version != WIRE_VERSION {
             return Err(decode_error(format!(
                 "unsupported UnivMon-Q wire version {}",
                 wire.version
             )));
         }
-        let mut result = Self::new(wire.config).map_err(|error| decode_error(error.to_string()))?;
+        if !wire.ordered_frequencies.is_empty() {
+            return Err(decode_error(
+                "version-1 distinct ordered samples cannot be upgraded to occurrence samples",
+            ));
+        }
+        let mut result = Self::new_with_source_id(wire.config, wire.source_id)
+            .map_err(|error| decode_error(error.to_string()))?;
         if wire.levels.len() != result.config.levels {
             return Err(decode_error("UnivMon-Q level count does not match config"));
         }
@@ -1332,12 +1407,16 @@ impl UnivMonQ<DefaultXxHasher> {
                 )));
             }
             let candidate_len = source.candidates.len();
+            let ever_evicted = source
+                .ever_evicted
+                .unwrap_or(candidate_len == result.config.candidates);
             let candidates: HashMap<u64, u64> = source.candidates.into_iter().collect();
             if candidates.len() != candidate_len {
                 return Err(decode_error("duplicate UnivMon-Q candidate keys"));
             }
             target.sketch = source.sketch;
             target.candidate_scores = candidates;
+            target.ever_evicted = ever_evicted;
             target.candidate_heap.clear();
             for (&key, &count) in &target.candidate_scores {
                 target.candidate_heap.push(Reverse((count, key)));
@@ -1354,24 +1433,34 @@ impl UnivMonQ<DefaultXxHasher> {
                 )));
             }
         }
-        if wire.ordered_frequencies.len() > result.config.ordered_samples {
+        if wire.ordered_occurrences.len() > result.config.ordered_samples {
             return Err(decode_error("UnivMon-Q ordered sample capacity exceeded"));
         }
-        let ordered_len = wire.ordered_frequencies.len();
-        let ordered: HashMap<u64, u64> = wire.ordered_frequencies.into_iter().collect();
-        if ordered.len() != ordered_len {
-            return Err(decode_error("duplicate UnivMon-Q ordered sample keys"));
+        let occurrence_len = wire.ordered_occurrences.len();
+        let unique_occurrences: HashSet<_> = wire.ordered_occurrences.iter().copied().collect();
+        if unique_occurrences.len() != occurrence_len {
+            return Err(decode_error("duplicate UnivMon-Q ordered occurrences"));
+        }
+        if result.config.ordered_samples == 0 && !wire.ordered_occurrences.is_empty() {
+            return Err(decode_error(
+                "UnivMon-Q has ordered state while ordered sampling is disabled",
+            ));
         }
         result.count = wire.count;
         result.min = wire.min;
         result.max = wire.max;
-        result.ordered_frequencies = ordered;
-        for &key in result.ordered_frequencies.keys() {
-            let priority = result.hash_layout.priority(result.hash_key(key));
-            result.ordered_heap.push((priority, key));
-        }
+        result.next_sequence = wire.next_sequence;
+        result.ordered_heap = BinaryHeap::from(wire.ordered_occurrences);
         Ok(result)
     }
+}
+
+fn allocate_source_id() -> u64 {
+    NEXT_SOURCE_ID
+        .fetch_update(AtomicOrdering::Relaxed, AtomicOrdering::Relaxed, |value| {
+            value.checked_add(1)
+        })
+        .expect("UnivMon-Q automatic source IDs exhausted")
 }
 
 fn validate_config(config: UnivMonQConfig) -> Result<(), UnivMonQError> {
@@ -1431,12 +1520,19 @@ fn estimate_g_sum_from<F>(heavy: &[Vec<RecoveredCandidate>], g: F) -> f64
 where
     F: Fn(f64) -> f64,
 {
+    estimate_keyed_sum_from(heavy, |_, frequency| g(frequency))
+}
+
+fn estimate_keyed_sum_from<F>(heavy: &[Vec<RecoveredCandidate>], g: F) -> f64
+where
+    F: Fn(u64, f64) -> f64,
+{
     let Some(last) = heavy.len().checked_sub(1) else {
         return 0.0;
     };
     let mut estimate: f64 = heavy[last]
         .iter()
-        .map(|candidate| g(candidate.frequency))
+        .map(|candidate| g(candidate.key, candidate.frequency))
         .sum();
     for level in (0..last).rev() {
         let correction: f64 = heavy[level]
@@ -1447,7 +1543,7 @@ where
                 } else {
                     -1.0
                 };
-                sign * g(candidate.frequency)
+                sign * g(candidate.key, candidate.frequency)
             })
             .sum();
         estimate = 2.0 * estimate + correction;
@@ -1503,6 +1599,23 @@ fn decode_error(message: impl Into<String>) -> RmpDecodeError {
 mod tests {
     use super::*;
 
+    #[derive(Serialize)]
+    struct LegacyLevelWire {
+        sketch: PackedCountSketch,
+        candidates: Vec<(u64, u64)>,
+    }
+
+    #[derive(Serialize)]
+    struct LegacyUnivMonQWire {
+        version: u8,
+        config: UnivMonQConfig,
+        levels: Vec<LegacyLevelWire>,
+        count: u64,
+        min: Option<u64>,
+        max: Option<u64>,
+        ordered_frequencies: Vec<(u64, u64)>,
+    }
+
     fn tiny_config() -> UnivMonQConfig {
         UnivMonQConfig {
             levels: 8,
@@ -1517,12 +1630,166 @@ mod tests {
     }
 
     #[test]
+    fn candidate_eviction_history_distinguishes_full_from_truncated() {
+        let mut level = Level::new(32, 1, 64, 2);
+        level.update(1, 1, 5);
+        level.update(2, 2, 5);
+        assert!(!level.ever_evicted, "filling the table is not an eviction");
+
+        level.update(3, 3, 5);
+        assert!(level.ever_evicted);
+        level.clear();
+        assert!(!level.ever_evicted);
+    }
+
+    #[test]
+    fn candidate_merge_uses_zero_error_for_full_complete_summary() {
+        let mut left = Level::new(32, 1, 64, 2);
+        for _ in 0..100 {
+            left.update(1, 1, 5);
+        }
+        left.update(2, 2, 5);
+        assert!(!left.ever_evicted);
+
+        let mut right = Level::new(32, 1, 64, 2);
+        right.update(3, 3, 5);
+        right.update(3, 3, 5);
+        left.merge(&right, 5, u128::from);
+
+        assert!(left.ever_evicted, "the merged union exceeded capacity");
+        assert_eq!(left.candidate_scores.get(&1), Some(&100));
+        assert_eq!(left.candidate_scores.get(&3), Some(&2));
+        assert!(!left.candidate_scores.contains_key(&2));
+    }
+
+    #[test]
+    fn native_messagepack_preserves_candidate_eviction_history() {
+        let config = UnivMonQConfig {
+            levels: 2,
+            candidates: 1,
+            ..tiny_config()
+        };
+        let mut sketch = UnivMonQ::new(config).unwrap();
+        for value in [1.0, 2.0, 3.0] {
+            sketch.update(&value);
+        }
+        assert!(sketch.levels.iter().any(|level| level.ever_evicted));
+
+        let bytes = sketch.serialize_to_bytes().unwrap();
+        let decoded = UnivMonQ::deserialize_from_bytes(&bytes).unwrap();
+        let original: Vec<bool> = sketch
+            .levels
+            .iter()
+            .map(|level| level.ever_evicted)
+            .collect();
+        let restored: Vec<bool> = decoded
+            .levels
+            .iter()
+            .map(|level| level.ever_evicted)
+            .collect();
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn legacy_full_candidate_table_decodes_as_possibly_evicted() {
+        let config = UnivMonQConfig {
+            levels: 2,
+            candidates: 1,
+            ordered_samples: 0,
+            ..tiny_config()
+        };
+        let mut sketch = UnivMonQ::new(config).unwrap();
+        sketch.update(&7.0);
+        let full_level = sketch
+            .levels
+            .iter()
+            .position(|level| level.candidate_scores.len() == config.candidates)
+            .unwrap();
+        assert!(!sketch.levels[full_level].ever_evicted);
+
+        let legacy = LegacyUnivMonQWire {
+            version: WIRE_VERSION,
+            config,
+            levels: sketch
+                .levels
+                .iter()
+                .map(|level| LegacyLevelWire {
+                    sketch: level.sketch.clone(),
+                    candidates: level
+                        .candidate_scores
+                        .iter()
+                        .map(|(&key, &score)| (key, score))
+                        .collect(),
+                })
+                .collect(),
+            count: sketch.count,
+            min: sketch.min,
+            max: sketch.max,
+            ordered_frequencies: Vec::new(),
+        };
+        let bytes = rmp_serde::to_vec_named(&legacy).unwrap();
+        let decoded = UnivMonQ::deserialize_from_bytes(&bytes).unwrap();
+        assert!(decoded.levels[full_level].ever_evicted);
+    }
+
+    #[test]
+    fn l2_heavy_candidate_survives_a_diffuse_tail() {
+        let config = UnivMonQConfig {
+            levels: 2,
+            width: 4096,
+            depth: 5,
+            counter_bits: 64,
+            candidates: 32,
+            ordered_samples: 0,
+            ..tiny_config()
+        };
+        let mut sketch = UnivMonQ::new(config).unwrap();
+        let terminal = 0;
+        let target = (0_u64..)
+            .find(|value| sketch.sample_level(float_to_ordered(*value as f64)) == terminal)
+            .unwrap();
+        for _ in 0..200 {
+            sketch.add(&target);
+        }
+
+        let mut distinct_tail = 0_usize;
+        for value in 1_u64.. {
+            if value != target && sketch.sample_level(float_to_ordered(value as f64)) == terminal {
+                sketch.add(&value);
+                distinct_tail += 1;
+                if distinct_tail == 50_000 {
+                    break;
+                }
+            }
+        }
+
+        let exact_f2 = 200_f64.powi(2) + distinct_tail as f64;
+        let l2_threshold = (exact_f2 / config.candidates as f64).sqrt();
+        assert!(200.0 > 2.0 * l2_threshold);
+        let target_key = float_to_ordered(target as f64);
+        assert!(sketch.levels[terminal].ever_evicted);
+        assert!(
+            sketch.levels[terminal]
+                .candidate_scores
+                .contains_key(&target_key),
+            "an item above twice the L2 threshold must remain recoverable"
+        );
+        let recovery = sketch.recover_candidates();
+        assert!(
+            sketch.logical_heavy_sets_from(&recovery)[terminal]
+                .iter()
+                .any(|candidate| candidate.key == target_key)
+        );
+    }
+
+    #[test]
     fn exact_for_tiny_frequency_vector() {
         let mut sketch = UnivMonQ::new(tiny_config()).unwrap();
         for value in [5.0, 1.0, 2.0, 2.0, 9.0, 5.0, 5.0] {
             sketch.update(&value);
         }
         assert_eq!(sketch.rank(2.0), Some(3));
+        assert_eq!(sketch.estimate_rank_universal(2.0), Some(3));
         assert_eq!(sketch.rank(5.0), Some(6));
         assert_eq!(sketch.quantile(0.5), Some(5.0));
         assert_eq!(sketch.quantile(0.0), Some(1.0));
@@ -1530,8 +1797,7 @@ mod tests {
         assert_eq!(sketch.estimate_frequency(5.0), 3);
         assert_eq!(sketch.estimate_distinct(), 4.0);
         assert_eq!(sketch.estimate_f2(), 15.0);
-        assert_eq!(sketch.estimate_f3(), 37.0);
-        assert_eq!(sketch.estimate_g_sum(|frequency| frequency.powi(4)), 99.0);
+        assert_eq!(sketch.estimate_g_sum(|frequency| frequency), 7.0);
         assert_eq!(sketch.heavy_hitters(1), vec![(5.0, 3)]);
 
         let query = sketch.prepare_queries();
@@ -1539,10 +1805,10 @@ mod tests {
         assert_eq!(query.estimate_frequency(5.0), 3);
         assert_eq!(query.estimate_distinct(), 4.0);
         assert_eq!(query.estimate_f2(), 15.0);
-        assert_eq!(query.estimate_f3(), 37.0);
-        assert_eq!(query.estimate_g_sum(|frequency| frequency.powi(4)), 99.0);
+        assert_eq!(query.estimate_g_sum(|frequency| frequency), 7.0);
         assert_eq!(query.heavy_hitters(1), vec![(5.0, 3)]);
         assert_eq!(query.rank(2.0), Some(3));
+        assert_eq!(query.estimate_rank_universal(2.0), Some(3));
         assert_eq!(
             query.quantiles(&[0.0, 0.5, 1.0]),
             vec![Some(1.0), Some(5.0), Some(9.0)]
@@ -1623,25 +1889,22 @@ mod tests {
 
         let direct_f0 = sketch.estimate_distinct();
         let direct_f2 = sketch.estimate_f2();
-        let direct_f3 = sketch.estimate_f3();
-        let direct_g4 = sketch.estimate_g_sum(|frequency| frequency.powi(4));
+        let direct_l1 = sketch.estimate_g_sum(|frequency| frequency);
         let direct_entropy = sketch.estimate_entropy();
         let direct_heavy = sketch.heavy_hitters(5);
         let direct_rank = sketch.rank(500.0);
+        let direct_universal_rank = sketch.estimate_rank_universal(500.0);
         let direct_quantiles = sketch.quantiles(&[0.1, 0.5, 0.9, 0.99]);
         let direct_cdf = sketch.cdf();
 
         let query = sketch.prepare_queries();
         assert_eq!(query.estimate_distinct(), direct_f0);
         assert_eq!(query.estimate_f2(), direct_f2);
-        assert_eq!(query.estimate_f3(), direct_f3);
-        assert_eq!(
-            query.estimate_g_sum(|frequency| frequency.powi(4)),
-            direct_g4
-        );
+        assert_eq!(query.estimate_g_sum(|frequency| frequency), direct_l1);
         assert_eq!(query.estimate_entropy(), direct_entropy);
         assert_eq!(query.heavy_hitters(5), direct_heavy);
         assert_eq!(query.rank(500.0), direct_rank);
+        assert_eq!(query.estimate_rank_universal(500.0), direct_universal_rank);
         assert_eq!(query.quantiles(&[0.1, 0.5, 0.9, 0.99]), direct_quantiles);
         assert_eq!(query.cdf(), direct_cdf);
     }
@@ -1655,9 +1918,53 @@ mod tests {
         let bytes = sketch.serialize_to_bytes().unwrap();
         let decoded = UnivMonQ::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(decoded.config(), sketch.config());
+        assert_eq!(decoded.source_id(), sketch.source_id());
         assert_eq!(decoded.count(), sketch.count());
         assert_eq!(decoded.cdf(), sketch.cdf());
         assert_eq!(decoded.estimate_f2(), sketch.estimate_f2());
+    }
+
+    #[test]
+    fn occurrence_sample_merge_is_associative() {
+        fn shard(source_id: u64, offset: u64) -> UnivMonQ {
+            let mut sketch = UnivMonQ::new_with_source_id(tiny_config(), source_id).unwrap();
+            for index in 0..1_000_u64 {
+                sketch.add(&((index.wrapping_mul(17) + offset) % 991));
+            }
+            sketch
+        }
+
+        let (a, b, c) = (shard(10, 0), shard(20, 1), shard(30, 2));
+        let mut left_associative = a.clone();
+        left_associative.merge(&b).unwrap();
+        left_associative.merge(&c).unwrap();
+
+        let mut right_branch = b;
+        right_branch.merge(&c).unwrap();
+        let mut right_associative = a;
+        right_associative.merge(&right_branch).unwrap();
+
+        let mut left_sample = left_associative.ordered_heap.clone().into_sorted_vec();
+        let mut right_sample = right_associative.ordered_heap.clone().into_sorted_vec();
+        left_sample.sort_unstable();
+        right_sample.sort_unstable();
+        assert_eq!(left_sample, right_sample);
+        assert_eq!(left_associative.cdf(), right_associative.cdf());
+    }
+
+    #[test]
+    fn legacy_distinct_ordered_sample_is_rejected() {
+        let legacy = LegacyUnivMonQWire {
+            version: 1,
+            config: tiny_config(),
+            levels: Vec::new(),
+            count: 1,
+            min: Some(float_to_ordered(1.0)),
+            max: Some(float_to_ordered(1.0)),
+            ordered_frequencies: vec![(float_to_ordered(1.0), 1)],
+        };
+        let bytes = rmp_serde::to_vec_named(&legacy).unwrap();
+        assert!(UnivMonQ::deserialize_from_bytes(&bytes).is_err());
     }
 
     #[test]

--- a/src/sketch_framework/univmon_q.rs
+++ b/src/sketch_framework/univmon_q.rs
@@ -6,7 +6,8 @@
 //! A separate coordinated bottom-k sample of stream occurrences is keyed by
 //! `(source_id, local_sequence)`. Query-time recursion reconstructs the
 //! logical UnivMon hierarchy; reliable heavy frequencies are combined with
-//! the residual occurrence sample for rank and quantile estimates.
+//! the residual occurrence sample for rank and quantile estimates. The same
+//! sample assists entropy when candidate recovery is incomplete.
 //!
 //! Provenance: adapted from the experimental `zaoxing/univmon-quantile`
 //! implementation and integrated with Sketchlib's numeric input, pluggable
@@ -160,6 +161,8 @@ pub struct UnivMonQQuery<'a, H: SketchHasher = DefaultXxHasher> {
     sketch: &'a UnivMonQ<H>,
     logical_heavy: Vec<Vec<RecoveredCandidate>>,
     heavy_hitters: Vec<RecoveredCandidate>,
+    occurrence_entropy: Option<f64>,
+    candidate_recovery_complete: bool,
     cdf: Vec<UnivMonQPoint>,
 }
 
@@ -594,8 +597,13 @@ impl<'a, H: SketchHasher> UnivMonQQuery<'a, H> {
             .max(0.0)
     }
 
-    /// Estimated Shannon entropy in nats.
-    pub fn estimate_entropy(&self) -> f64 {
+    /// Exact L1 norm for the insertion-only frequency vector.
+    pub fn estimate_l1(&self) -> f64 {
+        self.count() as f64
+    }
+
+    /// Shannon entropy estimate from the original UnivMon recurrence, in nats.
+    pub fn estimate_entropy_universal(&self) -> f64 {
         if self.count() == 0 {
             return 0.0;
         }
@@ -607,6 +615,37 @@ impl<'a, H: SketchHasher> UnivMonQQuery<'a, H> {
             }
         });
         ((self.count() as f64).ln() - frequency_log_frequency / self.count() as f64).max(0.0)
+    }
+
+    /// Assisted Shannon entropy estimate in nats.
+    ///
+    /// The universal recurrence is retained for diffuse streams and complete
+    /// candidate recovery. Concentrated streams with incomplete recovery use
+    /// the coordinated occurrence sample instead.
+    pub fn estimate_entropy(&self) -> f64 {
+        let universal = self.estimate_entropy_universal();
+        if self.count() == 0
+            || self.occurrence_entropy.is_none()
+            || self.candidate_recovery_complete
+        {
+            return universal;
+        }
+        let concentration = self.estimate_f2() / (self.count() as f64).powi(2);
+        if concentration < 1.0 / self.sketch.ordered_heap.len() as f64 {
+            universal
+        } else {
+            self.estimate_entropy_occurrence().unwrap_or(universal)
+        }
+    }
+
+    /// Experimental occurrence-sample entropy estimate in nats.
+    ///
+    /// This uses `H = E[ln(N / f_X)]` for an occurrence-uniform value `X`,
+    /// with frequencies supplied by the terminal CountSketch. It requires the
+    /// coordinated ordered sample and is primarily useful as an assisted
+    /// alternative to the universal recurrence.
+    pub fn estimate_entropy_occurrence(&self) -> Option<f64> {
+        self.occurrence_entropy
     }
 
     /// Recovered heavy values and estimated frequencies in descending order.
@@ -871,7 +910,10 @@ impl<H: SketchHasher> UnivMonQ<H> {
         let recovery = self.recover_candidates();
         let logical_heavy = self.logical_heavy_sets_from(&recovery);
         let heavy_hitters = self.top_candidates_from(&recovery);
+        let candidate_recovery_complete = self.candidate_recovery_complete();
         let ordered_heavy = self.assisted_ordered_heavy(&logical_heavy, &heavy_hitters);
+        let entropy_heavy = Self::assisted_entropy_heavy(&logical_heavy);
+        let occurrence_entropy = self.entropy_from_occurrences(&entropy_heavy);
         let cdf = self
             .cdf_keys_from(&ordered_heavy)
             .into_iter()
@@ -884,6 +926,8 @@ impl<H: SketchHasher> UnivMonQ<H> {
             sketch: self,
             logical_heavy,
             heavy_hitters,
+            occurrence_entropy,
+            candidate_recovery_complete,
             cdf,
         }
     }
@@ -915,8 +959,13 @@ impl<H: SketchHasher> UnivMonQ<H> {
             .max(0.0)
     }
 
-    /// Estimated Shannon entropy in nats.
-    pub fn estimate_entropy(&self) -> f64 {
+    /// Exact L1 norm for the insertion-only frequency vector.
+    pub fn estimate_l1(&self) -> f64 {
+        self.count as f64
+    }
+
+    /// Shannon entropy estimate from the original UnivMon recurrence, in nats.
+    pub fn estimate_entropy_universal(&self) -> f64 {
         if self.is_empty() {
             return 0.0;
         }
@@ -928,6 +977,105 @@ impl<H: SketchHasher> UnivMonQ<H> {
             }
         });
         ((self.count as f64).ln() - frequency_log_frequency / self.count as f64).max(0.0)
+    }
+
+    /// Assisted Shannon entropy estimate in nats.
+    pub fn estimate_entropy(&self) -> f64 {
+        if self.is_empty() {
+            return 0.0;
+        }
+        let recovery = self.recover_candidates();
+        let logical_heavy = self.logical_heavy_sets_from(&recovery);
+        let frequency_log_frequency = estimate_g_sum_from(&logical_heavy, |frequency| {
+            if frequency > 0.0 {
+                frequency * frequency.ln()
+            } else {
+                0.0
+            }
+        });
+        let universal =
+            ((self.count as f64).ln() - frequency_log_frequency / self.count as f64).max(0.0);
+        if self.ordered_heap.is_empty() || self.candidate_recovery_complete() {
+            return universal;
+        }
+        let f2 = estimate_g_sum_from(&logical_heavy, |frequency| frequency * frequency).max(0.0);
+        let concentration = f2 / (self.count as f64).powi(2);
+        if concentration < 1.0 / self.ordered_heap.len() as f64 {
+            universal
+        } else {
+            let assisted_heavy = Self::assisted_entropy_heavy(&logical_heavy);
+            self.entropy_from_occurrences(&assisted_heavy)
+                .unwrap_or(universal)
+        }
+    }
+
+    /// Experimental occurrence-sample entropy estimate in nats.
+    pub fn estimate_entropy_occurrence(&self) -> Option<f64> {
+        if self.is_empty() {
+            return Some(0.0);
+        }
+        let recovery = self.recover_candidates();
+        let logical_heavy = self.logical_heavy_sets_from(&recovery);
+        let assisted_heavy = Self::assisted_entropy_heavy(&logical_heavy);
+        self.entropy_from_occurrences(&assisted_heavy)
+    }
+
+    fn assisted_entropy_heavy(logical_heavy: &[Vec<RecoveredCandidate>]) -> Vec<(u64, f64)> {
+        logical_heavy
+            .first()
+            .into_iter()
+            .flatten()
+            .take(64)
+            .map(|candidate| (candidate.key, candidate.frequency))
+            .collect()
+    }
+
+    fn entropy_from_occurrences(&self, assisted_heavy: &[(u64, f64)]) -> Option<f64> {
+        if self.is_empty() {
+            return Some(0.0);
+        }
+        if self.ordered_heap.is_empty() {
+            return None;
+        }
+        let total = self.count as f64;
+        let mut heavy: BTreeMap<u64, f64> = assisted_heavy.iter().copied().collect();
+        let heavy_total = heavy.values().sum::<f64>();
+        if heavy_total > total {
+            let scale = total / heavy_total;
+            for frequency in heavy.values_mut() {
+                *frequency *= scale;
+            }
+        }
+        let heavy_entropy = heavy
+            .values()
+            .map(|frequency| {
+                let probability = frequency / total;
+                if probability > 0.0 {
+                    -probability * probability.ln()
+                } else {
+                    0.0
+                }
+            })
+            .sum::<f64>();
+        let residual_mass = (1.0 - heavy.values().sum::<f64>() / total).max(0.0);
+        let mut sampled_keys = BTreeMap::<u64, usize>::new();
+        for occurrence in &self.ordered_heap {
+            if !heavy.contains_key(&occurrence.key) {
+                *sampled_keys.entry(occurrence.key).or_default() += 1;
+            }
+        }
+        let residual_samples = sampled_keys.values().sum::<usize>();
+        if residual_samples == 0 {
+            return (residual_mass == 0.0).then_some(heavy_entropy);
+        }
+        let residual_entropy = sampled_keys
+            .into_iter()
+            .map(|(key, multiplicity)| {
+                let frequency = (self.frequency_key(key).max(1) as f64).min(total);
+                multiplicity as f64 * (total / frequency).ln()
+            })
+            .sum::<f64>();
+        Some((heavy_entropy + residual_mass * residual_entropy / residual_samples as f64).max(0.0))
     }
 
     /// Recovered heavy values and estimated frequencies in descending order.
@@ -1277,6 +1425,16 @@ impl<H: SketchHasher> UnivMonQ<H> {
         self.levels[terminal]
             .sketch
             .estimate(hash, self.hash_layout.bucket_bits)
+    }
+
+    fn candidate_recovery_complete(&self) -> bool {
+        self.levels.iter().all(|level| !level.ever_evicted)
+            && self
+                .levels
+                .iter()
+                .map(|level| level.candidate_scores.len())
+                .sum::<usize>()
+                <= self.config.candidates
     }
 }
 
@@ -1630,6 +1788,36 @@ mod tests {
     }
 
     #[test]
+    fn exact_l1_and_occurrence_entropy_for_known_distribution() {
+        let config = UnivMonQConfig {
+            levels: 8,
+            width: 4_096,
+            width_halving_period: 0,
+            depth: 5,
+            counter_bits: 64,
+            candidates: 1,
+            ordered_samples: 100,
+            hash_seed: 17,
+        };
+        let mut sketch = UnivMonQ::new(config).unwrap();
+        for _ in 0..80 {
+            sketch.update(&0.0);
+        }
+        for _ in 0..20 {
+            sketch.update(&1.0);
+        }
+
+        let expected_entropy = -(0.8_f64 * 0.8_f64.ln() + 0.2_f64 * 0.2_f64.ln());
+        assert_eq!(sketch.estimate_l1(), 100.0);
+        assert!((sketch.estimate_entropy_occurrence().unwrap() - expected_entropy).abs() < 1e-12);
+        assert!((sketch.estimate_entropy() - expected_entropy).abs() < 1e-12);
+
+        let query = sketch.prepare_queries();
+        assert_eq!(query.estimate_l1(), 100.0);
+        assert!((query.estimate_entropy() - expected_entropy).abs() < 1e-12);
+    }
+
+    #[test]
     fn candidate_eviction_history_distinguishes_full_from_truncated() {
         let mut level = Level::new(32, 1, 64, 2);
         level.update(1, 1, 5);
@@ -1889,8 +2077,10 @@ mod tests {
 
         let direct_f0 = sketch.estimate_distinct();
         let direct_f2 = sketch.estimate_f2();
-        let direct_l1 = sketch.estimate_g_sum(|frequency| frequency);
+        let direct_l1 = sketch.estimate_l1();
+        let direct_linear_g_sum = sketch.estimate_g_sum(|frequency| frequency);
         let direct_entropy = sketch.estimate_entropy();
+        let direct_universal_entropy = sketch.estimate_entropy_universal();
         let direct_heavy = sketch.heavy_hitters(5);
         let direct_rank = sketch.rank(500.0);
         let direct_universal_rank = sketch.estimate_rank_universal(500.0);
@@ -1900,8 +2090,13 @@ mod tests {
         let query = sketch.prepare_queries();
         assert_eq!(query.estimate_distinct(), direct_f0);
         assert_eq!(query.estimate_f2(), direct_f2);
-        assert_eq!(query.estimate_g_sum(|frequency| frequency), direct_l1);
+        assert_eq!(query.estimate_l1(), direct_l1);
+        assert_eq!(
+            query.estimate_g_sum(|frequency| frequency),
+            direct_linear_g_sum
+        );
         assert_eq!(query.estimate_entropy(), direct_entropy);
+        assert_eq!(query.estimate_entropy_universal(), direct_universal_entropy);
         assert_eq!(query.heavy_hitters(5), direct_heavy);
         assert_eq!(query.rank(500.0), direct_rank);
         assert_eq!(query.estimate_rank_universal(500.0), direct_universal_rank);


### PR DESCRIPTION
## Fixed UnivMon issues

- Corrects merge semantics for total stream weight, CountL2HH row norms, and candidate re-estimation from merged counters.
- Restores per-layer L2 maintenance for standard updates and Joltik terminal-only reconstruction for `fast_insert`.
- Tracks candidate completeness and explicit `ever_evicted` state through updates, merges, and native MessagePack.
- Makes L1 exact for non-negative streams in UnivMon, UnivMonPyramid, and UnivMon-Q instead of using a noisy generic recurrence.

## Experimental UnivMon-Q

- Adds a mergeable terminal-stratum UnivMon core with coordinated bottom-k occurrence sampling for rank, CDF, and quantiles.
- Adds adaptive entropy: the original recurrence handles diffuse or complete states; concentrated incomplete states use recovered-heavy entropy plus conditional residual occurrence sampling.
- Exposes `estimate_l1`, `estimate_entropy_universal`, and `estimate_entropy_occurrence`.
- Keeps F3 outside the advertised theoretical profile.
- Adds equal-memory and dedicated entropy-stress evaluators.

## UnivMon comparison

Release-scale sweep: 1M observations, 100K domain, seven Zipf skews, five trials, eight-way merges.

| Metric (worst p95) | UnivMon | Compact UnivMon-Q | Equal-memory UnivMon-Q |
| --- | ---: | ---: | ---: |
| Point-frequency nRMSE | 0.378% | 0.383% | 0.379% |
| F0 relative error | 9.52% | 12.04% | **6.13%** |
| F2 relative error | 4.96% | 10.12% | **2.63%** |
| Entropy relative error | 17.32% | **3.05%** | **3.05%** |
| L1 relative error | 0% exact | 0% exact | 0% exact |
| Quantile mean rank error | n/a | 0.45% | 0.45% |
| Maximum CDF error | n/a | 2.42% | 2.42% |

The 3.05% entropy result precedes the final heavy/residual variance refinement and is conservative for the current estimator.

Compact UnivMon-Q uses 0.707 MiB estimated memory versus at least 2.188 MiB of UnivMon counters before heap metadata. It is 8–204x faster on updates, 16–52x faster on eight-way merges, and 2.6–4.4x faster for all-metric query batches.

The conservative equal-memory profile fits all UnivMon-Q state within UnivMon's counter bytes alone. It remains 7.4–199x faster on updates, 13.2–18.3x faster on merge, and 1.4–2.2x faster on query batches.

## Entropy stress evaluation

The final assisted estimator was evaluated on 144 datasets / 576 sketch runs: four uniform supports, nine Zipf exponents, five 50%–99.99% heavy-head/diffuse-tail mixtures, eight trials, and eight-way merges.

| Profile | Samples | Worst adaptive entropy p95 |
| --- | ---: | ---: |
| Compact | 512 | 4.86% |
| Compact default | 4,096 | **1.75%** |
| Compact large | 16,384 | **1.46%** |
| Equal-memory | 4,096 | **1.36%** |

A raw occurrence estimator exposed 22.76% p95 error for a 99% heavy head. Computing recovered-heavy entropy directly and sampling only conditional residual entropy reduced it to 0.32%. Entropy was bit-identical across left-fold and balanced merge trees in all 576 evaluations.

## Validation

- `cargo test --all-targets`: 505 library tests plus all integration/example targets pass
- `cargo test --doc`: 20 pass
- `cargo clippy --all-targets -- -D warnings`: pass
- Formatting and diff checks pass
- Full methodology and guarantee boundaries: `docs/univmon_q_evaluation.md` and `docs/api/api_univmon_q.md`