### PR TITLE
Export impl_hll_bucket_list! so callers can build any HLL precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ signals a backwards-compatible change.
   noisy generic recurrence.
 
 ### Added
+- **Export the `impl_hll_bucket_list!` macro.** Downstream crates can now
+  generate an `HllRegisterStorage` type at any precision (e.g. `lg_k = 18`)
+  instead of being limited to the built-in `HllBucketListP12/P14/P16`.
 - **Experimental UnivMon-Q core sketch.** Adds `UnivMonQ<H>`, a Joltik-style
   terminal-stratum UnivMon implementation extended with an adaptively assisted
   occurrence sample for entropy, rank, CDF, and quantile estimates. The sketch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ signals a backwards-compatible change.
 - **Export the `impl_hll_bucket_list!` macro.** Downstream crates can now
   generate an `HllRegisterStorage` type at any precision (e.g. `lg_k = 18`)
   instead of being limited to the built-in `HllBucketListP12/P14/P16`.
+- **Heap-allocate HLL register storage.** `impl_hll_bucket_list!`'s `Default`
+  and `Deserialize` no longer build an `[u8; NUM_REGISTERS]` value on the
+  stack before boxing it, which overflowed the stack in debug builds at
+  larger precisions. The MessagePack encoding is unchanged.
 - **`ErtlMLE` estimation at any precision.** `HyperLogLogImpl::<ErtlMLE, _>::estimate`
   is now a generic impl instead of one generated per storage type, so it works
   with custom `impl_hll_bucket_list!` precisions rather than only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ signals a backwards-compatible change.
 - **Export the `impl_hll_bucket_list!` macro.** Downstream crates can now
   generate an `HllRegisterStorage` type at any precision (e.g. `lg_k = 18`)
   instead of being limited to the built-in `HllBucketListP12/P14/P16`.
+- **`ErtlMLE` estimation at any precision.** `HyperLogLogImpl::<ErtlMLE, _>::estimate`
+  is now a generic impl instead of one generated per storage type, so it works
+  with custom `impl_hll_bucket_list!` precisions rather than only
+  `HllBucketListP12/P14/P16`.
 - **Experimental UnivMon-Q core sketch.** Adds `UnivMonQ<H>`, a Joltik-style
   terminal-stratum UnivMon implementation extended with an adaptively assisted
   occurrence sample for entropy, rank, CDF, and quantile estimates. The sketch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ signals a backwards-compatible change.
 
 ### Fixed
 
+- **Heap-allocate HLL register storage.** `impl_hll_bucket_list!`'s `Default`
+  and `Deserialize` no longer build an `[u8; NUM_REGISTERS]` value on the
+  stack before boxing it, which overflowed the stack in debug builds at
+  larger precisions. The MessagePack encoding is unchanged.
 - Corrected UnivMon and UnivMonPyramid merge semantics: aggregate stream
   weight, recomputed CountL2HH row norms, and merged-counter candidate
   re-estimation.
@@ -29,10 +33,6 @@ signals a backwards-compatible change.
 - **Export the `impl_hll_bucket_list!` macro.** Downstream crates can now
   generate an `HllRegisterStorage` type at any precision (e.g. `lg_k = 18`)
   instead of being limited to the built-in `HllBucketListP12/P14/P16`.
-- **Heap-allocate HLL register storage.** `impl_hll_bucket_list!`'s `Default`
-  and `Deserialize` no longer build an `[u8; NUM_REGISTERS]` value on the
-  stack before boxing it, which overflowed the stack in debug builds at
-  larger precisions. The MessagePack encoding is unchanged.
 - **`ErtlMLE` estimation at any precision.** `HyperLogLogImpl::<ErtlMLE, _>::estimate`
   is now a generic impl instead of one generated per storage type, so it works
   with custom `impl_hll_bucket_list!` precisions rather than only

--- a/docs/features.md
+++ b/docs/features.md
@@ -21,6 +21,7 @@ This document provides a high-level overview of implemented and planned features
 - `DataInput` - Unified type system for all sketches
 - `Vector1D`, `Vector2D` - Flat storage structures for sketch counters
 - `impl_fixed_matrix!` macro - Define compile-time fixed-size matrix types with any counter type and dimensions
+- `impl_hll_bucket_list!` macro - Define compile-time fixed-size HLL register storage types at any precision (the crate ships `lg_k` 12/14/16)
 - `CommonHeap` & `HHHeap` - Generic and specialized heaps for heavy hitter tracking
 - Deterministic hashing with seed management
 - Pluggable hash via the `SketchHasher` trait — swap the hash function without changing sketch code

--- a/src/common/structures/fixed_structure.rs
+++ b/src/common/structures/fixed_structure.rs
@@ -84,10 +84,30 @@ macro_rules! impl_hll_bucket_list {
             pub const P_MASK: u64 = ($num_registers as u64) - 1;
         }
 
+        impl $name {
+            /// Allocates a zeroed register array directly on the heap.
+            ///
+            /// `Box::new([0_u8; N])` would build the array as a stack value
+            /// first and copy it into the box; release builds elide that
+            /// temporary, but debug builds do not and overflow the stack at
+            /// larger precisions. Going through a boxed slice never
+            /// materializes an `[u8; N]` value, so stack use is constant in
+            /// every profile.
+            fn zeroed_registers() -> Box<[u8; $num_registers]> {
+                let registers: Box<[u8]> = ::std::vec![0_u8; $num_registers].into_boxed_slice();
+                match <Box<[u8; $num_registers]> as ::std::convert::TryFrom<Box<[u8]>>>::try_from(
+                    registers,
+                ) {
+                    Ok(registers) => registers,
+                    Err(_) => unreachable!("boxed slice length is the register count"),
+                }
+            }
+        }
+
         impl Default for $name {
             fn default() -> Self {
                 Self {
-                    registers: Box::new([0_u8; $num_registers]),
+                    registers: Self::zeroed_registers(),
                 }
             }
         }
@@ -109,11 +129,44 @@ macro_rules! impl_hll_bucket_list {
             where
                 D: $crate::__private::serde::Deserializer<'de>,
             {
-                let data: [u8; $num_registers] =
-                    $crate::__private::serde_big_array::BigArray::deserialize(deserializer)?;
-                Ok(Self {
-                    registers: Box::new(data),
-                })
+                // Fills a heap-allocated array element by element. The
+                // encoding is the same fixed-length sequence `BigArray`
+                // writes, but decoding never builds an `[u8; N]` on the
+                // stack -- see `zeroed_registers`.
+                struct RegisterVisitor;
+
+                impl<'de> $crate::__private::serde::de::Visitor<'de> for RegisterVisitor {
+                    type Value = $name;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::std::fmt::Formatter,
+                    ) -> ::std::fmt::Result {
+                        ::std::write!(formatter, "an array of {} bytes", $num_registers)
+                    }
+
+                    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: $crate::__private::serde::de::SeqAccess<'de>,
+                    {
+                        let mut out = <$name as ::std::default::Default>::default();
+                        for i in 0..$num_registers {
+                            match seq.next_element::<u8>()? {
+                                Some(byte) => out.registers[i] = byte,
+                                None => {
+                                    return Err(
+                                        <A::Error as $crate::__private::serde::de::Error>::invalid_length(
+                                            i, &self,
+                                        ),
+                                    );
+                                }
+                            }
+                        }
+                        Ok(out)
+                    }
+                }
+
+                deserializer.deserialize_tuple($num_registers, RegisterVisitor)
             }
         }
 

--- a/src/common/structures/fixed_structure.rs
+++ b/src/common/structures/fixed_structure.rs
@@ -15,6 +15,14 @@ pub const DEFAULT_ROW_NUM: usize = 3;
 pub const DEFAULT_COL_NUM: usize = 4096;
 
 /// Register storage interface used by HyperLogLog implementations.
+///
+/// Implementations must keep the constants consistent:
+/// `NUM_REGISTERS == 1 << PRECISION`, `REGISTER_BITS == 64 - PRECISION`, and
+/// `P_MASK == NUM_REGISTERS - 1`, with `PRECISION >= 1`. The estimators rely
+/// on these relations (a register rank never exceeds `REGISTER_BITS + 1`), so
+/// an inconsistent hand-written impl silently produces wrong estimates.
+/// [`impl_hll_bucket_list!`](crate::impl_hll_bucket_list) enforces them at
+/// compile time.
 pub trait HllRegisterStorage:
     Clone + std::fmt::Debug + Default + Serialize + for<'de> Deserialize<'de>
 {
@@ -54,6 +62,12 @@ pub trait HllRegisterStorage:
 /// [`HllRegisterStorage`], so it plugs straight into `HyperLogLogImpl` and
 /// `HyperLogLogHIPImpl` and keeps the same monomorphized fast path.
 ///
+/// `num_registers` must be exactly `1 << precision`, and `precision` must be
+/// at least 1; both are checked at compile time. The register index is
+/// `(hash >> REGISTER_BITS) & P_MASK`, so a mismatched pair would address only
+/// `1 << precision` registers while dividing by `num_registers`, silently
+/// biasing every estimate.
+///
 /// ```
 /// use asap_sketchlib::sketches::hll::HyperLogLogImpl;
 /// use asap_sketchlib::{Classic, DataInput};
@@ -66,11 +80,22 @@ pub trait HllRegisterStorage:
 /// ```
 macro_rules! impl_hll_bucket_list {
     ($name:ident, $precision:literal, $num_registers:expr) => {
-        #[derive(Clone, Debug)]
+        const _: () = {
+            ::std::assert!(
+                $num_registers == 1_usize << $precision,
+                "impl_hll_bucket_list!: num_registers must equal 1 << precision",
+            );
+            ::std::assert!(
+                $precision >= 1,
+                "impl_hll_bucket_list!: precision must be at least 1",
+            );
+        };
+
+        #[derive(::std::clone::Clone, ::std::fmt::Debug)]
         /// Fixed-size HLL register storage.
         pub struct $name {
             /// Backing register array.
-            pub registers: Box<[u8; $num_registers]>,
+            pub registers: ::std::boxed::Box<[u8; $num_registers]>,
         }
 
         impl $name {
@@ -93,18 +118,20 @@ macro_rules! impl_hll_bucket_list {
             /// larger precisions. Going through a boxed slice never
             /// materializes an `[u8; N]` value, so stack use is constant in
             /// every profile.
-            fn zeroed_registers() -> Box<[u8; $num_registers]> {
-                let registers: Box<[u8]> = ::std::vec![0_u8; $num_registers].into_boxed_slice();
-                match <Box<[u8; $num_registers]> as ::std::convert::TryFrom<Box<[u8]>>>::try_from(
-                    registers,
-                ) {
+            fn zeroed_registers() -> ::std::boxed::Box<[u8; $num_registers]> {
+                let registers: ::std::boxed::Box<[u8]> =
+                    ::std::vec![0_u8; $num_registers].into_boxed_slice();
+                match <::std::boxed::Box<[u8; $num_registers]> as ::std::convert::TryFrom<
+                    ::std::boxed::Box<[u8]>,
+                >>::try_from(registers)
+                {
                     Ok(registers) => registers,
-                    Err(_) => unreachable!("boxed slice length is the register count"),
+                    Err(_) => ::std::unreachable!("boxed slice length is the register count"),
                 }
             }
         }
 
-        impl Default for $name {
+        impl ::std::default::Default for $name {
             fn default() -> Self {
                 Self {
                     registers: Self::zeroed_registers(),
@@ -113,7 +140,7 @@ macro_rules! impl_hll_bucket_list {
         }
 
         impl $crate::__private::serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
             where
                 S: $crate::__private::serde::Serializer,
             {
@@ -125,7 +152,7 @@ macro_rules! impl_hll_bucket_list {
         }
 
         impl<'de> $crate::__private::serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
             where
                 D: $crate::__private::serde::Deserializer<'de>,
             {
@@ -145,7 +172,10 @@ macro_rules! impl_hll_bucket_list {
                         ::std::write!(formatter, "an array of {} bytes", $num_registers)
                     }
 
-                    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                    fn visit_seq<A>(
+                        self,
+                        mut seq: A,
+                    ) -> ::std::result::Result<Self::Value, A::Error>
                     where
                         A: $crate::__private::serde::de::SeqAccess<'de>,
                     {

--- a/src/common/structures/fixed_structure.rs
+++ b/src/common/structures/fixed_structure.rs
@@ -1,8 +1,7 @@
 //! A fixed integer matrix.
 //! Size fixed at compile time and heap-backed via Box.
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::ops::{Index, IndexMut, Range};
+use serde::{Deserialize, Serialize};
 
 /// Quick-start row count for fixed matrix aliases.
 pub const QUICKSTART_ROW_NUM: usize = 5;
@@ -46,6 +45,25 @@ pub trait HllRegisterStorage:
     }
 }
 
+#[macro_export]
+/// Generates a fixed-size HLL register storage type for a given precision.
+///
+/// Use this to instantiate a precision the crate does not ship a type for
+/// (the built-ins are [`HllBucketListP12`], [`HllBucketListP14`], and
+/// [`HllBucketListP16`]). The generated type implements
+/// [`HllRegisterStorage`], so it plugs straight into `HyperLogLogImpl` and
+/// `HyperLogLogHIPImpl` and keeps the same monomorphized fast path.
+///
+/// ```
+/// use asap_sketchlib::sketches::hll::HyperLogLogImpl;
+/// use asap_sketchlib::{Classic, DataInput};
+///
+/// asap_sketchlib::impl_hll_bucket_list!(HllBucketListP18, 18, 1_usize << 18);
+///
+/// let mut hll = HyperLogLogImpl::<Classic, HllBucketListP18>::new();
+/// hll.insert(&DataInput::Str("hello"));
+/// assert_eq!(HllBucketListP18::NUM_REGISTERS, 1 << 18);
+/// ```
 macro_rules! impl_hll_bucket_list {
     ($name:ident, $precision:literal, $num_registers:expr) => {
         #[derive(Clone, Debug)]
@@ -74,29 +92,32 @@ macro_rules! impl_hll_bucket_list {
             }
         }
 
-        impl Serialize for $name {
+        impl $crate::__private::serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
-                S: Serializer,
+                S: $crate::__private::serde::Serializer,
             {
-                serde_big_array::BigArray::serialize(&*self.registers, serializer)
+                $crate::__private::serde_big_array::BigArray::serialize(
+                    &*self.registers,
+                    serializer,
+                )
             }
         }
 
-        impl<'de> Deserialize<'de> for $name {
+        impl<'de> $crate::__private::serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
-                D: Deserializer<'de>,
+                D: $crate::__private::serde::Deserializer<'de>,
             {
                 let data: [u8; $num_registers] =
-                    serde_big_array::BigArray::deserialize(deserializer)?;
+                    $crate::__private::serde_big_array::BigArray::deserialize(deserializer)?;
                 Ok(Self {
                     registers: Box::new(data),
                 })
             }
         }
 
-        impl Index<usize> for $name {
+        impl ::std::ops::Index<usize> for $name {
             type Output = u8;
 
             fn index(&self, index: usize) -> &Self::Output {
@@ -105,39 +126,39 @@ macro_rules! impl_hll_bucket_list {
             }
         }
 
-        impl IndexMut<usize> for $name {
+        impl ::std::ops::IndexMut<usize> for $name {
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
                 debug_assert!(index < $num_registers, "index out of bounds");
                 &mut self.registers[index]
             }
         }
 
-        impl Index<Range<usize>> for $name {
+        impl ::std::ops::Index<::std::ops::Range<usize>> for $name {
             type Output = [u8];
 
-            fn index(&self, range: Range<usize>) -> &Self::Output {
+            fn index(&self, range: ::std::ops::Range<usize>) -> &Self::Output {
                 debug_assert!(range.end <= $num_registers, "range end out of bounds");
                 &self.registers[range]
             }
         }
 
-        impl IndexMut<Range<usize>> for $name {
-            fn index_mut(&mut self, range: Range<usize>) -> &mut Self::Output {
+        impl ::std::ops::IndexMut<::std::ops::Range<usize>> for $name {
+            fn index_mut(&mut self, range: ::std::ops::Range<usize>) -> &mut Self::Output {
                 debug_assert!(range.end <= $num_registers, "range end out of bounds");
                 &mut self.registers[range]
             }
         }
 
-        impl<'a> IntoIterator for &'a $name {
+        impl<'a> ::std::iter::IntoIterator for &'a $name {
             type Item = &'a u8;
-            type IntoIter = std::slice::Iter<'a, u8>;
+            type IntoIter = ::std::slice::Iter<'a, u8>;
 
             fn into_iter(self) -> Self::IntoIter {
                 self.registers.iter()
             }
         }
 
-        impl HllRegisterStorage for $name {
+        impl $crate::HllRegisterStorage for $name {
             const PRECISION: usize = Self::PRECISION;
             const REGISTER_BITS: usize = Self::REGISTER_BITS;
             const NUM_REGISTERS: usize = Self::NUM_REGISTERS;

--- a/src/sketches/fold_cms.rs
+++ b/src/sketches/fold_cms.rs
@@ -579,9 +579,7 @@ impl<H: SketchHasher> FoldCMS<H> {
     /// The outer `Vec<FoldCell>` allocation is preserved; inner `Collided(Vec)`
     /// data is dropped.
     pub fn clear(&mut self) {
-        for cell in &mut self.cells {
-            *cell = FoldCell::Empty;
-        }
+        self.cells.fill(FoldCell::Empty);
         self.heap.clear();
     }
 

--- a/src/sketches/fold_cs.rs
+++ b/src/sketches/fold_cs.rs
@@ -416,9 +416,7 @@ impl<H: SketchHasher> FoldCS<H> {
     /// The outer `Vec<FoldCell>` allocation is preserved; inner `Collided(Vec)`
     /// data is dropped.
     pub fn clear(&mut self) {
-        for cell in &mut self.cells {
-            *cell = FoldCell::Empty;
-        }
+        self.cells.fill(FoldCell::Empty);
         self.heap.clear();
     }
 

--- a/src/sketches/hll.rs
+++ b/src/sketches/hll.rs
@@ -272,40 +272,36 @@ impl<Registers: HllRegisterStorage, H: SketchHasher> HyperLogLogImpl<ErtlMLE, Re
     }
 }
 
-macro_rules! impl_ertl_mle_estimate {
-    ($storage:ty) => {
-        impl<H: SketchHasher> HyperLogLogImpl<ErtlMLE, $storage, H> {
-            /// "New cardinality estimation algorithms for HyperLogLog sketches"
-            /// Otmar Ertl, arXiv:1702.01284
-            #[inline]
-            fn get_histogram(&self) -> [u32; { <$storage>::REGISTER_BITS + 2 }] {
-                let mut histogram = [0; { <$storage>::REGISTER_BITS + 2 }];
-                for &register in self.registers.as_slice() {
-                    histogram[register as usize] += 1;
-                }
-                histogram
-            }
+/// Upper bound on the Ertl histogram length. `REGISTER_BITS + 2` peaks at
+/// `64 + 2` for `precision = 0`, so one array covers every precision and the
+/// per-precision `[u32; REGISTER_BITS + 2]` sizing is not needed.
+const ERTL_HISTOGRAM_CAP: usize = 66;
 
-            /// Returns the estimated cardinality using the Ertl MLE algorithm.
-            pub fn estimate(&self) -> usize {
-                let histogram = self.get_histogram();
-                let m: f64 = <$storage>::NUM_REGISTERS as f64;
-                let mut z = m * self
-                    .hll_ertl_tau((m - histogram[<$storage>::REGISTER_BITS + 1] as f64) / m);
-                for i in histogram[1..=<$storage>::REGISTER_BITS].iter().rev() {
-                    z += *i as f64;
-                    z *= 0.5;
-                }
-                z += m * self.hll_ertl_sigma(histogram[0] as f64 / m);
-                (0.5 / 2_f64.ln() * m * m / z).round() as usize
-            }
+impl<Registers: HllRegisterStorage, H: SketchHasher> HyperLogLogImpl<ErtlMLE, Registers, H> {
+    /// "New cardinality estimation algorithms for HyperLogLog sketches"
+    /// Otmar Ertl, arXiv:1702.01284
+    #[inline]
+    fn get_histogram(&self) -> [u32; ERTL_HISTOGRAM_CAP] {
+        let mut histogram = [0; ERTL_HISTOGRAM_CAP];
+        for &register in self.registers.as_slice() {
+            histogram[register as usize] += 1;
         }
-    };
-}
+        histogram
+    }
 
-impl_ertl_mle_estimate!(HllBucketListP12);
-impl_ertl_mle_estimate!(HllBucketListP14);
-impl_ertl_mle_estimate!(HllBucketListP16);
+    /// Returns the estimated cardinality using the Ertl MLE algorithm.
+    pub fn estimate(&self) -> usize {
+        let histogram = self.get_histogram();
+        let m: f64 = Registers::NUM_REGISTERS as f64;
+        let mut z = m * self.hll_ertl_tau((m - histogram[Registers::REGISTER_BITS + 1] as f64) / m);
+        for i in histogram[1..=Registers::REGISTER_BITS].iter().rev() {
+            z += *i as f64;
+            z *= 0.5;
+        }
+        z += m * self.hll_ertl_sigma(histogram[0] as f64 / m);
+        (0.5 / 2_f64.ln() * m * m / z).round() as usize
+    }
+}
 
 impl<Registers: HllRegisterStorage> Default for HyperLogLogHIPImpl<Registers> {
     fn default() -> Self {
@@ -487,37 +483,33 @@ mod tests {
         }
     }
 
-    macro_rules! impl_ertl_mle_test_traits {
-        ($storage:ty) => {
-            impl<H: SketchHasher> HllEstimator for HyperLogLogImpl<ErtlMLE, $storage, H> {
-                fn push(&mut self, input: &DataInput) {
-                    self.insert(input);
-                }
+    impl<Registers: HllRegisterStorage, H: SketchHasher> HllEstimator
+        for HyperLogLogImpl<ErtlMLE, Registers, H>
+    {
+        fn push(&mut self, input: &DataInput) {
+            self.insert(input);
+        }
 
-                fn insert_with_hash(&mut self, hashed: u64) {
-                    HyperLogLogImpl::<ErtlMLE, $storage, H>::insert_with_hash(self, hashed);
-                }
+        fn insert_with_hash(&mut self, hashed: u64) {
+            HyperLogLogImpl::<ErtlMLE, Registers, H>::insert_with_hash(self, hashed);
+        }
 
-                fn estimate(&self) -> f64 {
-                    HyperLogLogImpl::<ErtlMLE, $storage, H>::estimate(self) as f64
-                }
+        fn estimate(&self) -> f64 {
+            HyperLogLogImpl::<ErtlMLE, Registers, H>::estimate(self) as f64
+        }
 
-                fn index(&self, i: usize) -> u8 {
-                    self.registers.as_slice()[i]
-                }
-            }
-
-            impl<H: SketchHasher> HllMerge for HyperLogLogImpl<ErtlMLE, $storage, H> {
-                fn merge_into(&mut self, other: &Self) {
-                    self.merge(other);
-                }
-            }
-        };
+        fn index(&self, i: usize) -> u8 {
+            self.registers.as_slice()[i]
+        }
     }
 
-    impl_ertl_mle_test_traits!(HllBucketListP12);
-    impl_ertl_mle_test_traits!(HllBucketListP14);
-    impl_ertl_mle_test_traits!(HllBucketListP16);
+    impl<Registers: HllRegisterStorage, H: SketchHasher> HllMerge
+        for HyperLogLogImpl<ErtlMLE, Registers, H>
+    {
+        fn merge_into(&mut self, other: &Self) {
+            self.merge(other);
+        }
+    }
 
     impl<Registers: HllRegisterStorage> HllEstimator for HyperLogLogHIPImpl<Registers> {
         fn push(&mut self, input: &DataInput) {

--- a/src/sketches/hll/wire.rs
+++ b/src/sketches/hll/wire.rs
@@ -214,7 +214,7 @@ impl<Registers: HllRegisterStorage> HyperLogLogHIPImpl<Registers> {
 mod tests {
     use super::*;
     use crate::sketches::hll::{HyperLogLog, HyperLogLogHIP, HyperLogLogHIPP12, HyperLogLogP12};
-    use crate::structures::fixed_structure::{HllBucketListP12, HllBucketListP14};
+    use crate::structures::fixed_structure::HllBucketListP14;
     use crate::{DataInput, HllBucketList};
 
     const ERROR_TOLERANCE: f64 = 0.02;
@@ -259,34 +259,29 @@ mod tests {
         }
     }
 
-    macro_rules! impl_ertl_mle_wire_test_traits {
-        ($storage:ty) => {
-            impl<H: SketchHasher> HllEstimator for HyperLogLogImpl<ErtlMLE, $storage, H> {
-                fn push(&mut self, input: &DataInput) {
-                    self.insert(input);
-                }
+    impl<Registers: HllRegisterStorage, H: SketchHasher> HllEstimator
+        for HyperLogLogImpl<ErtlMLE, Registers, H>
+    {
+        fn push(&mut self, input: &DataInput) {
+            self.insert(input);
+        }
 
-                fn estimate(&self) -> f64 {
-                    HyperLogLogImpl::<ErtlMLE, $storage, H>::estimate(self) as f64
-                }
-            }
-
-            impl<H: SketchHasher + HashProfile> HllSerializable
-                for HyperLogLogImpl<ErtlMLE, $storage, H>
-            {
-                fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
-                    HyperLogLogImpl::<ErtlMLE, $storage, H>::serialize_to_bytes(self)
-                }
-
-                fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
-                    HyperLogLogImpl::<ErtlMLE, $storage, H>::deserialize_from_bytes(bytes)
-                }
-            }
-        };
+        fn estimate(&self) -> f64 {
+            HyperLogLogImpl::<ErtlMLE, Registers, H>::estimate(self) as f64
+        }
     }
 
-    impl_ertl_mle_wire_test_traits!(HllBucketListP12);
-    impl_ertl_mle_wire_test_traits!(HllBucketListP14);
+    impl<Registers: HllRegisterStorage, H: SketchHasher + HashProfile> HllSerializable
+        for HyperLogLogImpl<ErtlMLE, Registers, H>
+    {
+        fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+            HyperLogLogImpl::<ErtlMLE, Registers, H>::serialize_to_bytes(self)
+        }
+
+        fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+            HyperLogLogImpl::<ErtlMLE, Registers, H>::deserialize_from_bytes(bytes)
+        }
+    }
 
     impl<Registers: HllRegisterStorage> HllEstimator for HyperLogLogHIPImpl<Registers> {
         fn push(&mut self, input: &DataInput) {

--- a/tests/hll_custom_precision.rs
+++ b/tests/hll_custom_precision.rs
@@ -10,7 +10,7 @@
 //! `lkarger` search space).
 
 use asap_sketchlib::sketches::hll::{HyperLogLogHIPImpl, HyperLogLogImpl};
-use asap_sketchlib::{Classic, DataInput, HllRegisterStorage};
+use asap_sketchlib::{Classic, DataInput, ErtlMLE, HllRegisterStorage};
 
 asap_sketchlib::impl_hll_bucket_list!(HllBucketListP4, 4, 1_usize << 4);
 asap_sketchlib::impl_hll_bucket_list!(HllBucketListP8, 8, 1_usize << 8);
@@ -23,9 +23,9 @@ fn item(i: usize) -> String {
     format!("key-{i:08}")
 }
 
-/// Checks the storage constants, then builds Classic and HIP sketches over
-/// `cardinality` distinct items and asserts both land within `tolerance`
-/// relative error.
+/// Checks the storage constants, then builds Classic, ErtlMLE, and HIP
+/// sketches over `cardinality` distinct items and asserts all three land
+/// within `tolerance` relative error.
 fn check_precision<R: HllRegisterStorage>(lg_k: usize, cardinality: usize, tolerance: f64) {
     let num_registers = 1_usize << lg_k;
     assert_eq!(R::PRECISION, lg_k, "PRECISION for lg_k={lg_k}");
@@ -51,10 +51,12 @@ fn check_precision<R: HllRegisterStorage>(lg_k: usize, cardinality: usize, toler
     );
 
     let mut classic = HyperLogLogImpl::<Classic, R>::new();
+    let mut ertl = HyperLogLogImpl::<ErtlMLE, R>::new();
     let mut hip = HyperLogLogHIPImpl::<R>::new();
     for i in 0..cardinality {
         let value = DataInput::String(item(i));
         classic.insert(&value);
+        ertl.insert(&value);
         hip.insert(&value);
     }
 
@@ -76,7 +78,11 @@ fn check_precision<R: HllRegisterStorage>(lg_k: usize, cardinality: usize, toler
         "register rank out of range for lg_k={lg_k}"
     );
 
-    for (name, estimate) in [("classic", classic.estimate()), ("hip", hip.estimate())] {
+    for (name, estimate) in [
+        ("classic", classic.estimate()),
+        ("ertl_mle", ertl.estimate()),
+        ("hip", hip.estimate()),
+    ] {
         let error = (estimate as f64 - cardinality as f64).abs() / cardinality as f64;
         assert!(
             error < tolerance,

--- a/tests/hll_custom_precision.rs
+++ b/tests/hll_custom_precision.rs
@@ -1,9 +1,10 @@
 //! Exercises `impl_hll_bucket_list!` from outside the crate.
 //!
 //! This is an integration test, so it compiles as a separate crate: it only
-//! sees `asap_sketchlib`'s public surface and does not depend on `serde` or
-//! `serde-big-array` itself. That makes it a real check that the exported
-//! macro is usable downstream — see issue #94.
+//! sees `asap_sketchlib`'s public surface, and it never imports `serde`,
+//! `serde-big-array`, or any of the other names the macro expansion needs.
+//! That makes it a real check that the exported macro is usable downstream —
+//! see issue #94.
 //!
 //! The precisions here are deliberately outside the built-in
 //! {12, 14, 16} set, including `lg_k = 18` (needed by sketch-bench's
@@ -97,8 +98,10 @@ fn check_precision<R: HllRegisterStorage>(lg_k: usize, cardinality: usize, toler
 fn custom_precisions_estimate_correctly() {
     // Tolerances are ~4x the 1.04/sqrt(m) standard error for the precision,
     // which is comfortably loose for these fixed inputs (the inputs are
-    // deterministic, so these assertions cannot flake).
-    check_precision::<HllBucketListP4>(4, 100, 1.10);
+    // deterministic, so these assertions cannot flake). They are all well
+    // under 1.0, so an estimator that returned zero would fail rather than
+    // pass on a slack bound.
+    check_precision::<HllBucketListP4>(4, 100, 0.60);
     check_precision::<HllBucketListP8>(8, 1_000, 0.30);
     check_precision::<HllBucketListP10>(10, 10_000, 0.15);
     check_precision::<HllBucketListP13>(13, 50_000, 0.06);
@@ -180,4 +183,50 @@ fn large_precision_allocates_on_the_heap() {
     let restored: HyperLogLogImpl<Classic, HllBucketListP18> =
         rmp_serde::from_slice(&bytes).expect("deserialize");
     assert_eq!(restored.registers_as_slice(), big.registers_as_slice());
+}
+
+/// The ASAPv1 envelope is the cross-language format, and it is a different
+/// code path from the derive-based serde impls above: it writes `precision`
+/// into the metadata and validates the register length on the way back in.
+/// Covers all three variants, including HIP's extra running scalars.
+#[test]
+fn custom_precision_round_trips_through_the_asapv1_wire_format() {
+    let mut classic = HyperLogLogImpl::<Classic, HllBucketListP13>::new();
+    let mut ertl = HyperLogLogImpl::<ErtlMLE, HllBucketListP13>::new();
+    let mut hip = HyperLogLogHIPImpl::<HllBucketListP13>::new();
+    for i in 0..5_000 {
+        let value = DataInput::String(item(i));
+        classic.insert(&value);
+        ertl.insert(&value);
+        hip.insert(&value);
+    }
+
+    let bytes = classic.serialize_to_bytes().expect("classic encode");
+    let restored = HyperLogLogImpl::<Classic, HllBucketListP13>::deserialize_from_bytes(&bytes)
+        .expect("classic decode");
+    assert_eq!(restored.registers_as_slice(), classic.registers_as_slice());
+    assert_eq!(restored.estimate(), classic.estimate());
+
+    let bytes = ertl.serialize_to_bytes().expect("ertl_mle encode");
+    let restored = HyperLogLogImpl::<ErtlMLE, HllBucketListP13>::deserialize_from_bytes(&bytes)
+        .expect("ertl_mle decode");
+    assert_eq!(restored.registers_as_slice(), ertl.registers_as_slice());
+    assert_eq!(restored.estimate(), ertl.estimate());
+
+    let bytes = hip.serialize_to_bytes().expect("hip encode");
+    let restored =
+        HyperLogLogHIPImpl::<HllBucketListP13>::deserialize_from_bytes(&bytes).expect("hip decode");
+    // HIP's estimate is a running scalar, so this also checks that kxq0/kxq1/est
+    // survived the round-trip rather than being recomputed from registers.
+    assert_eq!(restored.estimate(), hip.estimate());
+
+    // A payload whose register count does not match the target precision is
+    // rejected rather than silently accepted at the wrong precision.
+    let p18 = HyperLogLogImpl::<Classic, HllBucketListP18>::new()
+        .serialize_to_bytes()
+        .expect("p18 encode");
+    assert!(
+        HyperLogLogImpl::<Classic, HllBucketListP13>::deserialize_from_bytes(&p18).is_err(),
+        "decoding lg_k=18 bytes as lg_k=13 should fail"
+    );
 }

--- a/tests/hll_custom_precision.rs
+++ b/tests/hll_custom_precision.rs
@@ -17,6 +17,7 @@ asap_sketchlib::impl_hll_bucket_list!(HllBucketListP8, 8, 1_usize << 8);
 asap_sketchlib::impl_hll_bucket_list!(HllBucketListP10, 10, 1_usize << 10);
 asap_sketchlib::impl_hll_bucket_list!(HllBucketListP13, 13, 1_usize << 13);
 asap_sketchlib::impl_hll_bucket_list!(HllBucketListP18, 18, 1_usize << 18);
+asap_sketchlib::impl_hll_bucket_list!(HllBucketListP22, 22, 1_usize << 22);
 
 /// Distinct, deterministic inputs so every assertion below is reproducible.
 fn item(i: usize) -> String {
@@ -154,4 +155,29 @@ fn custom_precision_round_trips_through_serde() {
 
     assert_eq!(restored.registers_as_slice(), sketch.registers_as_slice());
     assert_eq!(restored.estimate(), sketch.estimate());
+}
+
+/// Regression: register storage must be allocated on the heap, never built as
+/// an `[u8; N]` value and copied into the box. Both operations below aborted
+/// with `fatal runtime error: stack overflow` in debug builds before that
+/// change -- test threads get a 2 MiB stack, and lg_k=22 is a 4 MiB array.
+/// Release builds happened to survive because the optimizer elided the
+/// temporary, which is exactly the profile dependence this pins down.
+#[test]
+fn large_precision_allocates_on_the_heap() {
+    let sketch = HyperLogLogImpl::<Classic, HllBucketListP22>::new();
+    assert_eq!(
+        sketch.registers_as_slice().len(),
+        HllBucketListP22::NUM_REGISTERS
+    );
+    assert!(sketch.registers_as_slice().iter().all(|&r| r == 0));
+
+    let mut big = HyperLogLogImpl::<Classic, HllBucketListP18>::new();
+    for i in 0..1_000 {
+        big.insert(&DataInput::String(item(i)));
+    }
+    let bytes = rmp_serde::to_vec(&big).expect("serialize");
+    let restored: HyperLogLogImpl<Classic, HllBucketListP18> =
+        rmp_serde::from_slice(&bytes).expect("deserialize");
+    assert_eq!(restored.registers_as_slice(), big.registers_as_slice());
 }

--- a/tests/hll_custom_precision.rs
+++ b/tests/hll_custom_precision.rs
@@ -1,0 +1,151 @@
+//! Exercises `impl_hll_bucket_list!` from outside the crate.
+//!
+//! This is an integration test, so it compiles as a separate crate: it only
+//! sees `asap_sketchlib`'s public surface and does not depend on `serde` or
+//! `serde-big-array` itself. That makes it a real check that the exported
+//! macro is usable downstream — see issue #94.
+//!
+//! The precisions here are deliberately outside the built-in
+//! {12, 14, 16} set, including `lg_k = 18` (needed by sketch-bench's
+//! `lkarger` search space).
+
+use asap_sketchlib::sketches::hll::{HyperLogLogHIPImpl, HyperLogLogImpl};
+use asap_sketchlib::{Classic, DataInput, HllRegisterStorage};
+
+asap_sketchlib::impl_hll_bucket_list!(HllBucketListP4, 4, 1_usize << 4);
+asap_sketchlib::impl_hll_bucket_list!(HllBucketListP8, 8, 1_usize << 8);
+asap_sketchlib::impl_hll_bucket_list!(HllBucketListP10, 10, 1_usize << 10);
+asap_sketchlib::impl_hll_bucket_list!(HllBucketListP13, 13, 1_usize << 13);
+asap_sketchlib::impl_hll_bucket_list!(HllBucketListP18, 18, 1_usize << 18);
+
+/// Distinct, deterministic inputs so every assertion below is reproducible.
+fn item(i: usize) -> String {
+    format!("key-{i:08}")
+}
+
+/// Checks the storage constants, then builds Classic and HIP sketches over
+/// `cardinality` distinct items and asserts both land within `tolerance`
+/// relative error.
+fn check_precision<R: HllRegisterStorage>(lg_k: usize, cardinality: usize, tolerance: f64) {
+    let num_registers = 1_usize << lg_k;
+    assert_eq!(R::PRECISION, lg_k, "PRECISION for lg_k={lg_k}");
+    assert_eq!(
+        R::NUM_REGISTERS,
+        num_registers,
+        "NUM_REGISTERS for lg_k={lg_k}"
+    );
+    assert_eq!(R::REGISTER_BITS, 64 - lg_k, "REGISTER_BITS for lg_k={lg_k}");
+    assert_eq!(
+        R::P_MASK,
+        (num_registers as u64) - 1,
+        "P_MASK for lg_k={lg_k}"
+    );
+
+    let storage = R::default();
+    assert_eq!(storage.len(), num_registers);
+    assert_eq!(storage.as_slice().len(), num_registers);
+    assert!(!storage.is_empty());
+    assert!(
+        storage.as_slice().iter().all(|&r| r == 0),
+        "fresh storage for lg_k={lg_k} should be zeroed"
+    );
+
+    let mut classic = HyperLogLogImpl::<Classic, R>::new();
+    let mut hip = HyperLogLogHIPImpl::<R>::new();
+    for i in 0..cardinality {
+        let value = DataInput::String(item(i));
+        classic.insert(&value);
+        hip.insert(&value);
+    }
+
+    // Registers really were written, and none exceeds the rank ceiling.
+    let touched = classic
+        .registers_as_slice()
+        .iter()
+        .filter(|&&r| r > 0)
+        .count();
+    assert!(
+        touched > 0,
+        "no register was set for lg_k={lg_k} after {cardinality} inserts"
+    );
+    assert!(
+        classic
+            .registers_as_slice()
+            .iter()
+            .all(|&r| (r as usize) <= R::REGISTER_BITS + 1),
+        "register rank out of range for lg_k={lg_k}"
+    );
+
+    for (name, estimate) in [("classic", classic.estimate()), ("hip", hip.estimate())] {
+        let error = (estimate as f64 - cardinality as f64).abs() / cardinality as f64;
+        assert!(
+            error < tolerance,
+            "{name} estimate at lg_k={lg_k}: got {estimate}, want ~{cardinality} \
+             (relative error {error:.4} >= tolerance {tolerance})"
+        );
+    }
+}
+
+#[test]
+fn custom_precisions_estimate_correctly() {
+    // Tolerances are ~4x the 1.04/sqrt(m) standard error for the precision,
+    // which is comfortably loose for these fixed inputs (the inputs are
+    // deterministic, so these assertions cannot flake).
+    check_precision::<HllBucketListP4>(4, 100, 1.10);
+    check_precision::<HllBucketListP8>(8, 1_000, 0.30);
+    check_precision::<HllBucketListP10>(10, 10_000, 0.15);
+    check_precision::<HllBucketListP13>(13, 50_000, 0.06);
+    check_precision::<HllBucketListP18>(18, 200_000, 0.02);
+}
+
+#[test]
+fn custom_precision_merges() {
+    let mut left = HyperLogLogImpl::<Classic, HllBucketListP18>::new();
+    let mut right = HyperLogLogImpl::<Classic, HllBucketListP18>::new();
+    for i in 0..60_000 {
+        left.insert(&DataInput::String(item(i)));
+    }
+    // Overlapping halves: the union is 100_000 distinct items.
+    for i in 40_000..100_000 {
+        right.insert(&DataInput::String(item(i)));
+    }
+
+    left.merge(&right);
+    let estimate = left.estimate();
+    let error = (estimate as f64 - 100_000.0).abs() / 100_000.0;
+    assert!(
+        error < 0.02,
+        "merged estimate at lg_k=18: got {estimate}, want ~100000 (relative error {error:.4})"
+    );
+}
+
+#[test]
+fn custom_precision_indexing_and_iteration() {
+    let mut storage = HllBucketListP10::default();
+    storage[0] = 7;
+    storage[HllBucketListP10::NUM_REGISTERS - 1] = 3;
+    assert_eq!(storage[0], 7);
+    assert_eq!(storage[HllBucketListP10::NUM_REGISTERS - 1], 3);
+    assert_eq!(&storage[0..2], &[7, 0]);
+
+    storage[1..3].copy_from_slice(&[1, 2]);
+    assert_eq!(storage.as_slice()[1..3], [1, 2]);
+
+    let sum: u32 = (&storage).into_iter().map(|&r| r as u32).sum();
+    assert_eq!(sum, 7 + 1 + 2 + 3);
+}
+
+#[test]
+fn custom_precision_round_trips_through_serde() {
+    let mut sketch = HyperLogLogImpl::<Classic, HllBucketListP13>::new();
+    for i in 0..5_000 {
+        sketch.insert(&DataInput::String(item(i)));
+    }
+
+    let bytes = rmp_serde::to_vec(&sketch).expect("serialize");
+    let restored: HyperLogLogImpl<Classic, HllBucketListP13> =
+        rmp_serde::from_slice(&bytes).expect("deserialize");
+
+    assert_eq!(restored.registers_as_slice(), sketch.registers_as_slice());
+    assert_eq!(restored.estimate(), sketch.estimate());
+}


### PR DESCRIPTION
Closes #94 (part **(a)** only — see *Not in scope* below).

## What

Six commits:

1. **`bd558fc` — export the macro.** Mark `impl_hll_bucket_list!` `#[macro_export]`.
   Downstream crates can now generate an `HllRegisterStorage` type at any
   precision (e.g. `lg_k = 18`, which sketch-bench's `lkarger` search space
   needs) instead of being stuck with the built-in `HllBucketListP12/P14/P16`.
   The generated type is the same monomorphized fast path, not a slow fallback.

2. **`c614acd` — test it.** `tests/hll_custom_precision.rs`.

3. **`debe577` — make `ErtlMLE::estimate` generic**, so custom precisions can
   query, not just insert and merge.

4. **`f60317d` — heap-allocate register storage**, so large precisions don't
   overflow the stack in debug builds.

5. **`72c190e` — harden the macro against caller context** (from review): qualify
   `Result`/`Box`/`Default`/`unreachable!`/derive paths, and assert
   `num_registers == 1 << precision` at compile time.

6. **`02ec700` — tighten the tests** (from review): non-vacuous lg_k=4 tolerance,
   ASAPv1 envelope round-trip for all three variants at a custom precision.

```rust
asap_sketchlib::impl_hll_bucket_list!(HllBucketListP18, 18, 1_usize << 18);

let mut hll = HyperLogLogImpl::<Classic, HllBucketListP18>::new();
```

Commits 3 and 4 came out of checking the full variant × operation matrix at a
custom precision. Result after this PR — every cell works:

| variant | insert | query | merge | ser/de |
|---|---|---|---|---|
| Classic | ✓ | ✓ | ✓ | ✓ |
| ErtlMLE | ✓ | ✓ (was ✗, commit 3) | ✓ | ✓ |
| HIP | ✓ | ✓ | n/a — no `merge` method, by design | ✓ |

## Commit 1 — note on "one line"

`#[macro_export]` is the one functional line, but it can't ship alone: the macro
body referenced `Serialize`, `Serializer`, `Deserialize`, `Deserializer`,
`serde_big_array::BigArray`, `Index`, `IndexMut`, `Range` and
`HllRegisterStorage` by bare name, so the expansion only compiled inside this
module. The rest is mechanical path-qualification — `$crate::__private::serde`,
`$crate::HllRegisterStorage`, `::std::ops::*` — exactly the pattern
`impl_fixed_matrix!` already uses (748f179). Without it a downstream caller
would have to import all eight names and take a `serde-big-array` dependency of
their own.

Also in commit 1: a doc example on the macro (runs as a doctest, i.e. from
outside the crate), a CHANGELOG entry, and one bullet in `docs/features.md`
next to `impl_fixed_matrix!`.

## Commit 3 — ErtlMLE at custom precisions

`estimate` for `ErtlMLE` came from `impl_ertl_mle_estimate!`, instantiated only
for P12/P14/P16, so a custom-precision sketch could `insert` and `merge` but
`estimate` did not exist:

```
error[E0599]: no method named `estimate` found for struct `HyperLogLogImpl<ErtlMLE, P18>`
```

The only thing forcing the macro was the exact-sized histogram
`[u32; REGISTER_BITS + 2]`, unwritable in a generic impl while
`generic_const_exprs` is unstable. It doesn't need to be exact: `REGISTER_BITS + 2`
peaks at 66, so one `[u32; 66]` covers every precision and the loop bounds stay
`Registers::REGISTER_BITS` — still a compile-time constant per monomorphization.
The extra slots are zeros the algorithm never reads, so estimates at existing
precisions are unchanged. Net −4 lines; also drops the two `#[cfg(test)]`
harness macros that only existed to work around the same limitation.

## Commit 4 — the debug stack overflow

`Default` built `[0_u8; N]` on the stack and copied it into the box; `Deserialize`
did the same via `BigArray`. Release elides those temporaries — debug does not.
On a 2 MiB test thread:

| operation | before (debug) | after (debug) |
|---|---|---|
| `default()` / `new()` | aborts at lg_k ≥ 22 | fine (no stack ceiling; tested to lg_k 30 / 1 GiB) |
| `rmp_serde::from_slice` | aborts at lg_k ≥ 17 | fine |
| `deserialize_from_bytes` (ASAPv1) | fine | fine |

Not a new bug — it's equally true of the shipped `HllBucketListP16` — but
exporting the macro makes the precisions where it bites reachable, and
`fatal runtime error: stack overflow` is a bad first experience for someone who
just generated a P18 type. Fix routes both paths through a heap allocation that
never names an `[u8; N]` value, so behavior no longer depends on the optimizer.

**Wire compatibility:** unchanged. `Serialize` still uses `BigArray`; the new
visitor reads the same fixed-length sequence via `deserialize_tuple`. Verified
directly — bytes written by the pre-change implementation decode to identical
registers under the new one and re-encode byte-for-byte (16388 bytes, P14).


## Review follow-ups (commits 5–6)

A review pass turned up two real defects in the exported macro, both reproduced
before fixing and re-verified after:

- **Unqualified `Result` broke the expansion in ordinary caller modules.** With
  `use std::io::Result` or `use std::fmt::Result` in scope — the aliases take a
  different number of generic arguments — the macro failed with 8 errors
  (E0053/E0107/E0277/E0308). Commit 1 had qualified `serde`, `std::ops`, `vec!`
  and `write!` but missed `Result` in three signatures, plus `Box`, `Default`
  and `unreachable!`. Now verified against a downstream crate that shadows
  `Result` two ways *and* declares its own `Default` trait, under `deny(warnings)`.
- **Nothing tied `precision` to `num_registers`.**
  `impl_hll_bucket_list!(Foo, 18, 1_usize << 20)` compiled and silently produced
  wrong estimates forever: the bucket index is `(hash >> REGISTER_BITS) & P_MASK`,
  so only `1 << 18` registers are ever reachable while `estimate()` divides by
  `1 << 20`. Measured on the broken pair: 83,131 of 1,048,576 registers ever
  touched. No panic, no bounds violation — it just returns bad numbers. A
  `const _: ()` block now rejects it at compile time:

  ```
  error[E0080]: evaluation panicked: impl_hll_bucket_list!: num_registers must equal 1 << precision
  ```

  `precision >= 1` is checked the same way, and `HllRegisterStorage` now
  documents the relations hand-written impls must uphold.

The review also independently confirmed the PR's three load-bearing claims:
ErtlMLE estimates byte-identical across P12/P14/P16 × 8 cardinalities; MessagePack
output byte-identical (16388 B, `cmp` clean, and bytes cross-decode both
directions); insert throughput unchanged.

**Known, deliberately not fixed here:** `impl_fixed_matrix!` in the same file has
the identical bare-`Result` flaw (pre-existing, and it is already exported). It
deserves its own pass over all of its unqualified names rather than a partial fix
smuggled into this PR.

## Test coverage

`tests/hll_custom_precision.rs` is an integration test, so it compiles as a
separate crate against the public surface only — invoking the macro there is
itself the check that the export works downstream. It instantiates lg_k
**4, 8, 10, 13, 18, and 22** (the last only in the allocation test) and asserts:

- storage constants (`PRECISION`, `NUM_REGISTERS`, `REGISTER_BITS`, `P_MASK`,
  `len`, zeroed on `default()`)
- Classic, **ErtlMLE**, and HIP estimates within tolerance at every precision,
  over deterministic inputs (so the assertions can't flake); tolerances are ~4x
  the 1.04/sqrt(m) standard error, and measured errors sit well inside them
  (e.g. lg_k=18: classic 0.01%, ErtlMLE 0.01%, HIP 0.15%)
- register ranks stay within `REGISTER_BITS + 1`
- `merge` of two overlapping lg_k=18 sketches recovers the union cardinality
- `Index`/`IndexMut` for `usize` and `Range`, and `IntoIterator`
- MessagePack round-trip at lg_k=13, and an ASAPv1 envelope round-trip at a
  custom precision for all three variants — including HIP's running scalars,
  plus a negative case (lg_k=18 bytes must not decode as lg_k=13)
- **stack regression** at lg_k 18 and 22 — this test aborts without commit 4

`cargo test` and `cargo test --release` both fully green (505 unit +
6/7/12/4/1 integration + 21 doctests). `cargo fmt --check` and
`cargo clippy --all-targets` clean.

## Not in scope

**Part (b), the `Vec<u8>` runtime-sized fallback**, is not here. Worth a separate
PR — with (a) in place, every precision is reachable, so (b) becomes a
convenience (no type declaration needed up front) rather than the only way to
run at lg_k=18. Note the portable wire type `message_pack_format::portable::HllSketch`
already carries a runtime `precision`, so there's prior art for the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

