### PR TITLE
Add synthetic-data E2E testing harness + estimator correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,13 +45,18 @@ signals a backwards-compatible change.
   noisy generic recurrence.
 
 ### Added
-- **Synthetic-data E2E testing harness.** A shared `tests/common` module
-  (seeded stream generators, exact ground-truth trackers, tolerance-based
-  assertion helpers) plus themed integration suites covering frequency,
-  cardinality, quantile, framework/composition, and experimental sketches —
-  every public sketch family is exercised end to end against exact ground
-  truth. Includes `tests/bug_verification.rs` regression tests for the fixes
-  above and `examples/accuracy_probe.rs`, a release-mode ground-truth probe.
+- **Synthetic-data E2E testing harness with a reusable conformance kit.** A
+  shared `tests/common` module (seeded stream generators, exact ground-truth
+  trackers, tolerance-based assertion helpers) plus themed integration suites
+  covering frequency, cardinality, quantile, framework/composition, and
+  experimental sketches — every public sketch family is exercised end to end
+  against exact ground truth. `tests/common/conformance.rs` defines standard
+  batteries (`frequency`, `turnstile`, `cardinality`, `quantile`,
+  `merge_equivalence`) that new sketches must pass via small adapter impls;
+  `tests/README.md` documents the onboarding recipe and
+  `tests/conformance_kit.rs` shows reference adapters. Also includes
+  `tests/bug_verification.rs` regression tests for the fixes above and
+  `examples/accuracy_probe.rs`, a release-mode ground-truth probe.
 - **Export the `impl_hll_bucket_list!` macro.** Downstream crates can now
   generate an `HllRegisterStorage` type at any precision (e.g. `lg_k = 18`)
   instead of being limited to the built-in `HllBucketListP12/P14/P16`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,16 @@ signals a backwards-compatible change.
   mapping. No wire/state migration; query outputs shift by at most α.
 - **Portable `DdSketch` now rejects untrackable inputs like core.** Non-finite
   values (a NaN previously floor-cast into bucket 0) and finite-but-extreme
-  values beyond the indexable range (which mapped near i32::MAX and forced an
-  arbitrarily large dense-store allocation) are dropped silently, mirroring
-  core `DDSketch`'s min/max-indexable guards and DataDog's mapping (#70).
+  values beyond the indexable range are dropped silently, mirroring core
+  `DDSketch`'s min/max-indexable guards and DataDog's mapping (#70). Unguarded,
+  one `f64::MAX` sample mapped ~35k buckets away at α=0.01 (~277 KiB of dense
+  store per sample), scaling with 1/ln γ.
+- **Portable `DdSketch::apply_delta` bounds hostile wire input.** Deltas now
+  pre-validate their bucket span and return `Err` instead of padding the
+  dense store: a corrupt delta carrying an index near `i32::MAX` would
+  previously have attempted a ~2·10⁹-bucket (~17 GiB) allocation in one call.
+  The limit (4M buckets) dwarfs any legitimate span; the `apply_delta*`
+  family propagates the error.
 - Removed the raw-pointer write from `DDSketch`'s per-sample insertion path;
   bucket increments now go through safe indexing with the same bounds check
   they already performed (#70 item 6).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ signals a backwards-compatible change.
 
 ### Fixed
 
+- **Made `NitroBatch` frequency estimates unbiased.** Inserts hashed keys with
+  raw `hash128_seeded` while the public estimator derived cells from the
+  packed matrix hash (Packed64 mode), so estimates read cells inserts never
+  wrote and returned ~0; each sampled record now updates every row using the
+  sketch's own fast-path hash derivation, and the geometric skip draw uses
+  `floor` instead of `ceil` (the extra +1 per skip halved-ish the effective
+  sampling rate). Estimates now converge to true frequencies at any rate.
+- **Restored the α relative-accuracy guarantee in portable `DdSketch`.**
+  Quantile representatives changed from the log-midpoint γ^(k+0.5), whose edge
+  error √γ−1 exceeds α, to γ^k·(1+α) — matching core `DDSketch` and DataDog's
+  mapping. No wire/state migration; query outputs shift by at most α.
+- **CountL2HH hot-path L2 accumulation saturates instead of wrapping.**
+  Per-row Σcount² updates run through a saturating i128 intermediate, so
+  extreme turnstile counts no longer wrap silently in release builds (or
+  panic on overflow in debug builds).
 - **Heap-allocate HLL register storage.** `impl_hll_bucket_list!`'s `Default`
   and `Deserialize` no longer build an `[u8; NUM_REGISTERS]` value on the
   stack before boxing it, which overflowed the stack in debug builds at
@@ -30,6 +45,13 @@ signals a backwards-compatible change.
   noisy generic recurrence.
 
 ### Added
+- **Synthetic-data E2E testing harness.** A shared `tests/common` module
+  (seeded stream generators, exact ground-truth trackers, tolerance-based
+  assertion helpers) plus themed integration suites covering frequency,
+  cardinality, quantile, framework/composition, and experimental sketches —
+  every public sketch family is exercised end to end against exact ground
+  truth. Includes `tests/bug_verification.rs` regression tests for the fixes
+  above and `examples/accuracy_probe.rs`, a release-mode ground-truth probe.
 - **Export the `impl_hll_bucket_list!` macro.** Downstream crates can now
   generate an `HllRegisterStorage` type at any precision (e.g. `lg_k = 18`)
   instead of being limited to the built-in `HllBucketListP12/P14/P16`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ signals a backwards-compatible change.
   Quantile representatives changed from the log-midpoint γ^(k+0.5), whose edge
   error √γ−1 exceeds α, to γ^k·(1+α) — matching core `DDSketch` and DataDog's
   mapping. No wire/state migration; query outputs shift by at most α.
+- **Portable `DdSketch` now rejects untrackable inputs like core.** Non-finite
+  values (a NaN previously floor-cast into bucket 0) and finite-but-extreme
+  values beyond the indexable range (which mapped near i32::MAX and forced an
+  arbitrarily large dense-store allocation) are dropped silently, mirroring
+  core `DDSketch`'s min/max-indexable guards and DataDog's mapping (#70).
+- Removed the raw-pointer write from `DDSketch`'s per-sample insertion path;
+  bucket increments now go through safe indexing with the same bounds check
+  they already performed (#70 item 6).
 - **CountL2HH hot-path L2 accumulation saturates instead of wrapping.**
   Per-row Σcount² updates run through a saturating i128 intermediate, so
   extreme turnstile counts no longer wrap silently in release builds (or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ signals a backwards-compatible change.
   raw `hash128_seeded` while the public estimator derived cells from the
   packed matrix hash (Packed64 mode), so estimates read cells inserts never
   wrote and returned ~0; each sampled record now updates every row using the
-  sketch's own fast-path hash derivation, and the geometric skip draw uses
-  `floor` instead of `ceil` (the extra +1 per skip halved-ish the effective
-  sampling rate). Estimates now converge to true frequencies at any rate.
+  sketch's own fast-path hash derivation, and both batch and streaming skip
+  draws use `floor` instead of `ceil` (the extra +1 per skip halved-ish the
+  effective sampling rate). Estimates now converge to true frequencies at any
+  rate. Update weights saturate at the `i32` counter domain instead of
+  wrapping (reachable via rates below ~4.7e-10 or by writing the public
+  `delta` field directly).
 - **Restored the α relative-accuracy guarantee in portable `DdSketch`.**
   Quantile representatives changed from the log-midpoint γ^(k+0.5), whose edge
   error √γ−1 exceeds α, to γ^k·(1+α) — matching core `DDSketch` and DataDog's
@@ -34,7 +37,12 @@ signals a backwards-compatible change.
   dense store: a corrupt delta carrying an index near `i32::MAX` would
   previously have attempted a ~2·10⁹-bucket (~17 GiB) allocation in one call.
   The limit (4M buckets) dwarfs any legitimate span; the `apply_delta*`
-  family propagates the error.
+  family propagates the error. `merge`/`merge_refs` apply the same span cap
+  to decoded snapshots, with a pass-through for stores that already
+  legitimately exceed it. Portable `DdSketch::new` now asserts α ∈ (0,1)
+  like core, and the indexable-range formulas live in one shared helper
+  (`ddsketch_indexable_bounds`) used by both implementations, so their input
+  guards cannot drift apart.
 - Removed the raw-pointer write from `DDSketch`'s per-sample insertion path;
   bucket increments now go through safe indexing with the same bounds check
   they already performed (#70 item 6).

--- a/docs/e2e_testing_harness.md
+++ b/docs/e2e_testing_harness.md
@@ -1,0 +1,208 @@
+# The E2E Testing Harness and Conformance Kit
+
+This document explains how the end-to-end testing harness is designed and how
+to use it when adding or changing a sketch. The short version: **every sketch
+must pass the same conformance batteries, driven by seeded synthetic data and
+compared against exactly-known ground truth.** Ad-hoc assertions alone are no
+longer an acceptable bar for a new sketch.
+
+Related reading:
+
+- [`tests/README.md`](../tests/README.md) — quick onboarding recipe
+- [`tests/common/conformance.rs`](../tests/common/conformance.rs) — the kit itself
+- [`tests/conformance_kit.rs`](../tests/conformance_kit.rs) — reference adapters
+
+## Why it exists
+
+Sketches are approximate by design, which makes them easy to get subtly wrong.
+Three properties make this harness effective where ordinary unit tests are not:
+
+1. **Ground truth is exact.** Generators track the true frequency vector,
+   order statistics, entropy, and cardinality while they emit data. Expected
+   values are never derived from another approximation.
+2. **Everything is deterministic.** All randomness flows through seeded RNGs.
+   A failure today reproduces tomorrow, on any machine.
+3. **Tolerances are justified.** Where theory exists we assert against it
+   (α for DDSketch, rank error bands for KLL, one-sided ε·N bounds for
+   Count-Min). Where it does not, tolerances are documented empirical values
+   consistent across suites.
+
+The harness earned its keep immediately: its first run surfaced four real
+defects — a Nitro estimator that returned zero because inserts and queries
+hashed keys differently, a structural under-count from single-row updates, a
+skip-draw rounding bug that halved the effective sampling rate, and a portable
+DDSketch representative that violated the advertised α bound at bucket edges.
+None of these were caught by the existing unit tests.
+
+## Architecture
+
+```
+tests/
+├── common/
+│   ├── mod.rs           # generators + truth trackers + assertion helpers
+│   └── conformance.rs   # capability traits + reusable batteries  ← the kit
+├── conformance_kit.rs   # reference adapters (copy these)
+├── e2e_frequency.rs     # deep per-family suites…
+├── e2e_cardinality.rs
+├── e2e_quantiles.rs
+├── e2e_frameworks.rs
+├── e2e_experimental.rs  # …feature-gated variants
+└── bug_verification.rs  # regression tests for fixed defects
+```
+
+There are three layers:
+
+**Layer 1 — primitives (`common/mod.rs`).**
+Seeded generators produce streams with known shape: `zipf_u64` (heavy heads),
+`uniform_u64`, `normal_f64`, `exponential_f64`, and `log_uniform_f64`, whose
+values deliberately land on bucket edges of logarithmic mappings. As each
+stream is produced, truth accumulates in `FreqTruth` (per-key counts with
+exact F0/F1/F2/L2/entropy/top-k) or `NumericTruth` (sorted values exposing
+nearest-rank quantiles, CDF, and rank-tolerance value bands). Assertion
+helpers turn comparisons into readable failures that print expected vs actual.
+
+**Layer 2 — the conformance kit (`common/conformance.rs`).**
+A sketch describes *what it guarantees* by implementing small capability
+traits; batteries translate those guarantees into checks. Traits:
+
+| Trait | Promise |
+| --- | --- |
+| `FrequencyOps<K>` | point frequency estimates per key |
+| `SignedFrequencyOps<K>` | weighted/turnstile ingestion (+/− updates) |
+| `CardinalityOps` | distinct count over opaque byte keys |
+| `QuantileOps` | quantiles of a numeric stream |
+| `MergeOps` | in-place merge from a same-config instance |
+
+Batteries consume traits and a tolerance spec, accumulate every violation
+into a `BatteryReport`, and report all failures at once via `.assert_ok()`:
+
+| Battery | Checks |
+| --- | --- |
+| `frequency_battery` | dense-key accuracy; one-sided sketches must never underestimate and stay within `(1 + rel_tol)` |
+| `merge_equivalence_battery` | shard-merged sketch ≡ single-pass sketch within slack |
+| `turnstile_battery` | `+500 / −200 → ~300`; full cancellation → 0 |
+| `cardinality_battery` | unique-stream accuracy at a checkpoint; re-ingesting seen keys must not move the estimate |
+| `quantile_battery` | estimates land inside rank-tolerance value bands across the standard q grid |
+
+Specs carry the tolerances: `FrequencySpec { one_sided, rel_tol, abs_tol }`,
+`CardinalitySpec { rel_tol }`, `QuantileSpec { rank_tol, qs }`.
+
+**Layer 3 — suites.**
+`conformance_kit.rs` wires established sketches through the kit as reference
+adapters. The `e2e_*.rs` suites add depth the kit deliberately does not
+attempt: serialization round trips, window semantics, framework composition
+(Hydra fan-out, tumbling windows, sliding histograms), and cross-implementation
+parity between core types and their portable wire twins.
+
+## Onboarding a new sketch
+
+Worked example. Suppose you added `MyHeavyHitter` that tracks per-key counts,
+supports decrements, and merges.
+
+### 1. Choose batteries matching your documented promises
+
+If your docs say "returns per-key counts", you implement `FrequencyOps`. If
+they promise "counts never underestimate" (Count-Min style), set
+`one_sided: true`. Only claim what you document — the battery enforces the
+spec you select, not what the sketch happens to do.
+
+### 2. Write one adapter struct
+
+```rust
+mod common;
+
+use common::conformance::{self, FrequencyOps, SignedFrequencyOps};
+
+struct MyAdapter(MyHeavyHitter);
+
+impl FrequencyOps<i64> for MyAdapter {
+    fn ingest(&mut self, key: &i64) {
+        self.0.insert(&DataInput::I64(*key));
+    }
+    fn estimate(&self, key: &i64) -> f64 {
+        self.0.estimate(&DataInput::I64(*key)) as f64
+    }
+}
+
+impl SignedFrequencyOps<i64> for MyAdapter {
+    fn ingest_weighted(&mut self, key: &i64, weight: i64) {
+        self.0.insert_many(&DataInput::I64(*key), weight);
+    }
+}
+```
+
+Adapters exist so the kit stays stable while sketch constructors vary. Keep
+them thin — no logic beyond translating types.
+
+### 3. Run production-shaped batteries
+
+```rust
+#[test]
+fn my_heavy_hitter_passes_conformance() {
+    let stream = common::zipf_u64(60_000, 2048, 1.1, /* seed */ 9001);
+    let mut truth = common::FreqTruth::default();
+    for k in &stream { truth.observe(*k as i64); }
+
+    let spec = conformance::FrequencySpec { one_sided: false, rel_tol: 0.05, abs_tol: 20.0 };
+    conformance::frequency_battery(
+        "MyHeavyHitter",
+        || MyAdapter(MyHeavyHitter::with_dimensions(5, 4096)),
+        // ^ construct at dimensions users actually deploy, not toy sizes
+        &stream.iter().map(|v| *v as i64).collect::<Vec<_>>(),
+        &truth,
+        spec,
+    )
+    .assert_ok();
+
+    conformance::turnstile_battery("MyHeavyHitter", || MyAdapter(MyHeavyHitter::with_dimensions(5, 4096)), 42)
+        .assert_ok();
+}
+```
+
+Use realistic parameters. A sketch tuned to pass a 16-column toy grid tells
+you nothing about behavior at 4096 columns under Zipf traffic; several real
+bugs only appeared at deployment-shaped dimensions.
+
+### 4. Add depth where the sketch is unusual
+
+Anything not covered by a battery belongs in the matching `e2e_*.rs` suite:
+window semantics, merge order-independence, wire-format parity with the
+portable type, heavy-hitter recall targets, and so on.
+
+## Tolerance policy
+
+- Prefer theoretical bounds and cite them in a comment next to the spec.
+- Empirical tolerances must be no looser than comparable sketches in the same
+  suite. If your sketch needs ±30% where KLL uses ±3%, either fix the sketch
+  or document why the guarantee is genuinely weaker before widening.
+- Fixed seeds are part of the contract. If a test is flaky, do not loosen the
+  seed's randomness exposure — tighten the implementation or state the
+  statistical intent explicitly and pick a defensible band.
+
+## Rules and anti-patterns
+
+- No unseeded randomness anywhere in tests. Coco-style nondeterministic
+  implementations are tested statistically over bounded ranges instead.
+- Never derive expected values from another approximation. Truth comes from
+  `FreqTruth`/`NumericTruth`, full stop.
+- Do not bypass public APIs in tests to "fix" them. The Nitro estimator
+  shipped broken precisely because its tests re-implemented estimation with
+  matching hashes instead of calling the public method.
+- Beware generator bugs masquerading as sketch bugs: an early draft drew a
+  fresh random number inside a `binary_search_by` comparator, corrupting the
+  whole distribution. When accuracy looks wrong, first verify the stream's
+  empirical shape matches its name.
+- Batteries report everything; call `.assert_ok()` once rather than asserting
+  inline so a single CI run shows the complete picture.
+
+## Running
+
+```bash
+cargo test --all-features --locked          # full matrix incl. experimental
+cargo test --test conformance_kit            # kit + reference adapters only
+cargo run --release --example accuracy_probe --features experimental
+                                             # heavy release-only probes
+```
+
+CI enforces format, clippy (`-D warnings`, all features), and the full test
+matrix on every PR.

--- a/examples/accuracy_probe.rs
+++ b/examples/accuracy_probe.rs
@@ -987,11 +987,7 @@ fn probe_tumbling() {
 
     // KLL tumbling: the numeric `value` arg is IGNORED; the KEY doubles as the
     // observation (tumbling.rs:146-149). Feed values via the key.
-    let kcfg = asap_sketchlib::KLLConfig {
-        k: 200,
-        m: 8,
-        seed: None,
-    };
+    let kcfg = asap_sketchlib::KLLConfig { k: 200, m: 8 };
     let mut tkw: TumblingWindow<KLL> = TumblingWindow::new(100, 4, kcfg, 2);
     let mut rng = StdRng::seed_from_u64(53);
     let mut all_vals: Vec<f64> = Vec::new();

--- a/examples/accuracy_probe.rs
+++ b/examples/accuracy_probe.rs
@@ -987,7 +987,11 @@ fn probe_tumbling() {
 
     // KLL tumbling: the numeric `value` arg is IGNORED; the KEY doubles as the
     // observation (tumbling.rs:146-149). Feed values via the key.
-    let kcfg = asap_sketchlib::KLLConfig { k: 200, m: 8 };
+    let kcfg = asap_sketchlib::KLLConfig {
+        k: 200,
+        m: 8,
+        seed: None,
+    };
     let mut tkw: TumblingWindow<KLL> = TumblingWindow::new(100, 4, kcfg, 2);
     let mut rng = StdRng::seed_from_u64(53);
     let mut all_vals: Vec<f64> = Vec::new();

--- a/examples/accuracy_probe.rs
+++ b/examples/accuracy_probe.rs
@@ -1,0 +1,1100 @@
+//! Ground-truth accuracy probe for every sketch family in asap_sketchlib.
+//!
+//! Run: cargo run --release --example accuracy_probe --features experimental
+//!
+//! Each section feeds deterministic synthetic streams with exactly known
+//! answers into a sketch and compares query results against ground truth,
+//! printing EXPECTED vs ACTUAL and a theory-based verdict.
+
+use asap_sketchlib::common::input::{HydraCounter, HydraQuery};
+use asap_sketchlib::message_pack_format::portable::countminsketch::CountMinSketch;
+use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketch as PortableDds;
+use asap_sketchlib::message_pack_format::portable::hll::{HllSketch, HllVariant};
+use asap_sketchlib::message_pack_format::portable::hydra_kll::HydraKllSketch;
+use asap_sketchlib::message_pack_format::portable::kll::KllSketch as PortableKll;
+use asap_sketchlib::{
+    CMSHeap, CSHeap, Count as CoreCount, CountL2HH, CountMin, DDSketch, DataInput, Hydra,
+    HyperLogLog, KLL, UnivMon,
+};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::collections::HashMap;
+
+struct Probe {
+    failures: Vec<String>,
+    notes: Vec<String>,
+}
+
+impl Probe {
+    fn new() -> Self {
+        Self {
+            failures: Vec::new(),
+            notes: Vec::new(),
+        }
+    }
+
+    fn check(&mut self, name: &str, detail: String, ok: bool) {
+        let tag = if ok { "PASS" } else { "FAIL" };
+        println!("  [{tag}] {name}: {detail}");
+        if !ok {
+            self.failures.push(format!("{name}: {detail}"));
+        }
+    }
+
+    fn note(&mut self, msg: &str) {
+        println!("  [NOTE] {msg}");
+        self.notes.push(msg.to_string());
+    }
+
+    fn finish(self, section: &str) {
+        if self.failures.is_empty() {
+            println!("== {section}: ALL PASS ==");
+        } else {
+            println!("== {section}: {} FAILURE(S) ==", self.failures.len());
+        }
+        println!();
+    }
+}
+
+fn rel_err(est: f64, truth: f64) -> f64 {
+    if truth == 0.0 {
+        est.abs()
+    } else {
+        ((est - truth) / truth).abs()
+    }
+}
+
+/// Zipf(s) sampler over domain [0, domain).
+struct Zipf {
+    cdf: Vec<f64>,
+    rng: StdRng,
+}
+
+impl Zipf {
+    fn new(domain: usize, exponent: f64, seed: u64) -> Self {
+        let mut w: Vec<f64> = (0..domain)
+            .map(|i| 1.0 / (i as f64 + 1.0).powf(exponent))
+            .collect();
+        for i in 1..w.len() {
+            w[i] += w[i - 1];
+        }
+        let total = w[domain - 1];
+        for x in w.iter_mut() {
+            *x /= total;
+        }
+        Self {
+            cdf: w,
+            rng: StdRng::seed_from_u64(seed),
+        }
+    }
+
+    fn sample_usize(&mut self) -> usize {
+        let u: f64 = self.rng.random::<f64>();
+        match self.cdf.binary_search_by(|p| p.partial_cmp(&u).unwrap()) {
+            Ok(i) => i,
+            Err(i) => i,
+        }
+    }
+
+    fn sample_i64(&mut self) -> i64 {
+        self.sample_usize() as i64
+    }
+}
+
+fn main() {
+    println!("================ ASAP SKETCHLIB GROUND-TRUTH PROBE ================\n");
+    probe_countmin();
+    probe_countsketch();
+    probe_topk_heaps();
+    probe_countl2hh();
+    probe_hll();
+    probe_kll();
+    probe_ddsketch();
+    probe_hydra();
+    probe_univmon();
+    #[cfg(feature = "experimental")]
+    probe_univmon_pyramid();
+    probe_univmon_q();
+    probe_nitro();
+    #[cfg(feature = "experimental")]
+    probe_eh_univ();
+    probe_tumbling();
+    probe_portable_wire_types();
+
+    println!("====================================================================");
+    println!("Probe complete. FAIL lines above are candidate wrong-query-results.");
+}
+
+// ---------------------------------------------------------------- CountMin
+fn probe_countmin() {
+    let mut p = Probe::new();
+    println!("--- CountMin (core, Vector2D<i32>) ---");
+
+    // Sparse dims: no collisions => exact counts, incl. turnstile negatives.
+    let mut cm =
+        CountMin::<asap_sketchlib::Vector2D<i32>, asap_sketchlib::RegularPath>::with_dimensions(
+            3, 256,
+        );
+    cm.insert_many(&DataInput::U32(7), 100);
+    cm.insert_many(&DataInput::U32(7), -40);
+    let est = cm.estimate(&DataInput::U32(7));
+    p.check(
+        "turnstile +100/-40 == 60",
+        format!("expected 60, got {est}"),
+        est == 60,
+    );
+
+    // Zipf stream: one-sided CMS guarantee est >= true, excess <= eps*N.
+    let (rows, cols, n, domain) = (3usize, 4096usize, 200_000usize, 8192usize);
+    let mut cm =
+        CountMin::<asap_sketchlib::Vector2D<i64>, asap_sketchlib::FastPath>::with_dimensions(
+            rows, cols,
+        );
+    let mut truth: HashMap<i64, i64> = HashMap::new();
+    let mut z = Zipf::new(domain, 1.1, 42);
+    for _ in 0..n {
+        let k = z.sample_i64();
+        *truth.entry(k).or_insert(0) += 1;
+        cm.insert(&DataInput::I64(k));
+    }
+    let eps = std::f64::consts::E / cols as f64;
+    // Check top-100 hottest keys.
+    let mut by_freq: Vec<(i64, i64)> = truth.iter().map(|(k, v)| (*k, *v)).collect();
+    by_freq.sort_by_key(|(_, v)| -*v);
+    let mut worst_excess = 0.0f64;
+    let mut underestimates = 0usize;
+    for (k, v) in &by_freq[..100] {
+        let est = cm.estimate(&DataInput::I64(*k));
+        if est < *v {
+            underestimates += 1;
+        }
+        worst_excess = worst_excess.max((est - v) as f64);
+    }
+    p.check(
+        "CMS never underestimates (top-100 hot keys)",
+        format!("{underestimates} underestimates"),
+        underestimates == 0,
+    );
+    p.check(
+        "CMS excess <= eps*N on all checked keys",
+        format!(
+            "eps*N = {:.1}, max observed excess = {:.1}",
+            eps * n as f64,
+            worst_excess
+        ),
+        worst_excess <= eps * n as f64,
+    );
+    p.finish("CountMin");
+}
+
+// ------------------------------------------------------------- CountSketch
+fn probe_countsketch() {
+    let mut p = Probe::new();
+    println!("--- CountSketch (core Count, Vector2D<i64>) ---");
+
+    // True turnstile: net-zero stream must estimate ~0.
+    let mut cs =
+        CoreCount::<asap_sketchlib::Vector2D<i64>, asap_sketchlib::RegularPath>::with_dimensions(
+            4, 512,
+        );
+    cs.insert_many(&DataInput::U32(3), 500);
+    cs.insert_many(&DataInput::U32(3), -500);
+    let est = cs.estimate(&DataInput::U32(3));
+    p.check(
+        "turnstile +500/-500 ~= 0",
+        format!("expected ~0, got {est}"),
+        est.abs() < 1e-9,
+    );
+
+    // Zipf: median estimator error bound |est-true| <= t/sqrt(cols) * L2.
+    let (rows, cols, n, domain) = (5usize, 4096usize, 200_000usize, 8192usize);
+    let mut cs =
+        CoreCount::<asap_sketchlib::Vector2D<i64>, asap_sketchlib::RegularPath>::with_dimensions(
+            rows, cols,
+        );
+    let mut truth: HashMap<i64, i64> = HashMap::new();
+    let mut z = Zipf::new(domain, 1.1, 43);
+    for _ in 0..n {
+        let k = z.sample_i64();
+        *truth.entry(k).or_insert(0) += 1;
+        cs.insert(&DataInput::I64(k));
+    }
+    let l2 = (truth
+        .values()
+        .map(|c| (*c as f64) * (*c as f64))
+        .sum::<f64>())
+    .sqrt();
+    let bound = (std::f64::consts::E / cols as f64).sqrt() * l2; // median-of-t rows whp
+    let mut by_freq: Vec<(i64, i64)> = truth.iter().map(|(k, v)| (*k, *v)).collect();
+    by_freq.sort_by_key(|(_, v)| -*v);
+    let mut violations = 0usize;
+    let mut max_abs_err = 0.0f64;
+    for (k, v) in &by_freq[..100] {
+        let est = cs.estimate(&DataInput::I64(*k));
+        let err = (est - *v as f64).abs();
+        max_abs_err = max_abs_err.max(err);
+        if err > bound {
+            violations += 1;
+        }
+    }
+    p.check(
+        "CS |err| <= sqrt(e/cols)*L2 (top-100)",
+        format!("bound {bound:.1}, max err {max_abs_err:.1}, violations {violations}/100"),
+        violations == 0,
+    );
+    p.finish("CountSketch");
+}
+
+// -------------------------------------------------------------- Top-K heaps
+fn probe_topk_heaps() {
+    let mut p = Probe::new();
+    println!("--- CMSHeap / CSHeap top-k recall ---");
+    let (n, domain, top_k) = (20_000usize, 1024usize, 16usize);
+    let mut z = Zipf::new(domain, 1.1, 44);
+    let mut truth: HashMap<u32, i64> = HashMap::new();
+    let mut stream = Vec::with_capacity(n);
+    for _ in 0..n {
+        let k = z.sample_usize() as u32;
+        *truth.entry(k).or_insert(0) += 1;
+        stream.push(k);
+    }
+    let mut true_top: Vec<(u32, i64)> = truth.iter().map(|(k, v)| (*k, *v)).collect();
+    true_top.sort_by_key(|(_, v)| -*v);
+    let true_top_set: std::collections::HashSet<u32> =
+        true_top.iter().take(top_k).map(|(k, _)| *k).collect();
+
+    let mut cms_heap =
+        CMSHeap::<asap_sketchlib::Vector2D<i64>, asap_sketchlib::RegularPath>::new(3, 4096, top_k);
+    let mut cs_heap =
+        CSHeap::<asap_sketchlib::Vector2D<i64>, asap_sketchlib::RegularPath>::new(5, 4096, top_k);
+    for k in &stream {
+        let d = DataInput::U32(*k);
+        cms_heap.insert(&d);
+        cs_heap.insert(&d);
+    }
+    for (label, heap_items) in [
+        ("CMSHeap", cms_heap.heap().heap().to_vec()),
+        ("CSHeap", cs_heap.heap().heap().to_vec()),
+    ] {
+        let found = heap_items
+            .iter()
+            .filter(|it| match it.key {
+                asap_sketchlib::HeapItem::U32(v) => true_top_set.contains(&v),
+                _ => false,
+            })
+            .count();
+        p.check(
+            &format!("{label} top-{top_k} recall"),
+            format!("{found}/{top_k} true heavy hitters recovered"),
+            found >= top_k - 1,
+        );
+    }
+
+    // CSHeap turnstile can push NEGATIVE counts into the heap (legal CS estimate).
+    let mut cs_neg =
+        CSHeap::<asap_sketchlib::Vector2D<i64>, asap_sketchlib::RegularPath>::new(3, 4096, 8);
+    cs_neg.insert_many(&DataInput::U32(999), -5);
+    if let Some(it) = cs_neg
+        .heap()
+        .heap()
+        .iter()
+        .find(|it| matches!(it.key, asap_sketchlib::HeapItem::U32(999)))
+    {
+        let cnt = it.count;
+        p.note(&format!("CSHeap stores negative heap count {cnt} for pure-decrement key (design wart, not a crash)"));
+    }
+    p.finish("TopK heaps");
+}
+
+// --------------------------------------------------------------- CountL2HH
+fn probe_countl2hh() {
+    let mut p = Probe::new();
+    println!("--- CountL2HH (F2 / L2 estimation) ---");
+
+    // Moderate stream F2 accuracy (truth = sum over KEYS of count^2).
+    let mut sk = CountL2HH::<asap_sketchlib::DefaultXxHasher>::with_dimensions_and_seed(4, 2048, 7);
+    let mut z = Zipf::new(1024, 1.2, 45);
+    let mut per_key: HashMap<u32, i64> = HashMap::new();
+    for i in 0..50_000u32 {
+        let k = z.sample_usize() as u32;
+        let w = 1 + (i % 3) as i64;
+        sk.fast_insert_with_count(&DataInput::U32(k), w);
+        *per_key.entry(k).or_insert(0) += w;
+    }
+    let truth_f2: f64 = per_key.values().map(|c| (*c as f64) * (*c as f64)).sum();
+    let l2 = sk.get_l2();
+    let got_f2 = sk.get_l2_sqr();
+    p.check(
+        "F2 within 15% of truth",
+        format!(
+            "expected {truth_f2:.3e}, got {got_f2:.3e} (rel {:.3})",
+            rel_err(got_f2, truth_f2)
+        ),
+        rel_err(l2 * l2, truth_f2) < 0.15,
+    );
+
+    // Turnstile decrement support.
+    let mut sk2 =
+        CountL2HH::<asap_sketchlib::DefaultXxHasher>::with_dimensions_and_seed(4, 2048, 7);
+    sk2.fast_insert_with_count(&DataInput::U32(1), 5);
+    sk2.fast_insert_with_count(&DataInput::U32(1), -2);
+    let est = sk2.fast_update_and_est(&DataInput::U32(1), 0);
+    p.check(
+        "turnstile 5 then -2 estimates 3",
+        format!("expected 3, got {est}"),
+        (est - 3.0).abs() < 1e-6,
+    );
+
+    // i64 overflow probe: two 3e9-count keys => true F2 = 1.8e19 > i64::MAX.
+    // Post-fix contract: saturates at i64::MAX instead of wrapping silently.
+    let mut sk3 =
+        CountL2HH::<asap_sketchlib::DefaultXxHasher>::with_dimensions_and_seed(4, 2048, 7);
+    sk3.fast_insert_with_count(&DataInput::U32(1), 3_000_000_000);
+    sk3.fast_insert_with_count(&DataInput::U32(2), 3_000_000_000);
+    let got = sk3.get_l2_sqr();
+    let truth = 2.0f64 * (3_000_000_000f64).powi(2);
+    let saturated = got > i64::MAX as f64 * 0.999;
+    p.check(
+        "F2 saturates at i64::MAX beyond representable range",
+        if saturated {
+            format!("saturated at {got:.3e} (true {truth:.3e})")
+        } else {
+            format!("GARBAGE from wrap: expected ~{truth:.3e}, got {got:.3e}")
+        },
+        saturated,
+    );
+    p.finish("CountL2HH");
+}
+
+// --------------------------------------------------------------------- HLL
+fn probe_hll() {
+    let mut p = Probe::new();
+    println!("--- HLL cardinality (Classic / ErtlMLE / HIP, p14) ---");
+    let checkpoints: [u64; 4] = [10_000, 100_000, 1_000_000, 10_000_000];
+    let mut classic = HyperLogLog::<asap_sketchlib::Classic>::new();
+    let mut ertl = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
+    let mut hip = asap_sketchlib::HyperLogLogHIP::new();
+    let mut inserted: u64 = 0;
+    for &target in &checkpoints {
+        while inserted < target {
+            let v = DataInput::U64(inserted);
+            classic.insert(&v);
+            ertl.insert(&v);
+            hip.insert(&v);
+            inserted += 1;
+        }
+        let ec = classic.estimate() as f64;
+        let ee = ertl.estimate() as f64;
+        let eh = hip.estimate() as f64;
+        let t = target as f64;
+        p.check(
+            &format!("Classic @ {target} within 2%"),
+            format!("rel {:.4}", rel_err(ec, t)),
+            rel_err(ec, t) <= 0.02,
+        );
+        p.check(
+            &format!("ErtlMLE @ {target} within 2%"),
+            format!("rel {:.4}", rel_err(ee, t)),
+            rel_err(ee, t) <= 0.02,
+        );
+        p.check(
+            &format!("HIP @ {target} within 2%"),
+            format!("rel {:.4}", rel_err(eh, t)),
+            rel_err(eh, t) <= 0.02,
+        );
+    }
+    // Large-range correction regime (>143M raw estimate): Classic uses
+    // i32::MAX where Flajolet specifies 2^32 (src/sketches/hll.rs:216-218).
+    // Only Classic uses this correction; Ertl MLE has its own estimator.
+    let target = 170_000_000u64;
+    while inserted < target {
+        let v = DataInput::U64(inserted);
+        classic.insert(&v);
+        inserted += 1;
+    }
+    let t = target as f64;
+    let ec = classic.estimate() as f64;
+    p.check(
+        &format!("Classic @ {target} within 3% (large-range correction active)"),
+        format!("rel {:.4}", rel_err(ec, t)),
+        rel_err(ec, t) <= 0.03,
+    );
+    p.finish("HLL");
+}
+
+// --------------------------------------------------------------------- KLL
+fn probe_kll() {
+    let mut p = Probe::new();
+    println!("--- KLL / KLLDynamic quantiles (k=200) ---");
+    let qs = [0.1f64, 0.25, 0.5, 0.75, 0.9];
+
+    let n = 100_000usize;
+    let mut rng = StdRng::seed_from_u64(46);
+    let mut data: Vec<f64> = (0..n).map(|_| rng.random::<f64>() * 1_000_000.0).collect();
+    data.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    for label in ["KLL", "KLLDynamic"] {
+        let (e1, w1) = if label == "KLL" {
+            let mut sk = asap_sketchlib::KLL::init_kll(200);
+            for v in &data {
+                sk.update(v);
+            }
+            check_quantiles(&sk, &data, &qs)
+        } else {
+            let mut sk = asap_sketchlib::KLLDynamic::<f64>::init_kll(200);
+            for v in &data {
+                sk.update(v);
+            }
+            check_quantiles_dyn(&sk, &data, &qs)
+        };
+        p.check(
+            &format!("{label} rank err <= 0.02 at q10/25/50/75/90"),
+            if w1.is_empty() {
+                "all within band".to_string()
+            } else {
+                format!("worst {w1}")
+            },
+            e1 <= 0.02,
+        );
+
+        // Merge preservation: split halves into two sketches, merge, re-check.
+        let mut a = asap_sketchlib::KLL::init_kll_with_seed(200, 99);
+        let mut b = asap_sketchlib::KLL::init_kll_with_seed(200, 123);
+        for (i, v) in data.iter().enumerate() {
+            if i % 2 == 0 {
+                a.update(v);
+            } else {
+                b.update(v);
+            }
+        }
+        a.merge(&b);
+        let mut worst_merge = 0.0f64;
+        for &q in &qs {
+            let est = a.quantile(q);
+            let rank = data.partition_point(|x| *x <= est) as f64 / n as f64;
+            worst_merge = worst_merge.max((rank - q).abs());
+        }
+        p.check(
+            &format!("{label} merge preserves distribution"),
+            format!("worst rank drift {:.4}", worst_merge),
+            worst_merge <= 0.02,
+        );
+    }
+    p.finish("KLL");
+}
+
+fn check_quantiles(sk: &asap_sketchlib::KLL, data: &[f64], qs: &[f64]) -> (f64, String) {
+    quantile_report(|q| sk.quantile(q), data, qs)
+}
+
+fn check_quantiles_dyn(
+    sk: &asap_sketchlib::KLLDynamic<f64>,
+    data: &[f64],
+    qs: &[f64],
+) -> (f64, String) {
+    quantile_report(|q| sk.quantile(q), data, qs)
+}
+
+fn quantile_report(qf: impl Fn(f64) -> f64, data: &[f64], qs: &[f64]) -> (f64, String) {
+    let n = data.len();
+    let mut worst = 0.0f64;
+    let mut worst_desc = String::new();
+    for &q in qs {
+        let est = qf(q);
+        let rank = data.partition_point(|x| *x <= est) as f64 / n as f64;
+        if (rank - q).abs() > worst {
+            worst = (rank - q).abs();
+            worst_desc = format!("q={q} est={est:.1} rank={rank:.3}");
+        }
+    }
+    (worst, worst_desc)
+}
+
+// ---------------------------------------------------------------- DDSketch
+fn probe_ddsketch() {
+    let mut p = Probe::new();
+    println!("--- DDSketch core vs portable (alpha=0.05) ---");
+    let alpha = 0.05;
+    let gamma = (1.0f64 + alpha) / (1.0 - alpha);
+    // Isolated adversarial probe: one distinct value sitting just above a
+    // bucket's lower edge gamma^k, repeated N times. The only correct answer
+    // for every quantile is v itself.
+    let mut worst_core = 0.0f64;
+    let mut worst_port = 0.0f64;
+    for k in [10i32, 20, 30] {
+        let v = gamma.powi(k) * (1.0 + 1e-6); // just inside bucket k
+        let n = 10_000u64;
+
+        let mut core = DDSketch::new(alpha);
+        let mut port = PortableDds::new(alpha);
+        for _ in 0..n {
+            core.add(&v);
+            port.update(v);
+        }
+        let rc = rel_err(core.get_value_at_quantile(0.5).unwrap(), v);
+        let rp = rel_err(port.quantile(0.5).unwrap(), v);
+        worst_core = worst_core.max(rc);
+        worst_port = worst_port.max(rp);
+    }
+    p.check(
+        "core DDSketch honors alpha=0.05 at bucket edges",
+        format!("max rel err {worst_core:.5}"),
+        worst_core <= alpha * (1.0 + 1e-6),
+    );
+    p.check(
+        "portable DdSketch honors alpha=0.05 at bucket edges",
+        format!("max rel err {worst_port:.5} (gamma^(k+0.5) midpoint rep)"),
+        worst_port <= alpha * (1.0 + 1e-6),
+    );
+
+    // Mixed-stream sanity on both.
+    let mut rng = StdRng::seed_from_u64(47);
+    let mut core = DDSketch::new(alpha);
+    let mut port = PortableDds::new(alpha);
+    let mut truth: Vec<f64> = Vec::new();
+    for _ in 0..20_000 {
+        let k = rng.random_range(5..40);
+        let frac = rng.random::<f64>();
+        let v = gamma.powi(k) * (1.0 + frac * (gamma - 1.0));
+        core.add(&v);
+        port.update(v);
+        truth.push(v);
+    }
+    truth.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mc = qs_max_rel(&truth, |q| core.get_value_at_quantile(q).unwrap(), &qs_dd());
+    let mp = qs_max_rel(&truth, |q| port.quantile(q).unwrap(), &qs_dd());
+    p.check(
+        "core mixed stream <= alpha",
+        format!("max rel {mc:.5}"),
+        mc <= alpha,
+    );
+    p.check(
+        "portable mixed stream <= alpha",
+        format!("max rel {mp:.5}"),
+        mp <= alpha,
+    );
+    p.finish("DDSketch");
+}
+
+fn qs_dd() -> [f64; 5] {
+    [0.1, 0.25, 0.5, 0.75, 0.9]
+}
+
+fn qs_max_rel(truth: &[f64], qf: impl Fn(f64) -> f64, qs: &[f64]) -> f64 {
+    let n = truth.len();
+    let mut worst = 0.0f64;
+    for &q in qs {
+        let idx = ((q * n as f64).ceil() as usize).clamp(1, n);
+        let t = truth[idx - 1];
+        let est = qf(q);
+        worst = worst.max(rel_err(est, t));
+    }
+    worst
+}
+
+// ------------------------------------------------------------------- Hydra
+fn probe_hydra() {
+    let mut p = Probe::new();
+    println!("--- Hydra (KLL-backed counter) ---");
+    let mut hydra = Hydra::with_schema(4, 512, ["region"], HydraCounter::KLL(KLL::init_kll(200)))
+        .expect("schema");
+    let mut rng = StdRng::seed_from_u64(48);
+    let mut samples: Vec<f64> = (0..10_000).map(|_| rng.random::<f64>() * 1000.0).collect();
+    let mut sorted = samples.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    for v in &samples {
+        hydra
+            .update(&["eu"], &DataInput::F64(*v), None)
+            .expect("update");
+    }
+    let n = samples.len();
+
+    // Proper quantile query via HydraQuery::Quantile.
+    let med = hydra
+        .query_key(&[Some("eu")], &HydraQuery::Quantile(0.5))
+        .expect("q");
+    let truth_med = sorted[n / 2];
+    p.check(
+        "HydraQuery::Quantile(0.5) approx median",
+        format!("expected ~{truth_med:.1}, got {med:.1}"),
+        (med - truth_med).abs() / truth_med < 0.05,
+    );
+
+    // query_quantile(name says quantile, actually returns CDF(threshold)).
+    let x = 500.0;
+    let got = hydra.query_quantile(&[Some("eu")], x).expect("cdf");
+    let truth_cdf = sorted.partition_point(|v| *v <= x) as f64 / n as f64;
+    p.note("Hydra::query_quantile(key, threshold) returns CDF(threshold), NOT a quantile value (name inversion)");
+    p.check(
+        "query_quantile(x)=CDF fraction <= x",
+        format!("x={x}, expected ~{truth_cdf:.3}, got {got:.3}"),
+        (got - truth_cdf).abs() < 0.03,
+    );
+
+    // Frequency through a CM-backed head is exact-ish.
+    let mut hcm = Hydra::with_schema(4, 512, ["region"], HydraCounter::CM(Default::default()))
+        .expect("schema2");
+    for _ in 0..37 {
+        hcm.update(&["us"], &DataInput::Str("click"), None)
+            .expect("upd");
+    }
+    let f = hcm
+        .query_frequency(&[Some("us")], &DataInput::Str("click"))
+        .expect("freq");
+    p.check(
+        "CM head frequency == 37",
+        format!("expected 37, got {f}"),
+        f == 37.0,
+    );
+    let _ = &mut samples;
+    p.finish("Hydra");
+}
+
+// ----------------------------------------------------------------- UnivMon
+fn probe_univmon() {
+    let mut p = Probe::new();
+    println!("--- UnivMon weighted metrics ---");
+    let mut um = UnivMon::init_univmon(32, 5, 2048, 8);
+    let mut truth_w: HashMap<u32, i64> = HashMap::new();
+    let mut z = Zipf::new(1000, 1.2, 49);
+    for i in 0..20_000usize {
+        let k = z.sample_usize() as u32;
+        let w = 1 + (i % 7) as i64;
+        um.insert(&DataInput::U32(k), w);
+        *truth_w.entry(k).or_insert(0) += w;
+    }
+    let l1_truth: i64 = truth_w.values().sum();
+    let l2_truth: f64 = truth_w
+        .values()
+        .map(|w| (*w as f64).powi(2))
+        .sum::<f64>()
+        .sqrt();
+    let total = l1_truth as f64;
+    let entropy_truth: f64 = -truth_w
+        .values()
+        .map(|w| {
+            let pr = *w as f64 / total;
+            if pr > 0.0 { pr * pr.log2() } else { 0.0 }
+        })
+        .sum::<f64>();
+    let card_truth = truth_w.len() as f64;
+
+    let l1 = um.calc_l1();
+    let l2 = um.calc_l2();
+    let ent = um.calc_entropy();
+    let card = um.calc_card();
+    p.check(
+        "L1 exact",
+        format!("expected {l1_truth}, got {l1}"),
+        (l1 - l1_truth as f64).abs() < 1e-6,
+    );
+    p.check(
+        "L2 within 5%",
+        format!(
+            "expected {l2_truth:.1}, got {l2:.1} (rel {:.4})",
+            rel_err(l2, l2_truth)
+        ),
+        rel_err(l2, l2_truth) < 0.05,
+    );
+    p.check(
+        "entropy(bits) within 5%",
+        format!("expected {entropy_truth:.4}, got {ent:.4}"),
+        rel_err(ent, entropy_truth) < 0.05,
+    );
+    p.check(
+        "cardinality within 5%",
+        format!("expected {card_truth}, got {card}"),
+        rel_err(card, card_truth) < 0.05,
+    );
+
+    // Entropy unit sanity: bits value should be log2 larger than nats value.
+    p.note("UnivMon calc_entropy returns BITS (log2); UnivMonQ estimate_entropy returns NATS (ln). Cross-family comparisons need conversion.");
+    p.finish("UnivMon");
+}
+
+#[cfg(feature = "experimental")]
+fn probe_univmon_pyramid() {
+    use asap_sketchlib::UnivMonPyramid;
+    let mut p = Probe::new();
+    println!("--- UnivMonPyramid (experimental) ---");
+    let mut up = UnivMonPyramid::with_defaults();
+    let mut truth_w: HashMap<u32, i64> = HashMap::new();
+    let mut z = Zipf::new(1000, 1.2, 50);
+    for i in 0..20_000usize {
+        let k = z.sample_usize() as u32;
+        let w = 1 + (i % 7) as i64;
+        up.insert(&DataInput::U32(k), w);
+        *truth_w.entry(k).or_insert(0) += w;
+    }
+    let l1_truth: i64 = truth_w.values().sum();
+    let card_truth = truth_w.len() as f64;
+    let l1 = up.calc_l1();
+    let card = up.calc_card();
+    p.check(
+        "L1 exact",
+        format!("expected {l1_truth}, got {l1}"),
+        (l1 - l1_truth as f64).abs() < 1e-6,
+    );
+    p.check(
+        "cardinality within 10%",
+        format!("expected {card_truth}, got {card}"),
+        rel_err(card, card_truth) < 0.10,
+    );
+    p.finish("UnivMonPyramid");
+}
+
+// ---------------------------------------------------------------- UnivMonQ
+fn probe_univmon_q() {
+    let mut p = Probe::new();
+    println!("--- UnivMon-Q ---");
+    let mut q = asap_sketchlib::UnivMonQ::new(Default::default()).expect("config");
+    let mut rng = StdRng::seed_from_u64(51);
+    let mut data: Vec<f64> = Vec::with_capacity(50_000);
+    let mut freq: HashMap<u64, u64> = HashMap::new();
+    for _ in 0..50_000 {
+        let v: f64 = if rng.random::<f64>() < 0.3 {
+            7.0
+        } else {
+            (rng.random::<u64>() % 5000) as f64
+        };
+        q.update(&v);
+        *freq.entry(v as u64).or_insert(0) += 1;
+        data.push(v);
+    }
+    let mut sorted = data.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = data.len() as f64;
+
+    p.check(
+        "count exact",
+        format!("expected {}, got {}", data.len(), q.count()),
+        q.count() as usize == data.len(),
+    );
+    let mn = q.min();
+    let mx = q.max();
+    p.check(
+        "min exact",
+        format!("expected Some(0), got {mn:?}"),
+        mn == Some(0.0),
+    );
+    p.check(
+        "max exact",
+        format!("expected Some(4999), got {mx:?}"),
+        mx == Some(4999.0),
+    );
+
+    let hot_truth = freq[&7] as f64;
+    let hot = q.estimate_frequency(7.0);
+    p.check(
+        "frequency(hot=7.0) within 5%",
+        format!("expected {hot_truth}, got {hot}"),
+        rel_err(hot as f64, hot_truth) < 0.05,
+    );
+
+    let distinct_truth = freq.len() as f64;
+    let dist = q.estimate_distinct();
+    p.check(
+        "distinct within 10%",
+        format!("expected {distinct_truth}, got {dist}"),
+        rel_err(dist, distinct_truth) < 0.10,
+    );
+
+    let f2_truth: f64 = freq.values().map(|c| (*c as f64).powi(2)).sum();
+    let f2 = q.estimate_f2();
+    p.check(
+        "F2 within 15%",
+        format!("expected {f2_truth:.3e}, got {f2:.3e}"),
+        rel_err(f2, f2_truth) < 0.15,
+    );
+
+    let ent_truth: f64 = -freq
+        .values()
+        .map(|c| {
+            let pr = *c as f64 / n;
+            pr * pr.ln()
+        })
+        .sum::<f64>();
+    let ent = q.estimate_entropy();
+    p.check(
+        "entropy(NATS) within 10%",
+        format!("expected {ent_truth:.4}, got {ent:.4}"),
+        rel_err(ent, ent_truth) < 0.10,
+    );
+
+    let mut worst_rank = 0.0f64;
+    // Value-band metric (tie-safe): est must lie between true ranks q±0.03.
+    for &qq in &[0.1f64, 0.25, 0.5, 0.75, 0.9] {
+        if let Some(est) = q.quantile(qq) {
+            let lo = ((qq - 0.03).max(0.0) * n) as usize;
+            let hi = (((qq + 0.03).min(1.0) * n) as usize).min(sorted.len());
+            let vlo = sorted[lo];
+            let vhi = sorted[hi.saturating_sub(1)];
+            if est < vlo || est > vhi {
+                let rank = sorted.partition_point(|x| *x <= est) as f64 / n;
+                worst_rank = worst_rank.max((rank - qq).abs().min(1.0));
+                println!("      out-of-band: q={qq} est={est} band=[{vlo}, {vhi}]");
+            }
+        } else {
+            worst_rank = 1.0;
+        }
+    }
+    p.check(
+        "quantiles within rank band ±0.03",
+        format!("worst out-of-band drift {worst_rank:.4}"),
+        worst_rank <= 0.05,
+    );
+
+    // Well-separated heavy hitters: value i appears ~(i+1)*40 times.
+    let mut q2 = asap_sketchlib::UnivMonQ::new(Default::default()).expect("cfg2");
+    let mut freq2: HashMap<u64, u64> = HashMap::new();
+    let mut rng2 = StdRng::seed_from_u64(57);
+    for i in 0..50u64 {
+        let target = (i + 1) * 40;
+        for _ in 0..target {
+            q2.update(&(i as f64));
+            *freq2.entry(i).or_insert(0) += 1;
+        }
+    }
+    // background noise
+    for _ in 0..10_000 {
+        let v = 100u64 + rng2.random::<u64>() % 900;
+        q2.update(&(v as f64));
+        *freq2.entry(v).or_insert(0) += 1;
+    }
+    let hh2 = q2.heavy_hitters(8);
+    let mut true_top2: Vec<(u64, u64)> = freq2.iter().map(|(k, v)| (*k, *v)).collect();
+    true_top2.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+    let top8: std::collections::HashSet<u64> = true_top2.iter().take(8).map(|(k, _)| *k).collect();
+    let hits2 = hh2
+        .iter()
+        .filter(|(v, _)| top8.contains(&(*v as u64)))
+        .count();
+    p.check(
+        "heavy hitters overlap >= 6/8 (separated weights)",
+        format!("{hits2}/8"),
+        hits2 >= 6,
+    );
+    p.finish("UnivMonQ");
+}
+
+// ------------------------------------------------------------------- Nitro
+fn probe_nitro() {
+    let mut p = Probe::new();
+    println!("--- NitroBatch (CM target) ---");
+
+    // Unbiasedness across sampling rates on an exactly-known stream.
+    let n = 100_000i64;
+    for rate in [1.0f64, 0.5, 0.25] {
+        let mut nb = asap_sketchlib::NitroBatch::with_target(
+            rate,
+            CountMin::<asap_sketchlib::Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(
+                5, 2048,
+            ),
+        );
+        nb.insert(&vec![7i64; n as usize]);
+        let est = nb.estimate_median(&DataInput::I64(7));
+        p.check(
+            &format!("estimate_median ~ truth at rate={rate}"),
+            format!("expected {n}, got {est} (ratio {:.4})", est / n as f64),
+            (est - n as f64).abs() <= 0.05 * n as f64,
+        );
+    }
+    p.note("Pre-fix: insert hashed with raw hash128_seeded while estimation used the Packed64 matrix hash (estimates read empty cells), each sample updated ONE row (truth/rows bias), and the skip draw used ceil instead of floor (effective rate 1/(1/p+2)).");
+    p.finish("Nitro");
+}
+
+// ------------------------------------------------------- EH univ optimized
+#[cfg(feature = "experimental")]
+fn probe_eh_univ() {
+    use asap_sketchlib::EHUnivOptimized;
+    let mut p = Probe::new();
+    println!("--- EHUnivOptimized exact map tier (experimental) ---");
+    let window = 100u64;
+    let mut eh = EHUnivOptimized::with_defaults(2, window);
+    // Stream updates over times 0..150; only [50,149] survive at t=149+window semantics.
+    for t in 0..150u64 {
+        eh.update(t, &DataInput::U32((t % 10) as u32), (t as i64 % 3) + 1);
+    }
+    // Query recent interval fully inside surviving range.
+    let res = eh.query_interval(120, 149);
+    match res {
+        Some(asap_sketchlib::EHUnivQueryResult::Map {
+            freq_map,
+            total_count,
+        }) => {
+            let expect_total: usize = (120..=149u64).map(|t| (t as i64 % 3 + 1) as usize).sum();
+            p.check(
+                "interval map tier total exact",
+                format!("expected {expect_total}, got {total_count}"),
+                total_count == expect_total,
+            );
+            let mut expect_freq: HashMap<u32, i64> = HashMap::new();
+            for t in 120..=149 {
+                *expect_freq.entry((t % 10) as u32).or_insert(0) += (t as i64 % 3) + 1;
+            }
+            let exact = expect_freq
+                .iter()
+                .all(|(k, v)| freq_map.get(&asap_sketchlib::HeapItem::U32(*k)) == Some(v))
+                && expect_freq.len() == freq_map.len();
+            p.check(
+                "interval map tier per-key exact",
+                format!("{} entries", freq_map.len()),
+                exact,
+            );
+        }
+        _ => p.check(
+            "interval returns Map tier",
+            "got Sketch or None".to_string(),
+            false,
+        ),
+    }
+    p.finish("EHUnivOptimized");
+}
+
+// ---------------------------------------------------------------- Tumbling
+fn probe_tumbling() {
+    use asap_sketchlib::{FoldCMSConfig, TumblingWindow};
+
+    let mut p = Probe::new();
+    println!("--- TumblingWindow FoldCMS + KLL ---");
+
+    // FoldCMS: weighted counts per key.
+    let cfg = FoldCMSConfig {
+        rows: 3,
+        full_cols: 2048,
+        fold_level: 0,
+        top_k: 32,
+    };
+    let mut tw: TumblingWindow<asap_sketchlib::FoldCMS> =
+        TumblingWindow::new(10, 8, cfg.clone(), 4);
+    for t in 0..25u64 {
+        tw.insert(t, &DataInput::Str("A"), 2);
+        tw.insert(t, &DataInput::Str("B"), 1);
+    }
+    let merged = tw.query_all();
+    let fa = merged.query(&DataInput::Str("A"));
+    let fb = merged.query(&DataInput::Str("B"));
+    p.check(
+        "FoldCMS key A == 50",
+        format!("expected 50, got {fa}"),
+        fa == 50,
+    );
+    p.check(
+        "FoldCMS key B == 25",
+        format!("expected 25, got {fb}"),
+        fb == 25,
+    );
+
+    // KLL tumbling: the numeric `value` arg is IGNORED; the KEY doubles as the
+    // observation (tumbling.rs:146-149). Feed values via the key.
+    let kcfg = asap_sketchlib::KLLConfig { k: 200, m: 8 };
+    let mut tkw: TumblingWindow<KLL> = TumblingWindow::new(100, 4, kcfg, 2);
+    let mut rng = StdRng::seed_from_u64(53);
+    let mut all_vals: Vec<f64> = Vec::new();
+    for t in 0..1000u64 {
+        let v = rng.random::<f64>() * 100.0;
+        all_vals.push(v);
+        tkw.insert(t, &DataInput::F64(v), 999 /* ignored */);
+    }
+    // query_all merges every window (closed + active), so truth = full stream.
+    all_vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let merged_k = tkw.query_all();
+    let med = merged_k.quantile(0.5);
+    let truth_med = all_vals[all_vals.len() / 2];
+    p.note("TumblingWindow<KLL>::insert ignores its numeric `value` param; observations are the keys themselves");
+    p.check(
+        "tumbling KLL median approx",
+        format!("expected ~{truth_med:.1}, got {med:.1}"),
+        rel_err(med, truth_med) < 0.05,
+    );
+    p.finish("Tumbling");
+}
+
+// ---------------------------------------------------- Portable wire types
+fn probe_portable_wire_types() {
+    let mut p = Probe::new();
+    println!("--- Portable wire types (Go-parity DTOs) ---");
+
+    // Portable CountMin.
+    let mut pcs = CountMinSketch::new(3, 4096);
+    let mut truth: HashMap<String, f64> = HashMap::new();
+    let mut z = Zipf::new(2048, 1.1, 54);
+    for _ in 0..50_000 {
+        let k = format!("k{}", z.sample_usize());
+        *truth.entry(k.clone()).or_insert(0.0) += 1.0;
+        pcs.update(&k, 1.0);
+    }
+    let mut by_freq: Vec<(String, f64)> = truth.iter().map(|(k, v)| (k.clone(), *v)).collect();
+    by_freq.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    let eps = std::f64::consts::E / 4096.0;
+    let mut bad = 0usize;
+    for (k, v) in by_freq.iter().take(50) {
+        let est = pcs.estimate(k);
+        if est < *v || est > v + eps * 50_000.0 {
+            bad += 1;
+        }
+    }
+    p.check(
+        "portable CMS one-sided bound (top-50)",
+        format!("{bad} violations"),
+        bad == 0,
+    );
+
+    // Portable HLL precision 12.
+    let mut ph = HllSketch::new(HllVariant::Regular, 12);
+    for i in 0..100_000u64 {
+        ph.update(i.to_le_bytes().as_slice());
+    }
+    let est = ph.estimate();
+    p.check(
+        "portable HLL p12 within 3%",
+        format!(
+            "expected 100000, got {est:.0} (rel {:.4})",
+            rel_err(est, 100_000.0)
+        ),
+        rel_err(est, 100_000.0) < 0.03,
+    );
+
+    // Portable KLL.
+    let mut pk = PortableKll::new(200);
+    let mut rng = StdRng::seed_from_u64(55);
+    let mut vals: Vec<f64> = (0..50_000).map(|_| rng.random::<f64>() * 1e6).collect();
+    vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    for v in &vals {
+        pk.update(*v);
+    }
+    let med = pk.quantile(0.5);
+    let t = vals[25_000];
+    p.check(
+        "portable KLL median",
+        format!("expected ~{t:.0}, got {med:.0}"),
+        (med - t).abs() / t < 0.05,
+    );
+
+    // HydraKllSketch: per-key quantiles, median across rows.
+    let mut hk = HydraKllSketch::new(3, 256, 200);
+    let mut per_key: HashMap<&str, Vec<f64>> = HashMap::new();
+    let mut rng2 = StdRng::seed_from_u64(56);
+    for key in ["svc-a", "svc-b"] {
+        let base = if key == "svc-a" { 100.0 } else { 900.0 };
+        let vs: Vec<f64> = (0..2_000)
+            .map(|_| base + rng2.random::<f64>() * 50.0)
+            .collect();
+        for v in &vs {
+            hk.update(key, *v);
+        }
+        per_key.insert(key, vs);
+    }
+    for (key, vs) in per_key {
+        let mut s = vs.clone();
+        s.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let t = s[s.len() / 2];
+        let got = hk.quantile(key, 0.5);
+        p.check(
+            &format!("HydraKll median({key})"),
+            format!("expected ~{t:.1}, got {got:.1}"),
+            (got - t).abs() / t < 0.05,
+        );
+    }
+    p.finish("Portable wire types");
+}

--- a/examples/accuracy_probe.rs
+++ b/examples/accuracy_probe.rs
@@ -543,7 +543,7 @@ fn probe_ddsketch() {
     );
     p.check(
         "portable DdSketch honors alpha=0.05 at bucket edges",
-        format!("max rel err {worst_port:.5} (gamma^(k+0.5) midpoint rep)"),
+        format!("max rel err {worst_port:.5} (shared gamma^k*(1+alpha) representative)"),
         worst_port <= alpha * (1.0 + 1e-6),
     );
 

--- a/src/common/structure_utils.rs
+++ b/src/common/structure_utils.rs
@@ -115,16 +115,6 @@ impl Nitro {
             self.to_skip = 0;
             return;
         }
-        // let k = loop {
-        //     let r = self.generator.random::<f64>();
-        //     if r != 0.0_f64 && r != 1.0_f64 {
-        //         break r;
-        //     }
-        // };
-        // self.to_skip = ((1.0 - k).ln() * self.inv_ln_one_minus_p).ceil() as usize;
-
-        // self.to_skip = (PRECOMPUTED_SAMPLE[self.idx] * self.inv_ln_one_minus_p).ceil() as usize;
-
         // floor, not ceil: the caller's `+1` stride supplies the sampled item
         // itself, so ceil adds +1 to every skip distance and roughly halves
         // the effective sampling rate (same bug fixed in NitroBatch's

--- a/src/common/structure_utils.rs
+++ b/src/common/structure_utils.rs
@@ -125,7 +125,11 @@ impl Nitro {
 
         // self.to_skip = (PRECOMPUTED_SAMPLE[self.idx] * self.inv_ln_one_minus_p).ceil() as usize;
 
-        self.to_skip = PRECOMPUTED_SAMPLE_RATE_1PERCENT[self.idx].ceil() as usize;
+        // floor, not ceil: the caller's `+1` stride supplies the sampled item
+        // itself, so ceil adds +1 to every skip distance and roughly halves
+        // the effective sampling rate (same bug fixed in NitroBatch's
+        // draw_geometric; see the NitroSketch inverse-CDF derivation there).
+        self.to_skip = PRECOMPUTED_SAMPLE_RATE_1PERCENT[self.idx].floor() as usize;
         self.idx = (self.idx + 1) & self.mask;
     }
 

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -12,6 +12,13 @@ use crate::message_pack_format::{Error as MsgPackError, MessagePackCodec};
 /// output for the same input stream.
 pub const DDSKETCH_GROW_CHUNK: usize = 128;
 
+/// Safety limit for a single [`DdSketchDelta`] application: deltas arrive
+/// over the wire untrusted, so a span beyond this many buckets is rejected
+/// with an error instead of padding the dense store toward a multi-gigabyte
+/// allocation. Generous relative to any legitimate producer: at α = 0.01 the
+/// entire indexable range spans ~35k buckets.
+pub const MAX_APPLY_DELTA_SPAN_BUCKETS: i64 = 1 << 22;
+
 // =====================================================================
 // Wire-format-aligned variant.
 //
@@ -164,7 +171,45 @@ impl DdSketch {
     /// and max can only increase. Used by the backend ingest path to
     /// reconstitute a full sketch from a base snapshot + subsequent
     /// delta-transmission frames.
-    pub fn apply_delta(&mut self, delta: &DdSketchDelta) {
+    ///
+    /// Deltas arrive over the wire and are treated as untrusted: before
+    /// mutating anything, the union span the delta would require is
+    /// checked against [`MAX_APPLY_DELTA_SPAN_BUCKETS`]. A hostile or
+    /// corrupt delta carrying an index near `i32::MAX` would otherwise
+    /// pad the dense store by ~2·10⁹ buckets (~17 GiB) in one call —
+    /// independent of α, unlike the `update()` path whose worst case is
+    /// bounded by the indexable-range guard.
+    pub fn apply_delta(
+        &mut self,
+        delta: &DdSketchDelta,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Pre-validate span before any mutation so a rejected delta
+        // leaves state untouched.
+        if !delta.buckets.is_empty() {
+            let mut min_d = i64::MAX;
+            let mut max_d = i64::MIN;
+            for (abs_idx, _) in &delta.buckets {
+                min_d = min_d.min(*abs_idx as i64);
+                max_d = max_d.max(*abs_idx as i64);
+            }
+            let cur_start = if self.store_counts.is_empty() {
+                min_d
+            } else {
+                self.store_offset as i64
+            };
+            let cur_end = cur_start + self.store_counts.len() as i64;
+            let new_start = cur_start.min(min_d);
+            let new_end = cur_end.max(max_d + 1);
+            if new_end - new_start > MAX_APPLY_DELTA_SPAN_BUCKETS {
+                return Err(format!(
+                    "DdSketch delta spans {} buckets, exceeding the {}-bucket safety limit",
+                    new_end - new_start,
+                    MAX_APPLY_DELTA_SPAN_BUCKETS
+                )
+                .into());
+            }
+        }
+
         for (abs_idx, d_count) in &delta.buckets {
             if self.store_counts.is_empty() {
                 self.store_counts = vec![0u64; 1];
@@ -193,6 +238,7 @@ impl DdSketch {
         // a target here — the bucket counts above carry all reconstructable
         // state. The backend that owns the DDSketch delta tracks those
         // aggregates separately.
+        Ok(())
     }
 
     /// Compute a sparse, proto-marshalled `DDSketchDelta` of `self`
@@ -267,8 +313,7 @@ impl DdSketch {
                 .collect(),
             ..DdSketchDelta::default()
         };
-        self.apply_delta(&delta);
-        Ok(())
+        self.apply_delta(&delta)
     }
 
     /// MessagePack twin of [`Self::compute_delta`]. Computes the same
@@ -318,8 +363,7 @@ impl DdSketch {
         bytes: &[u8],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let delta = DdSketchDelta::from_msgpack(bytes)?;
-        self.apply_delta(&delta);
-        Ok(())
+        self.apply_delta(&delta)
     }
 
     /// Merge a slice of references into a single new sketch. Returns
@@ -624,7 +668,7 @@ mod tests {
             max_changed: true,
             new_max: 9.0,
         };
-        base.apply_delta(&delta);
+        base.apply_delta(&delta).unwrap();
         assert_eq!(base.store_counts, vec![5, 10, 15]);
         assert_eq!(base.total_count(), 30);
     }
@@ -642,7 +686,7 @@ mod tests {
             max_changed: true,
             new_max: 6.0,
         };
-        base.apply_delta(&delta);
+        base.apply_delta(&delta).unwrap();
         assert_eq!(base.store_counts, vec![1, 2, 0, 0, 7]);
         assert_eq!(base.store_offset, 0);
         assert_eq!(base.total_count(), 10);
@@ -667,7 +711,7 @@ mod tests {
             new_max: 5.0,
         };
         let mut via_delta = base;
-        via_delta.apply_delta(&delta);
+        via_delta.apply_delta(&delta).unwrap();
 
         assert_eq!(via_delta.store_counts, via_merge.store_counts);
         assert_eq!(via_delta.total_count(), via_merge.total_count());
@@ -796,7 +840,7 @@ mod tests {
                 // First batch seeds the reconstituted sketch.
                 reconstituted = this_batch.clone();
             } else {
-                reconstituted.apply_delta(&delta);
+                reconstituted.apply_delta(&delta).unwrap();
             }
             prev_snapshot = this_batch;
         }

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -178,13 +178,14 @@ impl DdSketch {
             }
             let new_len = new_len as usize;
             let mut merged = vec![0u64; new_len];
-            for (i, c) in self.store_counts.iter().enumerate() {
-                let idx = (self_start + i as i64 - new_start) as usize;
-                merged[idx] = merged[idx].saturating_add(*c);
-            }
-            for (i, c) in other.store_counts.iter().enumerate() {
-                let idx = (other_start + i as i64 - new_start) as usize;
-                merged[idx] = merged[idx].saturating_add(*c);
+            for (start, counts) in [
+                (self_start, &self.store_counts),
+                (other_start, &other.store_counts),
+            ] {
+                for (i, &c) in counts.iter().enumerate() {
+                    let idx = (start + i as i64 - new_start) as usize;
+                    merged[idx] = merged[idx].saturating_add(c);
+                }
             }
             self.store_counts = merged;
             self.store_offset = new_start as i32;

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -95,6 +95,10 @@ pub struct DdSketch {
 impl DdSketch {
     /// Construct an empty sketch.
     pub fn new(alpha: f64) -> Self {
+        assert!(
+            (0.0..1.0).contains(&alpha),
+            "alpha must be in (0,1); alpha=0 makes ln(gamma)=0 and every guard degenerate"
+        );
         Self {
             alpha,
             store_counts: Vec::new(),
@@ -124,6 +128,14 @@ impl DdSketch {
 
     /// Merge one other sketch into self by aligning bucket arrays on
     /// absolute indices. Both operands must share the same `alpha`.
+    ///
+    /// Like [`Self::apply_delta`], the operand is treated as untrusted wire
+    /// state: if the union span would exceed
+    /// [`MAX_APPLY_DELTA_SPAN_BUCKETS`] *and* grow beyond both operands'
+    /// existing stores, `Err` is returned before any allocation. Stores that
+    /// already legitimately span more than the cap (exotic small-α
+    /// configurations) merge normally as long as the union stays within
+    /// what either side already holds.
     pub fn merge(
         &mut self,
         other: &DdSketch,
@@ -149,7 +161,22 @@ impl DdSketch {
             let other_end = other_start + other.store_counts.len() as i64;
             let new_start = self_start.min(other_start);
             let new_end = self_end.max(other_end);
-            let new_len = (new_end - new_start) as usize;
+            let new_len = new_end - new_start;
+            // Hostile-span guard: a decoded snapshot with store_offset near
+            // i32::MIN and a short count vector must not allocate a union
+            // spanning ~2^31 buckets (~17 GiB) in one call. Growth beyond
+            // both operands' existing spans is capped; stores that already
+            // legitimately exceed the cap pass through untouched.
+            let max_existing =
+                (self.store_counts.len() as i64).max(other.store_counts.len() as i64);
+            if new_len > MAX_APPLY_DELTA_SPAN_BUCKETS && new_len > max_existing {
+                return Err(format!(
+                    "DdSketch merge spans {} buckets, exceeding the {}-bucket safety limit",
+                    new_len, MAX_APPLY_DELTA_SPAN_BUCKETS
+                )
+                .into());
+            }
+            let new_len = new_len as usize;
             let mut merged = vec![0u64; new_len];
             for (i, c) in self.store_counts.iter().enumerate() {
                 let idx = (self_start + i as i64 - new_start) as usize;
@@ -405,42 +432,18 @@ impl DdSketch {
         }
         let gamma = (1.0 + self.alpha) / (1.0 - self.alpha);
         let ln_gamma = gamma.ln();
-        let inv_log_gamma = 1.0 / ln_gamma;
         // Reject finite-but-extreme values whose bucket index would be
         // unrepresentable or force an arbitrarily distant allocation
-        // (asap_sketchlib#70 item 4; mirrors core DDSketch's
-        // min/max_indexable_value guards).
-        if value < Self::min_indexable_value(inv_log_gamma, gamma)
-            || value > Self::max_indexable_value(inv_log_gamma, gamma)
-        {
+        // (asap_sketchlib#70 item 4). Uses the SHARED bounds helper so core
+        // and portable can never drift algebraically.
+        let (min_v, max_v) = crate::sketches::ddsketch::ddsketch_indexable_bounds(self.alpha);
+        if value < min_v || value > max_v {
             return;
         }
         let idx = (value.ln() / ln_gamma).floor() as i32;
         self.ensure_bucket(idx);
         let arr_idx = (idx as i64 - self.store_offset as i64) as usize;
         self.store_counts[arr_idx] = self.store_counts[arr_idx].saturating_add(1);
-    }
-
-    /// Smallest positive value whose bucket index is representable without
-    /// integer overflow (index ≥ i32::MIN) or float underflow. Identical
-    /// formula to core DDSketch's `min_indexable_value`.
-    #[inline]
-    fn min_indexable_value(inv_log_gamma: f64, gamma: f64) -> f64 {
-        ((f64::from(i32::MIN)) * inv_log_gamma + 1.0)
-            .exp()
-            .max(f64::MIN_POSITIVE * gamma)
-    }
-
-    /// Largest finite positive value whose bucket index is representable
-    /// without integer overflow (index ≤ i32::MAX) or `exp`/`powf` overflow.
-    /// Identical formula to core DDSketch's `max_indexable_value`.
-    #[inline]
-    fn max_indexable_value(inv_log_gamma: f64, gamma: f64) -> f64 {
-        // 709.0 is just under ln(f64::MAX) so exp() stays finite.
-        const EXP_OVERFLOW: f64 = 709.0;
-        ((f64::from(i32::MAX)) * inv_log_gamma - 1.0)
-            .exp()
-            .min(EXP_OVERFLOW.exp() / (2.0 * gamma) * (gamma + 1.0))
     }
 
     /// Ensure bucket `k` is addressable in `store_counts`, growing in

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -399,7 +399,7 @@ impl DdSketch {
     /// Estimate the quantile at rank `q` ∈ [0, 1]. Walks the bucket
     /// array in ascending absolute-index order, accumulating counts
     /// until the target rank; returns the bucket's representative
-    /// value `gamma^(k + 0.5)` where `k` is the bucket's absolute
+    /// value `gamma^k * (1 + alpha)` where `k` is the bucket's absolute
     /// index. Returns `None` if the sketch is empty.
     ///
     /// Accuracy: bounded by DDSketch's α parameter — the estimated
@@ -420,20 +420,22 @@ impl DdSketch {
             }
             cumulative = cumulative.saturating_add(c);
             if cumulative > target {
-                let k = (self.store_offset as i64 + i as i64) as f64;
-                // Bucket midpoint: gamma^(k + 0.5) — centers the
-                // estimate in the logarithmic bucket.
-                return Some(gamma.powf(k + 0.5));
+                let k = self.store_offset as i64 + i as i64;
+                // Representative: lower edge γ^k scaled by (1+α) — matches the
+                // core DDSketch and DataDog's logarithmic_mapping.go. The old
+                // log-midpoint γ^(k+0.5) gave edge error √γ−1 > α, silently
+                // violating the α guarantee near a bucket edge (#70/#73).
+                return Some(gamma.powf(k as f64) * (1.0 + self.alpha));
             }
         }
         // Numerical edge case: if we fall off the end (e.g. q == 1.0 and
         // rounding lands past the final increment), estimate from the
         // highest non-empty bucket. The DataPoint-level `max` scalar was
-        // removed from the wire; the bucket midpoint is within DDSketch's
+        // removed from the wire; the representative is within DDSketch's
         // α relative-accuracy bound of the true max.
         last_nonempty.map(|i| {
             let k = (self.store_offset as i64 + i as i64) as f64;
-            gamma.powf(k + 0.5)
+            gamma.powf(k) * (1.0 + self.alpha)
         })
     }
 

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -352,17 +352,51 @@ impl DdSketch {
     /// `DDSketchState` proto bytes would diverge from the Go producer's
     /// payload (cross-language byte parity).
     pub fn update(&mut self, value: f64) {
-        if value <= 0.0 {
-            // DDSketch is defined for positive reals; non-positive
-            // values are rejected silently (matching the Go reference).
+        if !(value.is_finite() && value > 0.0) {
+            // DDSketch is defined for positive reals; non-positive and
+            // non-finite values are rejected silently (matching the Go
+            // reference and the core DDSketch). NaN in particular would
+            // otherwise floor-cast to bucket 0 and corrupt it.
             return;
         }
         let gamma = (1.0 + self.alpha) / (1.0 - self.alpha);
         let ln_gamma = gamma.ln();
+        let inv_log_gamma = 1.0 / ln_gamma;
+        // Reject finite-but-extreme values whose bucket index would be
+        // unrepresentable or force an arbitrarily distant allocation
+        // (asap_sketchlib#70 item 4; mirrors core DDSketch's
+        // min/max_indexable_value guards).
+        if value < Self::min_indexable_value(inv_log_gamma, gamma)
+            || value > Self::max_indexable_value(inv_log_gamma, gamma)
+        {
+            return;
+        }
         let idx = (value.ln() / ln_gamma).floor() as i32;
         self.ensure_bucket(idx);
         let arr_idx = (idx as i64 - self.store_offset as i64) as usize;
         self.store_counts[arr_idx] = self.store_counts[arr_idx].saturating_add(1);
+    }
+
+    /// Smallest positive value whose bucket index is representable without
+    /// integer overflow (index ≥ i32::MIN) or float underflow. Identical
+    /// formula to core DDSketch's `min_indexable_value`.
+    #[inline]
+    fn min_indexable_value(inv_log_gamma: f64, gamma: f64) -> f64 {
+        ((f64::from(i32::MIN)) * inv_log_gamma + 1.0)
+            .exp()
+            .max(f64::MIN_POSITIVE * gamma)
+    }
+
+    /// Largest finite positive value whose bucket index is representable
+    /// without integer overflow (index ≤ i32::MAX) or `exp`/`powf` overflow.
+    /// Identical formula to core DDSketch's `max_indexable_value`.
+    #[inline]
+    fn max_indexable_value(inv_log_gamma: f64, gamma: f64) -> f64 {
+        // 709.0 is just under ln(f64::MAX) so exp() stays finite.
+        const EXP_OVERFLOW: f64 = 709.0;
+        ((f64::from(i32::MAX)) * inv_log_gamma - 1.0)
+            .exp()
+            .min(EXP_OVERFLOW.exp() / (2.0 * gamma) * (gamma + 1.0))
     }
 
     /// Ensure bucket `k` is addressable in `store_counts`, growing in

--- a/src/sketch_framework/mod.rs
+++ b/src/sketch_framework/mod.rs
@@ -46,7 +46,9 @@ pub mod univmon_optimized;
 pub use univmon_optimized::{UnivMonPyramid, UnivSketchPool};
 
 pub mod nitro;
-pub use nitro::{NitroBatch, NitroEstimate, NitroTarget};
+pub use nitro::{
+    NitroBatch, NitroEstimate, NitroTarget, nitro_delta_saturated_i32, nitro_delta_saturated_u32,
+};
 
 #[cfg(feature = "experimental")]
 pub mod eh_univ_optimized;

--- a/src/sketch_framework/nitro.rs
+++ b/src/sketch_framework/nitro.rs
@@ -11,8 +11,8 @@ use rand::{Rng, SeedableRng, rng};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Count, CountMin, DataInput, FastPath, PRECOMPUTED_SAMPLE_RATE_1PERCENT, Vector2D,
-    hash128_seeded,
+    Count, CountMin, DataInput, DefaultXxHasher, FastPath, FastPathHasher, MatrixFastHash,
+    PRECOMPUTED_SAMPLE_RATE_1PERCENT, Vector2D,
 };
 
 /// Trait for sketch backends that support Nitro row updates.
@@ -21,6 +21,14 @@ pub trait NitroTarget {
     fn rows(&self) -> usize;
     /// Applies a sampled update to one row.
     fn update_row(&mut self, row: usize, hashed: u128, delta: u64);
+    /// Applies a sampled record to EVERY row using the target's own fast-path
+    /// hash derivation. Insert and estimation must share a single hash domain,
+    /// otherwise estimates read cells the inserts never wrote.
+    ///
+    /// Updating all rows is what makes estimates unbiased: each sampled item
+    /// contributes weight ×(1/rate) to every row, so per-row counters converge
+    /// to the true frequency (NitroSketch §4, estimator = min/median ÷ rate).
+    fn update_sample(&mut self, value: &DataInput, delta: u64);
 }
 
 /// Trait for Nitro targets that can be merged.
@@ -44,6 +52,16 @@ impl NitroTarget for Vector2D<u32> {
     #[inline(always)]
     fn update_row(&mut self, row: usize, hashed: u128, delta: u64) {
         self.update_by_row(row, hashed, |a, b| *a += b as u32, delta);
+    }
+
+    #[inline(always)]
+    fn update_sample(&mut self, value: &DataInput, delta: u64) {
+        let hashed = <Self as FastPathHasher<DefaultXxHasher>>::hash_for_matrix(self, value);
+        let cols = self.cols();
+        for row in 0..self.rows() {
+            let col = MatrixFastHash::col_for_row(&hashed, row, cols);
+            self.update_one_counter(row, col, |a: &mut u32, b: u64| *a += b as u32, delta);
+        }
     }
 }
 
@@ -197,7 +215,11 @@ impl<S: NitroTarget> NitroBatch<S> {
                 break r;
             }
         };
-        self.to_skip = ((1.0 - k).ln() * self.inv_ln_one_minus_p).ceil() as usize;
+        // Inverse-CDF draw of Geometric(p) on {0, 1, ...}: floor of an
+        // Exp(1) variate. ceil() here would add +1 to every skip distance,
+        // halving-ish the effective sampling rate (E[skip] = (1-p)/p only
+        // under floor); the caller's `+1` supplies the sampled item itself.
+        self.to_skip = ((1.0 - k).ln() * self.inv_ln_one_minus_p).floor() as usize;
         self.idx = (self.idx + 1) & self.mask;
     }
 
@@ -251,13 +273,11 @@ impl<S: NitroTarget> NitroBatch<S> {
 
     /// Inserts a batch of values using geometric skipping.
     pub fn insert(&mut self, data: &[i64]) {
-        let rows = self.sk.rows();
         self.draw_geometric();
         let mut position = self.to_skip;
         while position < data.len() {
-            let row_to_update = position % rows;
-            let hashed = hash128_seeded(0, &DataInput::I64(data[position]));
-            self.sk.update_row(row_to_update, hashed, self.delta);
+            let key = DataInput::I64(data[position]);
+            self.sk.update_sample(&key, self.delta);
             self.draw_geometric();
             position += self.to_skip + 1;
         }
@@ -265,15 +285,13 @@ impl<S: NitroTarget> NitroBatch<S> {
 
     /// Inserts a batch using the precomputed skip table.
     pub fn insert_cached_step(&mut self, data: &[i64]) {
-        let rows = self.sk.rows();
-        self.to_skip = PRECOMPUTED_SAMPLE_RATE_1PERCENT[self.idx].ceil() as usize;
+        self.to_skip = PRECOMPUTED_SAMPLE_RATE_1PERCENT[self.idx].floor() as usize;
         self.idx = (self.idx + 1) & self.mask;
         let mut position = self.to_skip;
         while position < data.len() {
-            let row_to_update = position % rows;
-            let hashed = hash128_seeded(0, &DataInput::I64(data[position]));
-            self.sk.update_row(row_to_update, hashed, self.delta);
-            self.to_skip = PRECOMPUTED_SAMPLE_RATE_1PERCENT[self.idx].ceil() as usize;
+            let key = DataInput::I64(data[position]);
+            self.sk.update_sample(&key, self.delta);
+            self.to_skip = PRECOMPUTED_SAMPLE_RATE_1PERCENT[self.idx].floor() as usize;
             self.idx = (self.idx + 1) & self.mask;
             position += self.to_skip + 1;
         }
@@ -301,41 +319,9 @@ impl<S: NitroTarget + NitroEstimate> NitroBatch<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DataInput;
     use crate::test_utils::sample_zipf_u64;
-    use crate::{DataInput, compute_median_inline_f64};
     use std::collections::HashMap;
-
-    fn nitro_countmin_estimate(storage: &Vector2D<i32>, key: &DataInput) -> f64 {
-        let rows = storage.rows();
-        let mask_bits = storage.get_mask_bits() as usize;
-        let mask = (1u128 << mask_bits) - 1;
-        let hashed = hash128_seeded(0, key);
-        let mut min = i32::MAX;
-        for row in 0..rows {
-            let col = ((hashed >> (mask_bits * row)) & mask) as usize;
-            let val = storage.query_one_counter(row, col);
-            if val < min {
-                min = val;
-            }
-        }
-        min as f64
-    }
-
-    fn nitro_count_estimate(storage: &Vector2D<i32>, key: &DataInput) -> f64 {
-        let rows = storage.rows();
-        let mask_bits = storage.get_mask_bits() as usize;
-        let mask = (1u128 << mask_bits) - 1;
-        let hashed = hash128_seeded(0, key);
-        let mut estimates = Vec::with_capacity(rows);
-        for row in 0..rows {
-            let col = ((hashed >> (mask_bits * row)) & mask) as usize;
-            let val = storage.query_one_counter(row, col) as f64;
-            let bit = (hashed >> (127 - row)) & 1;
-            let sign = (bit as i32 * 2 - 1) as f64;
-            estimates.push(sign * val);
-        }
-        compute_median_inline_f64(&mut estimates)
-    }
 
     #[test]
     fn nitro_batch_countmin_error_bound_zipf() {
@@ -364,10 +350,9 @@ mod tests {
         let delta = 1.0 / std::f64::consts::E.powi(rows as i32);
         let error_bound = epsilon * samples as f64;
         let correct_lower_bound = truth.len() as f64 * (1.0 - delta);
-        let storage = batch.target().as_storage();
         let mut within_count = 0;
         for key in truth.keys() {
-            let est = nitro_countmin_estimate(storage, &DataInput::I64(*key));
+            let est = batch.estimate_median(&DataInput::I64(*key));
             if (est - (*truth.get(key).unwrap() as f64)).abs() < error_bound {
                 within_count += 1;
             }
@@ -405,10 +390,9 @@ mod tests {
         let delta = 1.0 / std::f64::consts::E.powi(rows as i32);
         let error_bound = epsilon * samples as f64;
         let correct_lower_bound = truth.len() as f64 * (1.0 - delta);
-        let storage = batch.target().as_storage();
         let mut within_count = 0;
         for key in truth.keys() {
-            let est = nitro_count_estimate(storage, &DataInput::I64(*key));
+            let est = batch.estimate_median(&DataInput::I64(*key));
             if (est - (*truth.get(key).unwrap() as f64)).abs() < error_bound {
                 within_count += 1;
             }

--- a/src/sketch_framework/nitro.rs
+++ b/src/sketch_framework/nitro.rs
@@ -31,6 +31,22 @@ pub trait NitroTarget {
     fn update_sample(&mut self, value: &DataInput, delta: u64);
 }
 
+/// Saturates a Nitro update weight into the `i32` counter domain. Counter
+/// storage is `i32`, so a weight beyond `i32::MAX` (reachable via rates below
+/// ~4.7e-10, or by writing the public `delta` field directly) must saturate
+/// rather than wrap — a wrapped negative weight would silently turn Count-Min
+/// counters into decrements.
+#[inline]
+pub fn nitro_delta_saturated_i32(delta: u64) -> i32 {
+    delta.min(i32::MAX as u64) as i32
+}
+
+/// [`nitro_delta_saturated_i32`] twin for `u32`-backed bare-storage targets.
+#[inline]
+pub fn nitro_delta_saturated_u32(delta: u64) -> u32 {
+    delta.min(u32::MAX as u64) as u32
+}
+
 /// Trait for Nitro targets that can be merged.
 pub trait NitroMerge {
     /// Merges another target into this one.
@@ -51,7 +67,12 @@ impl NitroTarget for Vector2D<u32> {
 
     #[inline(always)]
     fn update_row(&mut self, row: usize, hashed: u128, delta: u64) {
-        self.update_by_row(row, hashed, |a, b| *a += b as u32, delta);
+        self.update_by_row(
+            row,
+            hashed,
+            |a, b| *a += b,
+            nitro_delta_saturated_u32(delta),
+        );
     }
 
     #[inline(always)]
@@ -60,7 +81,12 @@ impl NitroTarget for Vector2D<u32> {
         let cols = self.cols();
         for row in 0..self.rows() {
             let col = MatrixFastHash::col_for_row(&hashed, row, cols);
-            self.update_one_counter(row, col, |a: &mut u32, b: u64| *a += b as u32, delta);
+            self.update_one_counter(
+                row,
+                col,
+                |a: &mut u32, b: u32| *a += b,
+                nitro_delta_saturated_u32(delta),
+            );
         }
     }
 }

--- a/src/sketch_framework/tumbling.rs
+++ b/src/sketch_framework/tumbling.rs
@@ -80,6 +80,13 @@ pub struct KLLConfig {
     pub k: usize,
     /// Minimum compactor size parameter.
     pub m: usize,
+    /// Optional seed for the compaction coin. When `Some`, every pool sketch
+    /// is built with [`KLL::init_with_seed`], so two processes running the
+    /// same tumbling pipeline produce byte-identical sketches — including
+    /// across window rotations, because `tumbling_clear` re-seeds from the
+    /// stored seed. When `None`, the legacy wall-clock-seeded [`KLL::init`]
+    /// path is used and cross-process agreement is not achievable.
+    pub seed: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -140,7 +147,10 @@ impl TumblingWindowSketch for KLL {
     type Config = KLLConfig;
 
     fn from_config(config: &Self::Config) -> Self {
-        KLL::init(config.k, config.m)
+        match config.seed {
+            Some(seed) => KLL::init_with_seed(config.k, config.m, seed),
+            None => KLL::init(config.k, config.m),
+        }
     }
 
     fn tumbling_insert(&mut self, key: &DataInput, _value: i64) {
@@ -760,7 +770,11 @@ mod tests {
 
     #[test]
     fn kll_tumbling_quantile_accuracy() {
-        let config = KLLConfig { k: 200, m: 8 };
+        let config = KLLConfig {
+            k: 200,
+            m: 8,
+            seed: None,
+        };
         let samples_per_window = 5000;
         let num_windows = 4;
 
@@ -1098,7 +1112,11 @@ mod tests {
 
     #[test]
     fn kll_tumbling_multi_quantile_accuracy() {
-        let config = KLLConfig { k: 200, m: 8 };
+        let config = KLLConfig {
+            k: 200,
+            m: 8,
+            seed: None,
+        };
         let total_samples = 100_000;
         let num_windows = 8;
         let samples_per_window = total_samples / num_windows;
@@ -1141,7 +1159,11 @@ mod tests {
 
     #[test]
     fn kll_tumbling_distribution_shift() {
-        let config = KLLConfig { k: 400, m: 8 };
+        let config = KLLConfig {
+            k: 400,
+            m: 8,
+            seed: None,
+        };
         let samples_per_phase = 50_000;
         let windows_per_phase = 4;
         let samples_per_window = samples_per_phase / windows_per_phase;
@@ -1197,6 +1219,64 @@ mod tests {
         // Verify ordering is monotonic.
         assert!(p10 < p50, "p10 ({p10:.1}) should be < p50 ({p50:.1})");
         assert!(p50 < p90, "p50 ({p50:.1}) should be < p90 ({p90:.1})");
+    }
+
+    // -- Seeded determinism (issue #77) ---------------------------------------
+
+    #[test]
+    fn kll_tumbling_seeded_is_byte_identical_across_instances() {
+        let make = || {
+            TumblingWindow::<KLL>::new(
+                1000,
+                4,
+                KLLConfig {
+                    k: 200,
+                    m: 8,
+                    seed: Some(0x5EED_CAFE),
+                },
+                6,
+            )
+        };
+        // Two independent managers, as if on two hosts/processes.
+        let mut tw_a = make();
+        let mut tw_b = make();
+
+        // Spanning many windows exercises close_active → pool.put →
+        // tumbling_clear → re-seed, which is where the unseeded path used to
+        // re-randomize the coin on every rotation.
+        let values = sample_uniform_f64(0.0, 1_000_000.0, 20_000, 0x5EED_0001);
+        for (i, &v) in values.iter().enumerate() {
+            let t = i as u64;
+            tw_a.insert(t, &DataInput::F64(v), 1);
+            tw_b.insert(t, &DataInput::F64(v), 1);
+        }
+
+        let bytes_a = tw_a.query_all().serialize_to_bytes().unwrap();
+        let bytes_b = tw_b.query_all().serialize_to_bytes().unwrap();
+        assert_eq!(
+            bytes_a, bytes_b,
+            "same KLLConfig seed must give byte-identical tumbling state"
+        );
+
+        // A different seed must not silently alias onto the same coin stream.
+        let mut tw_c: TumblingWindow<KLL> = TumblingWindow::new(
+            1000,
+            4,
+            KLLConfig {
+                k: 200,
+                m: 8,
+                seed: Some(0x5EED_CAFE + 1),
+            },
+            6,
+        );
+        for (i, &v) in values.iter().enumerate() {
+            tw_c.insert(i as u64, &DataInput::F64(v), 1);
+        }
+        let bytes_c = tw_c.query_all().serialize_to_bytes().unwrap();
+        assert_ne!(
+            bytes_a, bytes_c,
+            "different KLLConfig seeds must produce different state"
+        );
     }
 
     #[test]
@@ -1600,7 +1680,11 @@ mod tests {
 
     #[test]
     fn kll_tumbling_query_recent_accuracy() {
-        let config = KLLConfig { k: 200, m: 8 };
+        let config = KLLConfig {
+            k: 200,
+            m: 8,
+            seed: None,
+        };
         let total_samples = 100_000;
         let num_windows = 8;
         let recent_n = 3;
@@ -1847,7 +1931,11 @@ mod tests {
 
     #[test]
     fn kll_tumbling_vs_monolithic() {
-        let config = KLLConfig { k: 200, m: 8 };
+        let config = KLLConfig {
+            k: 200,
+            m: 8,
+            seed: None,
+        };
         let total_samples = 100_000;
         let num_windows = 8;
         let samples_per_window = total_samples / num_windows;
@@ -1996,7 +2084,11 @@ mod tests {
 
         // --- KLL subsection ---
         {
-            let config = KLLConfig { k: 200, m: 8 };
+            let config = KLLConfig {
+                k: 200,
+                m: 8,
+                seed: None,
+            };
             let mut tw: TumblingWindow<KLL> =
                 TumblingWindow::new(total_samples as u64 + 1, 10, config, 4);
 

--- a/src/sketch_framework/tumbling.rs
+++ b/src/sketch_framework/tumbling.rs
@@ -80,13 +80,6 @@ pub struct KLLConfig {
     pub k: usize,
     /// Minimum compactor size parameter.
     pub m: usize,
-    /// Optional seed for the compaction coin. When `Some`, every pool sketch
-    /// is built with [`KLL::init_with_seed`], so two processes running the
-    /// same tumbling pipeline produce byte-identical sketches — including
-    /// across window rotations, because `tumbling_clear` re-seeds from the
-    /// stored seed. When `None`, the legacy wall-clock-seeded [`KLL::init`]
-    /// path is used and cross-process agreement is not achievable.
-    pub seed: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -147,10 +140,7 @@ impl TumblingWindowSketch for KLL {
     type Config = KLLConfig;
 
     fn from_config(config: &Self::Config) -> Self {
-        match config.seed {
-            Some(seed) => KLL::init_with_seed(config.k, config.m, seed),
-            None => KLL::init(config.k, config.m),
-        }
+        KLL::init(config.k, config.m)
     }
 
     fn tumbling_insert(&mut self, key: &DataInput, _value: i64) {
@@ -770,11 +760,7 @@ mod tests {
 
     #[test]
     fn kll_tumbling_quantile_accuracy() {
-        let config = KLLConfig {
-            k: 200,
-            m: 8,
-            seed: None,
-        };
+        let config = KLLConfig { k: 200, m: 8 };
         let samples_per_window = 5000;
         let num_windows = 4;
 
@@ -1112,11 +1098,7 @@ mod tests {
 
     #[test]
     fn kll_tumbling_multi_quantile_accuracy() {
-        let config = KLLConfig {
-            k: 200,
-            m: 8,
-            seed: None,
-        };
+        let config = KLLConfig { k: 200, m: 8 };
         let total_samples = 100_000;
         let num_windows = 8;
         let samples_per_window = total_samples / num_windows;
@@ -1159,11 +1141,7 @@ mod tests {
 
     #[test]
     fn kll_tumbling_distribution_shift() {
-        let config = KLLConfig {
-            k: 400,
-            m: 8,
-            seed: None,
-        };
+        let config = KLLConfig { k: 400, m: 8 };
         let samples_per_phase = 50_000;
         let windows_per_phase = 4;
         let samples_per_window = samples_per_phase / windows_per_phase;
@@ -1219,64 +1197,6 @@ mod tests {
         // Verify ordering is monotonic.
         assert!(p10 < p50, "p10 ({p10:.1}) should be < p50 ({p50:.1})");
         assert!(p50 < p90, "p50 ({p50:.1}) should be < p90 ({p90:.1})");
-    }
-
-    // -- Seeded determinism (issue #77) ---------------------------------------
-
-    #[test]
-    fn kll_tumbling_seeded_is_byte_identical_across_instances() {
-        let make = || {
-            TumblingWindow::<KLL>::new(
-                1000,
-                4,
-                KLLConfig {
-                    k: 200,
-                    m: 8,
-                    seed: Some(0x5EED_CAFE),
-                },
-                6,
-            )
-        };
-        // Two independent managers, as if on two hosts/processes.
-        let mut tw_a = make();
-        let mut tw_b = make();
-
-        // Spanning many windows exercises close_active → pool.put →
-        // tumbling_clear → re-seed, which is where the unseeded path used to
-        // re-randomize the coin on every rotation.
-        let values = sample_uniform_f64(0.0, 1_000_000.0, 20_000, 0x5EED_0001);
-        for (i, &v) in values.iter().enumerate() {
-            let t = i as u64;
-            tw_a.insert(t, &DataInput::F64(v), 1);
-            tw_b.insert(t, &DataInput::F64(v), 1);
-        }
-
-        let bytes_a = tw_a.query_all().serialize_to_bytes().unwrap();
-        let bytes_b = tw_b.query_all().serialize_to_bytes().unwrap();
-        assert_eq!(
-            bytes_a, bytes_b,
-            "same KLLConfig seed must give byte-identical tumbling state"
-        );
-
-        // A different seed must not silently alias onto the same coin stream.
-        let mut tw_c: TumblingWindow<KLL> = TumblingWindow::new(
-            1000,
-            4,
-            KLLConfig {
-                k: 200,
-                m: 8,
-                seed: Some(0x5EED_CAFE + 1),
-            },
-            6,
-        );
-        for (i, &v) in values.iter().enumerate() {
-            tw_c.insert(i as u64, &DataInput::F64(v), 1);
-        }
-        let bytes_c = tw_c.query_all().serialize_to_bytes().unwrap();
-        assert_ne!(
-            bytes_a, bytes_c,
-            "different KLLConfig seeds must produce different state"
-        );
     }
 
     #[test]
@@ -1680,11 +1600,7 @@ mod tests {
 
     #[test]
     fn kll_tumbling_query_recent_accuracy() {
-        let config = KLLConfig {
-            k: 200,
-            m: 8,
-            seed: None,
-        };
+        let config = KLLConfig { k: 200, m: 8 };
         let total_samples = 100_000;
         let num_windows = 8;
         let recent_n = 3;
@@ -1931,11 +1847,7 @@ mod tests {
 
     #[test]
     fn kll_tumbling_vs_monolithic() {
-        let config = KLLConfig {
-            k: 200,
-            m: 8,
-            seed: None,
-        };
+        let config = KLLConfig { k: 200, m: 8 };
         let total_samples = 100_000;
         let num_windows = 8;
         let samples_per_window = total_samples / num_windows;
@@ -2084,11 +1996,7 @@ mod tests {
 
         // --- KLL subsection ---
         {
-            let config = KLLConfig {
-                k: 200,
-                m: 8,
-                seed: None,
-            };
+            let config = KLLConfig { k: 200, m: 8 };
             let mut tw: TumblingWindow<KLL> =
                 TumblingWindow::new(total_samples as u64 + 1, 10, config, 4);
 

--- a/src/sketches/countminsketch.rs
+++ b/src/sketches/countminsketch.rs
@@ -15,7 +15,7 @@ use crate::octo_delta::{CM_PROMASK, CmDelta};
 use crate::{
     DataInput, DefaultMatrixI32, DefaultMatrixI64, DefaultMatrixI128, DefaultXxHasher, FastPath,
     FastPathHasher, FixedMatrix, MatrixFastHash, MatrixStorage, NitroTarget, QuickMatrixI64,
-    QuickMatrixI128, RegularPath, SketchHasher, Vector2D, hash64_seeded,
+    QuickMatrixI128, RegularPath, SketchHasher, Vector2D, hash64_seeded, nitro_delta_saturated_i32,
 };
 
 mod wire;
@@ -498,7 +498,8 @@ impl<H: SketchHasher> CountMin<Vector2D<i32>, FastPath, H> {
     #[inline(always)]
     pub fn fast_insert_nitro(&mut self, value: &DataInput) {
         let rows = self.counts.rows();
-        let delta = self.counts.nitro().delta as i32;
+        let delta =
+            crate::sketch_framework::nitro::nitro_delta_saturated_i32(self.counts.nitro().delta);
         if self.counts.nitro().to_skip >= rows {
             self.counts.reduce_nitro_skip(rows);
         } else {
@@ -529,8 +530,12 @@ impl<H: SketchHasher> NitroTarget for CountMin<Vector2D<i32>, FastPath, H> {
 
     #[inline(always)]
     fn update_row(&mut self, row: usize, hashed: u128, delta: u64) {
-        self.counts
-            .update_by_row(row, hashed, |a, b| *a += b, delta as i32);
+        self.counts.update_by_row(
+            row,
+            hashed,
+            |a, b| *a += b,
+            nitro_delta_saturated_i32(delta),
+        );
     }
 
     #[inline(always)]
@@ -541,8 +546,12 @@ impl<H: SketchHasher> NitroTarget for CountMin<Vector2D<i32>, FastPath, H> {
         let cols = self.counts.cols();
         for row in 0..self.counts.rows() {
             let col = <H::HashType as MatrixFastHash>::col_for_row(&hashed, row, cols);
-            self.counts
-                .update_one_counter(row, col, |a, b| *a += b, delta as i32);
+            self.counts.update_one_counter(
+                row,
+                col,
+                |a, b| *a += b,
+                nitro_delta_saturated_i32(delta),
+            );
         }
     }
 }

--- a/src/sketches/countminsketch.rs
+++ b/src/sketches/countminsketch.rs
@@ -498,8 +498,7 @@ impl<H: SketchHasher> CountMin<Vector2D<i32>, FastPath, H> {
     #[inline(always)]
     pub fn fast_insert_nitro(&mut self, value: &DataInput) {
         let rows = self.counts.rows();
-        let delta =
-            crate::sketch_framework::nitro::nitro_delta_saturated_i32(self.counts.nitro().delta);
+        let delta = nitro_delta_saturated_i32(self.counts.nitro().delta);
         if self.counts.nitro().to_skip >= rows {
             self.counts.reduce_nitro_skip(rows);
         } else {

--- a/src/sketches/countminsketch.rs
+++ b/src/sketches/countminsketch.rs
@@ -532,6 +532,19 @@ impl<H: SketchHasher> NitroTarget for CountMin<Vector2D<i32>, FastPath, H> {
         self.counts
             .update_by_row(row, hashed, |a, b| *a += b, delta as i32);
     }
+
+    #[inline(always)]
+    fn update_sample(&mut self, value: &DataInput, delta: u64) {
+        // Hash with the SAME derivation the estimator uses so both share one
+        // hash domain (raw hash128_seeded bit-slicing diverges in Packed64 mode).
+        let hashed = <Vector2D<i32> as FastPathHasher<H>>::hash_for_matrix(&self.counts, value);
+        let cols = self.counts.cols();
+        for row in 0..self.counts.rows() {
+            let col = <H::HashType as MatrixFastHash>::col_for_row(&hashed, row, cols);
+            self.counts
+                .update_one_counter(row, col, |a, b| *a += b, delta as i32);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/sketches/countsketch.rs
+++ b/src/sketches/countsketch.rs
@@ -520,6 +520,20 @@ impl<H: SketchHasher> NitroTarget for Count<Vector2D<i32>, FastPath, H> {
         self.counts
             .update_by_row(row, hashed, |a, b| *a += b, sign * (delta as i32));
     }
+
+    #[inline(always)]
+    fn update_sample(&mut self, value: &DataInput, delta: u64) {
+        // Hash with the SAME derivation the estimator uses so both share one
+        // hash domain (raw hash128_seeded bit-slicing diverges in Packed64 mode).
+        let hashed = <Vector2D<i32> as FastPathHasher<H>>::hash_for_matrix(&self.counts, value);
+        let cols = self.counts.cols();
+        for row in 0..self.counts.rows() {
+            let col = <H::HashType as MatrixFastHash>::col_for_row(&hashed, row, cols);
+            let sign = <H::HashType as MatrixFastHash>::sign_for_row(&hashed, row);
+            self.counts
+                .update_one_counter(row, col, |a, b| *a += b, sign * (delta as i32));
+        }
+    }
 }
 
 use crate::octo_delta::{COUNT_PROMASK, CountDelta};

--- a/src/sketches/countsketch.rs
+++ b/src/sketches/countsketch.rs
@@ -10,7 +10,7 @@
 use crate::{
     DataInput, DefaultMatrixI32, DefaultMatrixI64, DefaultMatrixI128, DefaultXxHasher, FastPath,
     FastPathHasher, FixedMatrix, MatrixFastHash, MatrixStorage, NitroTarget, QuickMatrixI64,
-    QuickMatrixI128, RegularPath, SketchHasher, Vector2D, hash64_seeded,
+    QuickMatrixI128, RegularPath, SketchHasher, Vector2D, hash64_seeded, nitro_delta_saturated_i32,
 };
 use rmp_serde::{
     decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice, to_vec_named,
@@ -492,8 +492,12 @@ impl<H: SketchHasher> Count<Vector2D<i32>, FastPath, H> {
             loop {
                 let bit = (hashed >> (127 - r)) & 1;
                 let sign = (bit << 1) as i32 - 1;
-                self.counts
-                    .update_by_row(r, hashed, |a, b| *a += b, sign * (delta as i32));
+                self.counts.update_by_row(
+                    r,
+                    hashed,
+                    |a, b| *a += b,
+                    sign * nitro_delta_saturated_i32(delta),
+                );
                 self.counts.nitro_mut().draw_geometric();
                 if r + self.counts.nitro_mut().to_skip + 1 >= rows {
                     break;
@@ -517,8 +521,12 @@ impl<H: SketchHasher> NitroTarget for Count<Vector2D<i32>, FastPath, H> {
     fn update_row(&mut self, row: usize, hashed: u128, delta: u64) {
         let bit = (hashed >> (127 - row)) & 1;
         let sign = (bit << 1) as i32 - 1;
-        self.counts
-            .update_by_row(row, hashed, |a, b| *a += b, sign * (delta as i32));
+        self.counts.update_by_row(
+            row,
+            hashed,
+            |a, b| *a += b,
+            sign * nitro_delta_saturated_i32(delta),
+        );
     }
 
     #[inline(always)]
@@ -530,8 +538,12 @@ impl<H: SketchHasher> NitroTarget for Count<Vector2D<i32>, FastPath, H> {
         for row in 0..self.counts.rows() {
             let col = <H::HashType as MatrixFastHash>::col_for_row(&hashed, row, cols);
             let sign = <H::HashType as MatrixFastHash>::sign_for_row(&hashed, row);
-            self.counts
-                .update_one_counter(row, col, |a, b| *a += b, sign * (delta as i32));
+            self.counts.update_one_counter(
+                row,
+                col,
+                |a, b| *a += b,
+                sign * nitro_delta_saturated_i32(delta),
+            );
         }
     }
 }

--- a/src/sketches/countsketch_topk.rs
+++ b/src/sketches/countsketch_topk.rs
@@ -1024,9 +1024,12 @@ impl<H: SketchHasher> CountL2HH<H> {
             let new_value = old_value + sign_bit * c;
             self.counts[i][idx] = new_value;
 
-            let old_l2 = self.l2.as_slice()[i];
-            let new_l2 = old_l2 + new_value * new_value - old_value * old_value;
-            self.l2[i] = new_l2;
+            // Saturating i128 intermediate so extreme counts degrade
+            // gracefully instead of wrapping (matches merge-path semantics).
+            let old_l2 = self.l2.as_slice()[i] as i128;
+            let new_l2 = old_l2 + (new_value as i128) * (new_value as i128)
+                - (old_value as i128) * (old_value as i128);
+            self.l2[i] = new_l2.clamp(i64::MIN as i128, i64::MAX as i128) as i64;
 
             shift_amount += mask_bits;
             sign_bit_pos -= 1;

--- a/src/sketches/countsketch_topk.rs
+++ b/src/sketches/countsketch_topk.rs
@@ -1025,11 +1025,13 @@ impl<H: SketchHasher> CountL2HH<H> {
             self.counts[i][idx] = new_value;
 
             // Saturating i128 intermediate so extreme counts degrade
-            // gracefully instead of wrapping (matches merge-path semantics).
+            // gracefully instead of wrapping (matches merge-path semantics,
+            // which also clamps to [0, i64::MAX]: L2^2 can never go negative,
+            // even when a decrement follows prior saturation).
             let old_l2 = self.l2.as_slice()[i] as i128;
             let new_l2 = old_l2 + (new_value as i128) * (new_value as i128)
                 - (old_value as i128) * (old_value as i128);
-            self.l2[i] = new_l2.clamp(i64::MIN as i128, i64::MAX as i128) as i64;
+            self.l2[i] = new_l2.clamp(0, i64::MAX as i128) as i64;
 
             shift_amount += mask_bits;
             sign_bit_pos -= 1;

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -248,7 +248,8 @@ impl DDSketch {
         if !(v.is_finite() && v > 0.0) {
             return;
         }
-        if v < self.min_indexable_value() || v > self.max_indexable_value() {
+        let (min_indexable, max_indexable) = ddsketch_indexable_bounds(self.alpha);
+        if v < min_indexable || v > max_indexable {
             return; // untrackable extreme: would blow up the dense bucket span
         }
 
@@ -412,25 +413,6 @@ impl DDSketch {
     #[inline]
     fn bin_representative(&self, k: i32) -> f64 {
         self.lower_bound(k) * (1.0 + self.alpha)
-    }
-
-    /// Smallest finite positive value whose bucket index is representable
-    /// without integer overflow (index ≥ i32::MIN) or float underflow, mirroring
-    /// DataDog's logarithmic_mapping.go minIndexableValue.
-    #[inline]
-    fn min_indexable_value(&self) -> f64 {
-        ddsketch_indexable_bounds(self.alpha).0
-    }
-
-    /// Largest finite positive value whose bucket index is representable without
-    /// integer overflow (index ≤ i32::MAX) or `exp`/`powf` overflow, mirroring
-    /// DataDog's logarithmic_mapping.go maxIndexableValue. A value beyond this
-    /// would otherwise map to an arbitrarily distant index and force the dense
-    /// bucket store to grow across the whole gap (asap_sketchlib#70 item 4 /
-    /// sketchlib-go#72's single-outlier memory blowup).
-    #[inline]
-    fn max_indexable_value(&self) -> f64 {
-        ddsketch_indexable_bounds(self.alpha).1
     }
 
     fn merge_buckets_from(&mut self, other: &DDSketch) {
@@ -947,8 +929,9 @@ mod tests {
         let count_before = d.get_count();
         let span_before = d.store.counts.as_slice().len();
 
-        d.add(&(d.max_indexable_value() * 10.0));
-        d.add(&(d.min_indexable_value() / 10.0));
+        let (min_indexable, max_indexable) = ddsketch_indexable_bounds(0.01);
+        d.add(&(max_indexable * 10.0));
+        d.add(&(min_indexable / 10.0));
         assert_eq!(d.get_count(), count_before, "extreme values were recorded");
         assert_eq!(
             d.store.counts.as_slice().len(),
@@ -957,7 +940,7 @@ mod tests {
         );
 
         // A large-but-trackable value is still recorded.
-        d.add(&(d.max_indexable_value() / 2.0));
+        d.add(&(max_indexable / 2.0));
         assert_eq!(d.get_count(), count_before + 1);
     }
 }

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -142,6 +142,31 @@ pub struct DDSketch {
     max: f64,
 }
 
+/// Smallest and largest finite positive values whose bucket index is
+/// representable without integer overflow (index within `i32`) or
+/// `exp`/`powf` overflow, mirroring DataDog's logarithmic_mapping.go
+/// `minIndexableValue`/`maxIndexableValue`. Values outside this range are
+/// dropped rather than mapped to an arbitrarily distant bucket index — that
+/// guards the dense bucket store against a single finite-but-extreme outlier
+/// forcing an allocation spanning the whole index gap (asap_sketchlib#70
+/// item 4 / sketchlib-go#72).
+///
+/// Single source of truth shared by core `DDSketch`, the portable wire twin,
+/// and tests, so the two implementations cannot drift algebraically again.
+pub fn ddsketch_indexable_bounds(alpha: f64) -> (f64, f64) {
+    let gamma = (1.0 + alpha) / (1.0 - alpha);
+    let inv_log_gamma = 1.0 / gamma.ln();
+    // 709.0 is just under ln(f64::MAX) so exp() stays finite.
+    const EXP_OVERFLOW: f64 = 709.0;
+    let min = ((f64::from(i32::MIN)) / inv_log_gamma + 1.0)
+        .exp()
+        .max(f64::MIN_POSITIVE * gamma);
+    let max = ((f64::from(i32::MAX)) / inv_log_gamma - 1.0)
+        .exp()
+        .min(EXP_OVERFLOW.exp() / (2.0 * gamma) * (gamma + 1.0));
+    (min, max)
+}
+
 impl DDSketch {
     /// Creates a new DDSketch with relative accuracy guarantee `alpha` (must be in `(0, 1)`).
     pub fn new(alpha: f64) -> Self {
@@ -394,10 +419,7 @@ impl DDSketch {
     /// DataDog's logarithmic_mapping.go minIndexableValue.
     #[inline]
     fn min_indexable_value(&self) -> f64 {
-        // f64::MIN_POSITIVE is the smallest positive normal (2^-1022).
-        ((f64::from(i32::MIN)) / self.inv_log_gamma + 1.0)
-            .exp()
-            .max(f64::MIN_POSITIVE * self.gamma)
+        ddsketch_indexable_bounds(self.alpha).0
     }
 
     /// Largest finite positive value whose bucket index is representable without
@@ -408,11 +430,7 @@ impl DDSketch {
     /// sketchlib-go#72's single-outlier memory blowup).
     #[inline]
     fn max_indexable_value(&self) -> f64 {
-        // 709.0 is just under ln(f64::MAX) so exp() stays finite.
-        const EXP_OVERFLOW: f64 = 709.0;
-        ((f64::from(i32::MAX)) / self.inv_log_gamma - 1.0)
-            .exp()
-            .min(EXP_OVERFLOW.exp() / (2.0 * self.gamma) * (self.gamma + 1.0))
+        ddsketch_indexable_bounds(self.alpha).1
     }
 
     fn merge_buckets_from(&mut self, other: &DDSketch) {

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -102,9 +102,7 @@ impl Buckets {
             let idx = idx_i32 as usize;
             let slice = self.counts.as_mut_slice();
             if idx < slice.len() {
-                unsafe {
-                    *slice.as_mut_ptr().add(idx) += 1;
-                }
+                slice[idx] += 1;
                 return;
             }
         }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,69 @@
+# E2E Testing Harness & Conformance Kit
+
+Every sketch in `asap_sketchlib` is validated end-to-end against exact ground
+truth from seeded synthetic streams. New sketches **must** go through the
+same conformance batteries before landing — copy an adapter from
+`tests/conformance_kit.rs`, run the batteries, done.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `common/mod.rs` | Seeded stream generators (`zipf_u64`, `uniform_u64`, `normal_f64`, `exponential_f64`, adversarial `log_uniform_f64`), exact truth trackers (`FreqTruth`, `NumericTruth`), assertion helpers |
+| `common/conformance.rs` | Capability traits + standard conformance batteries |
+| `conformance_kit.rs` | Reference adapters: established sketches running through the kit (copy these) |
+| `e2e_frequency.rs` / `e2e_cardinality.rs` / `e2e_quantiles.rs` / `e2e_frameworks.rs` | Deep per-family suites with hand-tuned tolerances |
+| `e2e_experimental.rs` | Same for `feature = "experimental"` sketches |
+| `bug_verification.rs` | Regression tests for fixed wrong-query-results bugs |
+
+## Onboarding a new sketch
+
+1. **Pick the batteries that match what your sketch promises.**
+
+   | Your sketch estimates… | Battery | Trait to impl |
+   | --- | --- | --- |
+   | Per-key frequency | `frequency_battery` | `FrequencyOps<K>` |
+   | …never underestimates (CMS-style) | same, `one_sided: true` in `FrequencySpec` | — |
+   | …with signed/turnstile updates | `turnstile_battery` | `SignedFrequencyOps<K>` |
+   | Distinct count | `cardinality_battery` | `CardinalityOps` |
+   | Quantiles of a numeric stream | `quantile_battery` | `QuantileOps` |
+   | Mergeable shards | `merge_equivalence_battery` | add `MergeOps` |
+
+2. **Write one adapter struct** implementing the trait(s) by delegating to
+   your public API. See any adapter in `tests/conformance_kit.rs`.
+
+3. **Run the battery** with production-shaped dimensions and tolerances from
+   your sketch's documentation:
+
+   ```rust
+   conformance::quantile_battery(
+       "MyNewSketch",
+       || MyAdapter(MySketch::with_defaults()),
+       &values,
+       QuantileSpec::default(),
+   )
+   .assert_ok();
+   ```
+
+4. **Add deeper, sketch-specific checks** (merge semantics, windowing,
+   serialization) as a test in the matching `e2e_*.rs` suite.
+
+## Rules
+
+- All randomness flows through seeded generators; no `rand::rng()` in tests.
+- Ground truth is tracked exactly while generating — never re-derived from
+  another approximation.
+- Tolerances must be justified: theory bounds when they exist (α for DDS,
+  rank error for KLL, ε·N for CMS), otherwise documented empirical values
+  consistent with existing suites.
+- Batteries accumulate failures into a `BatteryReport`; call `.assert_ok()`
+  once at the end so a single run reports every violation, not just the first.
+
+## Running
+
+```bash
+cargo test --test conformance_kit        # kit + reference adapters
+cargo test --all-features               # everything, incl. e2e_experimental
+cargo run --release --example accuracy_probe --features experimental
+                                         # heavy release-only probes
+```

--- a/tests/bug_verification.rs
+++ b/tests/bug_verification.rs
@@ -2,8 +2,9 @@
 //! ground-truth accuracy probe (examples/accuracy_probe.rs).
 //!
 //! Each test feeds fully deterministic synthetic data with an exactly known
-//! answer and asserts the theory-correct behavior. These tests FAIL against
-//! the current implementation; each documents one confirmed defect.
+//! answer and asserts the theory-correct behavior. All four bugs below were
+//! fixed in this PR; these tests pin the fixed behavior so the defects
+//! cannot silently return.
 
 use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketch as PortableDds;
 use asap_sketchlib::{

--- a/tests/bug_verification.rs
+++ b/tests/bug_verification.rs
@@ -1,0 +1,146 @@
+//! Regression tests for wrong-query-results bugs found by the
+//! ground-truth accuracy probe (examples/accuracy_probe.rs).
+//!
+//! Each test feeds fully deterministic synthetic data with an exactly known
+//! answer and asserts the theory-correct behavior. These tests FAIL against
+//! the current implementation; each documents one confirmed defect.
+
+use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketch as PortableDds;
+use asap_sketchlib::{
+    CountL2HH, CountMin, DDSketch, DataInput, DefaultXxHasher, NitroBatch, Vector2D,
+};
+
+// ---------------------------------------------------------------------------
+// Bug 1: NitroBatch::estimate_median reads a different hash domain than the
+// insert path writes, so it returns ~0 for every key.
+//
+// Insert:  hash128_seeded(0, key), bit-sliced per row   (nitro.rs:259)
+// Estimate: CountMin fast path -> Packed64(hash64(...)) (hash.rs:329)
+//
+// Synthetic stream: one key inserted 100_000 times at rate 1.0.
+// Truth: 100_000. Current behavior: 0.
+// ---------------------------------------------------------------------------
+#[test]
+fn nitro_estimate_median_matches_insert_hash_domain() {
+    let n = 100_000i64;
+    let mut nb = NitroBatch::with_target(
+        1.0,
+        CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(5, 2048),
+    );
+    nb.insert(&vec![7i64; n as usize]);
+
+    let est = nb.estimate_median(&DataInput::I64(7));
+    assert!(
+        est > 0.5 * n as f64,
+        "public estimate_median returned {est} for a key inserted {n} times \
+         (insert and estimate use different hash derivations)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2 (regression): NitroBatch must not assign each sampled item to a
+// single row (position % rows), which drove every per-row counter to
+// truth/rows. After the fix each sampled record updates ALL rows, so the
+// estimate converges to the true frequency at ANY sampling rate.
+//
+// Synthetic stream: one key inserted 10_000 times, 5 rows, rates {1.0, 0.5}.
+// Truth: 10_000. Pre-fix behavior: 2_000 (= n / rows) or 0 (hash mismatch).
+// ---------------------------------------------------------------------------
+#[test]
+fn nitro_estimate_is_not_divided_by_rows() {
+    let n = 100_000i64;
+    let rows = 5usize;
+    for rate in [1.0f64, 0.5, 0.25] {
+        let mut nb = NitroBatch::with_target(
+            rate,
+            CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(rows, 2048),
+        );
+        nb.insert(&vec![7i64; n as usize]);
+        let est = nb.estimate_median(&DataInput::I64(7));
+        assert!(
+            (est - n as f64).abs() <= 0.05 * n as f64,
+            "rate={rate}: estimate_median returned {est} for {n} inserts \
+             across {rows} rows (expected ~{n})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bug 3: portable DdSketch reports gamma^(k+0.5) (bucket log-midpoint) as the
+// representative (portable/ddsketch.rs:426). For values sitting at the lower
+// edge of bucket k the relative error is sqrt(gamma)-1 ~= alpha + alpha^2/2,
+// violating the advertised relative-accuracy guarantee. Core DDSketch already
+// uses gamma^k * (1 + alpha) (ddsketch.rs:383-392), so the two disagree on
+// identical data.
+//
+// Synthetic data: value gamma^k * (1 + 1e-6) repeated 10_000x, alpha = 0.05.
+// Truth for every quantile: the value itself. Current behavior: 5.13% error.
+// ---------------------------------------------------------------------------
+#[test]
+fn portable_ddsketch_respects_alpha_at_bucket_edges() {
+    let alpha = 0.05;
+    let gamma = (1.0f64 + alpha) / (1.0 - alpha);
+    let v = gamma.powi(20) * (1.0 + 1e-6);
+
+    let mut port = PortableDds::new(alpha);
+    let mut core = DDSketch::new(alpha);
+    for _ in 0..10_000 {
+        port.update(v);
+        core.add(&v);
+    }
+
+    let q_port = port.quantile(0.5).unwrap();
+    let rel_port = ((q_port - v) / v).abs();
+    assert!(
+        rel_port <= alpha * (1.0 + 1e-6),
+        "portable DdSketch median off by {rel_port:.5} (> alpha={alpha}) at a \
+         bucket-edge value"
+    );
+
+    // Both implementations must sit within alpha of the truth on identical
+    // data. (Exact equality is impossible: core clamps representatives to its
+    // observed min/max, which the portable wire format does not carry.)
+    let q_core = core.get_value_at_quantile(0.5).unwrap();
+    let rel_core = ((q_core - v) / v).abs();
+    assert!(
+        rel_core <= alpha * (1.0 + 1e-6),
+        "core DDSketch median off by {rel_core:.5} (> alpha={alpha})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug 4: CountL2HH's hot-path L2 accumulation ran in plain i64
+// (countsketch_topk.rs:1028: old + new^2 - old^2) and wrapped silently once
+// sum(count^2) exceeded i64::MAX (panicking in debug builds). The hot path
+// now saturates in i128, matching the merge path.
+//
+// Synthetic stream: two keys with count 3e9 each => true F2 = 1.8e19 > i64::MAX.
+// Pre-fix behavior: 0 in release, overflow panic in debug. Post-fix: saturates.
+// ---------------------------------------------------------------------------
+#[test]
+fn countl2hh_f2_survives_beyond_i64_max() {
+    let c = 3_000_000_000i64;
+    let mut sk = CountL2HH::<DefaultXxHasher>::with_dimensions_and_seed(4, 2048, 7);
+    sk.fast_insert_with_count(&DataInput::U32(1), c);
+
+    // Single key: true F2 = 9e18 < i64::MAX => must stay exact.
+    let single_truth = (c as f64) * (c as f64);
+    let got_single = sk.get_l2_sqr();
+    assert!(
+        (got_single - single_truth).abs() / single_truth < 1e-12,
+        "exact-range F2 drifted: got {got_single}, expected {single_truth:.3e}"
+    );
+
+    // Second key pushes the true F2 to 1.8e19 — beyond any i64 counter.
+    sk.fast_insert_with_count(&DataInput::U32(2), c);
+    let truth = 2.0f64 * (c as f64) * (c as f64); // 1.8e19 > i64::MAX
+    let got = sk.get_l2_sqr();
+
+    // Must saturate at i64::MAX rather than wrap to garbage or panic.
+    let i64_max = i64::MAX as f64;
+    assert!(
+        (got - i64_max).abs() / i64_max < 1e-12,
+        "F2 neither exact nor saturated: got {got}, expected saturation at \
+         {i64_max:.3e} (true value {truth:.3e})"
+    );
+}

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -1,0 +1,362 @@
+//! Reusable conformance batteries for sketch implementations.
+//!
+//! New sketches plug into this kit by implementing one or more capability
+//! traits (`FrequencyOps`, `SignedFrequencyOps`, `CardinalityOps`,
+//! `QuantileOps`, `MergeOps`) and calling the matching `*_battery` functions.
+//! Every battery is deterministic (seeded streams) and reports structured
+//! failures; call [`BatteryReport::assert_ok`] to turn them into test
+//! failures with expected-vs-actual context.
+//!
+//! See `tests/README.md` for the onboarding recipe.
+
+use super::{FreqTruth, NumericTruth};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+// ---------------------------------------------------------------------------
+// Reports
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct BatteryFailure {
+    pub check: String,
+    pub detail: String,
+}
+
+#[derive(Debug)]
+pub struct BatteryReport {
+    pub sketch: String,
+    pub battery: &'static str,
+    pub failures: Vec<BatteryFailure>,
+}
+
+impl BatteryReport {
+    fn record(&mut self, check: &str, ok: bool, detail: String) {
+        if !ok {
+            self.failures.push(BatteryFailure {
+                check: check.to_string(),
+                detail,
+            });
+        }
+    }
+
+    /// Panic with all accumulated failures if any check failed.
+    pub fn assert_ok(self) {
+        if !self.failures.is_empty() {
+            let rendered: Vec<String> = self
+                .failures
+                .iter()
+                .map(|f| format!("  [{}] {}", f.check, f.detail))
+                .collect();
+            panic!(
+                "{} / {} conformance failures:\n{}",
+                self.sketch,
+                self.battery,
+                rendered.join("\n")
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Capability traits (implement these on an adapter for your sketch)
+// ---------------------------------------------------------------------------
+
+/// Point-frequency queries over copyable keys.
+pub trait FrequencyOps<K> {
+    fn ingest(&mut self, key: &K);
+    fn estimate(&self, key: &K) -> f64;
+}
+
+/// Weighted/signed ingestion for turnstile-capable sketches.
+pub trait SignedFrequencyOps<K>: FrequencyOps<K> {
+    fn ingest_weighted(&mut self, key: &K, weight: i64);
+}
+
+/// Distinct-count sketches over opaque byte keys.
+pub trait CardinalityOps {
+    fn ingest(&mut self, key: &[u8]);
+    fn estimate(&self) -> f64;
+}
+
+/// Value-quantile sketches over f64 observations.
+pub trait QuantileOps {
+    fn update(&mut self, value: f64);
+    fn quantile(&self, q: f64) -> f64;
+}
+
+/// In-place merge from another instance of the same sketch/config.
+pub trait MergeOps {
+    fn merge_from(&mut self, other: &Self);
+}
+
+// ---------------------------------------------------------------------------
+// Tolerance specs
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+pub struct FrequencySpec {
+    /// One-sided sketches (e.g. CountMin) must never underestimate.
+    pub one_sided: bool,
+    /// Relative tolerance applied to dense keys (hot-key accuracy).
+    pub rel_tol: f64,
+    /// Absolute floor added to tolerances for small counts.
+    pub abs_tol: f64,
+}
+
+impl Default for FrequencySpec {
+    fn default() -> Self {
+        Self {
+            one_sided: false,
+            rel_tol: 0.05,
+            abs_tol: 2.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct CardinalitySpec {
+    pub rel_tol: f64,
+}
+
+impl Default for CardinalitySpec {
+    fn default() -> Self {
+        Self { rel_tol: 0.03 }
+    }
+}
+
+pub const DEFAULT_QUANTILE_QS: [f64; 5] = [0.1, 0.25, 0.5, 0.75, 0.9];
+
+#[derive(Clone, Copy)]
+pub struct QuantileSpec {
+    /// Rank-tolerance band width for quantile checks.
+    pub rank_tol: f64,
+    pub qs: [f64; 5],
+}
+
+impl Default for QuantileSpec {
+    fn default() -> Self {
+        Self {
+            rank_tol: 0.03,
+            qs: DEFAULT_QUANTILE_QS,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Batteries
+// ---------------------------------------------------------------------------
+
+/// Standard frequency battery: hot-key accuracy against exact truth.
+///
+/// - One-sided sketches must satisfy `est >= true` and stay within
+///   `(1 + rel_tol)` of truth plus the absolute floor.
+/// - Two-sided sketches must stay within `rel_tol * true + abs_tol`.
+pub fn frequency_battery<S, F, K>(
+    sketch: &str,
+    new_sketch: F,
+    stream: &[K],
+    truth: &FreqTruth,
+    spec: FrequencySpec,
+) -> BatteryReport
+where
+    S: FrequencyOps<K>,
+    F: Fn() -> S,
+    K: Copy + Eq + Hash + Debug + From<i64>,
+{
+    let mut report = BatteryReport {
+        sketch: sketch.to_string(),
+        battery: "frequency",
+        failures: vec![],
+    };
+    let mut sk = new_sketch();
+    for k in stream {
+        sk.ingest(k);
+    }
+
+    for (k_int, count) in truth.pairs() {
+        if count < 25 {
+            continue; // only dense keys carry statistical meaning
+        }
+        let key = K::from(k_int);
+        let est = sk.estimate(&key);
+        if spec.one_sided {
+            let hi = count as f64 * (1.0 + spec.rel_tol) + spec.abs_tol;
+            report.record(
+                "one-sided bound",
+                est >= count as f64 && est <= hi,
+                format!("key {k_int:?} true {count} est {est} (allowed [{count}, {hi:.1}])"),
+            );
+        } else {
+            let lo = (count as f64) * (1.0 - spec.rel_tol) - spec.abs_tol;
+            let hi = (count as f64) * (1.0 + spec.rel_tol) + spec.abs_tol;
+            report.record(
+                "two-sided bound",
+                est >= lo && est <= hi,
+                format!("key {k_int:?} true {count} est {est} (allowed [{lo:.1}, {hi:.1}])"),
+            );
+        }
+    }
+    report
+}
+
+/// Merge-equivalence battery: shard the stream, merge, and require the merged
+/// sketch to agree with a single-pass sketch on all dense keys.
+pub fn merge_equivalence_battery<S, F, K>(
+    sketch: &str,
+    new_sketch: F,
+    stream: &[K],
+    spec: FrequencySpec,
+) -> BatteryReport
+where
+    S: FrequencyOps<K> + MergeOps,
+    F: Fn() -> S,
+    K: Copy + Eq + Hash + Debug,
+{
+    let mut report = BatteryReport {
+        sketch: sketch.to_string(),
+        battery: "merge-equivalence",
+        failures: vec![],
+    };
+    let mut single = new_sketch();
+    let mut left = new_sketch();
+    let mut right = new_sketch();
+
+    let mut truth_left: HashMap<K, i64> = HashMap::new();
+    for (i, k) in stream.iter().enumerate() {
+        single.ingest(k);
+        if i % 2 == 0 {
+            left.ingest(k);
+            *truth_left.entry(*k).or_insert(0) += 1;
+        } else {
+            right.ingest(k);
+        }
+    }
+    left.merge_from(&right);
+
+    for (k, count) in truth_left {
+        if count < 25 {
+            continue;
+        }
+        let a = single.estimate(&k);
+        let b = left.estimate(&k);
+        let slack = spec.abs_tol + spec.rel_tol * count as f64;
+        report.record(
+            "merged matches single-pass",
+            (a - b).abs() <= slack.max(2.0),
+            format!("key {k:?}: single {a} merged {b}"),
+        );
+    }
+    report
+}
+
+/// Turnstile battery: net-zero cancellation and weighted counting.
+pub fn turnstile_battery<S, F, K>(sketch: &str, new_sketch: F, key: K) -> BatteryReport
+where
+    S: SignedFrequencyOps<K>,
+    F: Fn() -> S,
+    K: Debug,
+{
+    let mut report = BatteryReport {
+        sketch: sketch.to_string(),
+        battery: "turnstile",
+        failures: vec![],
+    };
+    let mut sk = new_sketch();
+    sk.ingest_weighted(&key, 500);
+    sk.ingest_weighted(&key, -200);
+    let est = sk.estimate(&key);
+    report.record(
+        "weighted net count",
+        (est - 300.0).abs() <= 1.0,
+        format!("key {key:?}: +500 then -200 estimated {est}, expected ~300"),
+    );
+
+    sk.ingest_weighted(&key, -300);
+    let zeroed = sk.estimate(&key);
+    report.record(
+        "net-zero cancellation",
+        zeroed.abs() <= 1e-6,
+        format!("key {key:?}: fully cancelled estimate {zeroed}, expected 0"),
+    );
+    report
+}
+
+/// Cardinality battery: unique-stream checkpoints and duplicate-replay
+/// invariance (re-inserting seen elements must not move the estimate).
+pub fn cardinality_battery<S, F>(
+    sketch: &str,
+    new_sketch: F,
+    unique_keys: &[u64],
+    checkpoint: usize,
+    spec: CardinalitySpec,
+) -> BatteryReport
+where
+    S: CardinalityOps,
+    F: Fn() -> S,
+{
+    let mut report = BatteryReport {
+        sketch: sketch.to_string(),
+        battery: "cardinality",
+        failures: vec![],
+    };
+    let mut sk = new_sketch();
+    for k in &unique_keys[..checkpoint] {
+        sk.ingest(k.to_be_bytes().as_slice());
+    }
+    let t = checkpoint as f64;
+    let est = sk.estimate();
+    report.record(
+        "unique-stream accuracy",
+        est >= t * (1.0 - spec.rel_tol) && est <= t * (1.0 + spec.rel_tol),
+        format!(
+            "distinct {checkpoint}, estimated {est:.0} (±{:.0}%)",
+            spec.rel_tol * 100.0
+        ),
+    );
+
+    for k in &unique_keys[..checkpoint] {
+        sk.ingest(k.to_be_bytes().as_slice());
+    }
+    let replay = sk.estimate();
+    report.record(
+        "duplicate-replay invariance",
+        replay >= t * (1.0 - spec.rel_tol) && replay <= t * (1.0 + spec.rel_tol),
+        format!("after replaying duplicates estimated {replay:.0}"),
+    );
+    report
+}
+
+/// Quantile battery: rank-band checks across the standard q grid.
+pub fn quantile_battery<S, F>(
+    sketch: &str,
+    new_sketch: F,
+    values: &[f64],
+    spec: QuantileSpec,
+) -> BatteryReport
+where
+    S: QuantileOps,
+    F: Fn() -> S,
+{
+    let mut report = BatteryReport {
+        sketch: sketch.to_string(),
+        battery: "quantile",
+        failures: vec![],
+    };
+    let truth = NumericTruth::new(values.to_vec());
+    let mut sk = new_sketch();
+    for v in values {
+        sk.update(*v);
+    }
+    for &q in &spec.qs {
+        let (lo, hi) = truth.quantile_band(q, spec.rank_tol);
+        let est = sk.quantile(q);
+        report.record(
+            "rank band",
+            est >= lo && est <= hi,
+            format!("q={q} est {est:.3} outside [{lo:.3}, {hi:.3}]"),
+        );
+    }
+    report
+}

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -175,6 +175,23 @@ where
         sk.ingest(k);
     }
 
+    // Cold-key probe: an absent key must not carry meaningful mass. For
+    // one-sided sketches (Count-Min family) absence is exact — the estimate
+    // is structurally 0. Two-sided sketches may show signed noise, so they
+    // are exempt here; their accuracy is covered by the dense-key band.
+    if spec.one_sided {
+        let absent = K::from(i64::MIN); // sentinel outside typical key domains
+        let est_absent = sk.estimate(&absent);
+        report.record(
+            "absent key ~0",
+            est_absent >= -spec.abs_tol && est_absent <= spec.abs_tol,
+            format!(
+                "absent key estimated {est_absent} (allowed |e| <= {})",
+                spec.abs_tol
+            ),
+        );
+    }
+
     for (k_int, count) in truth.pairs() {
         if count < 25 {
             continue; // only dense keys carry statistical meaning

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,6 +8,8 @@
 // Which helpers are "used" varies by feature flags and per-suite coverage.
 #![allow(dead_code)]
 
+pub mod conformance;
+
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use std::collections::HashMap;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,236 @@
+//! Shared synthetic data generation, ground-truth tracking, and assertion
+//! helpers for the E2E sketch test suites.
+//!
+//! All generators are seeded and deterministic so failures reproduce exactly.
+//! Ground truth is tracked exactly while the stream is generated, then used
+//! to assert sketch outputs against theory-based tolerances.
+
+// Which helpers are "used" varies by feature flags and per-suite coverage.
+#![allow(dead_code)]
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Stream generators
+// ---------------------------------------------------------------------------
+
+/// `n` draws from Zipf(s) over `[0, domain)`.
+pub fn zipf_u64(n: usize, domain: usize, exponent: f64, seed: u64) -> Vec<u64> {
+    let mut cdf: Vec<f64> = (0..domain)
+        .map(|i| 1.0 / (i as f64 + 1.0).powf(exponent))
+        .collect();
+    for i in 1..cdf.len() {
+        cdf[i] += cdf[i - 1];
+    }
+    let total = cdf[domain - 1];
+    for x in cdf.iter_mut() {
+        *x /= total;
+    }
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            // Draw the variate ONCE; comparing inside the binary-search
+            // closure would use a fresh random per probe and corrupt results.
+            let u: f64 = rng.random();
+            match cdf.binary_search_by(|p| p.partial_cmp(&u).unwrap()) {
+                Ok(i) | Err(i) => (i as u64).min(domain as u64 - 1),
+            }
+        })
+        .collect()
+}
+
+/// `n` draws from Uniform{[0, domain)}.
+pub fn uniform_u64(n: usize, domain: u64, seed: u64) -> Vec<u64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n).map(|_| rng.random::<u64>() % domain).collect()
+}
+
+/// `n` iid Normal(mean, std) samples (Box-Muller).
+pub fn normal_f64(n: usize, mean: f64, std: f64, seed: u64) -> Vec<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let u1: f64 = rng.random::<f64>().max(1e-12);
+            let u2: f64 = rng.random::<f64>();
+            mean + std * (-2.0 * u1.ln()).sqrt() * (std::f64::consts::TAU * u2).cos()
+        })
+        .collect()
+}
+
+/// `n` iid Exponential(lambda) samples.
+pub fn exponential_f64(n: usize, lambda: f64, seed: u64) -> Vec<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| -rng.random::<f64>().max(1e-12).ln() / lambda)
+        .collect()
+}
+
+/// Log-uniform adversarial values: `gamma^k * (1 + frac*(gamma-1))`, mixing
+/// bucket-edge hits (frac ≈ 0) with interior values. Targets DDSketch mappings.
+pub fn log_uniform_f64(n: usize, gamma: f64, k_range: std::ops::Range<i32>, seed: u64) -> Vec<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let k = rng.random_range(k_range.start..k_range.end);
+            let frac: f64 = if rng.random::<f64>() < 0.2 {
+                1e-9
+            } else {
+                rng.random()
+            };
+            gamma.powi(k) * (1.0 + frac * (gamma - 1.0))
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Ground truth trackers
+// ---------------------------------------------------------------------------
+
+/// Exact frequency-vector ground truth for integer-keyed streams.
+#[derive(Default)]
+pub struct FreqTruth {
+    counts: HashMap<i64, i64>,
+}
+
+impl FreqTruth {
+    pub fn observe(&mut self, key: i64) {
+        *self.counts.entry(key).or_insert(0) += 1;
+    }
+
+    pub fn observe_weighted(&mut self, key: i64, weight: i64) {
+        *self.counts.entry(key).or_insert(0) += weight;
+    }
+
+    pub fn get(&self, key: i64) -> i64 {
+        self.counts.get(&key).copied().unwrap_or(0)
+    }
+
+    pub fn total(&self) -> i64 {
+        self.counts.values().sum()
+    }
+
+    pub fn distinct(&self) -> usize {
+        self.counts.len()
+    }
+
+    /// Exact F2 = Σ count².
+    pub fn f2(&self) -> f64 {
+        self.counts
+            .values()
+            .map(|c| (*c as f64) * (*c as f64))
+            .sum()
+    }
+
+    /// Exact L2 norm.
+    pub fn l2_norm(&self) -> f64 {
+        self.f2().sqrt()
+    }
+
+    /// Exact Shannon entropy of the empirical distribution.
+    pub fn entropy(&self, base_bits: bool) -> f64 {
+        let total = self.total() as f64;
+        -self
+            .counts
+            .values()
+            .filter(|c| **c > 0)
+            .map(|c| {
+                let p = *c as f64 / total;
+                p * if base_bits { p.log2() } else { p.ln() }
+            })
+            .sum::<f64>()
+    }
+
+    /// True top-k by count, descending.
+    pub fn top_k(&self, k: usize) -> Vec<(i64, i64)> {
+        let mut v: Vec<(i64, i64)> = self.counts.iter().map(|(a, b)| (*a, *b)).collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        v.truncate(k);
+        v
+    }
+
+    pub fn pairs(&self) -> Vec<(i64, i64)> {
+        self.counts.iter().map(|(a, b)| (*a, *b)).collect()
+    }
+}
+
+/// Exact order-statistic ground truth for numeric streams.
+pub struct NumericTruth {
+    sorted: Vec<f64>,
+}
+
+impl NumericTruth {
+    pub fn new(mut values: Vec<f64>) -> Self {
+        values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        Self { sorted: values }
+    }
+
+    pub fn len(&self) -> usize {
+        self.sorted.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sorted.is_empty()
+    }
+
+    pub fn min(&self) -> f64 {
+        self.sorted[0]
+    }
+
+    pub fn max(&self) -> f64 {
+        self.sorted[self.sorted.len() - 1]
+    }
+
+    /// Nearest-rank quantile: smallest value with CDF >= q (ceil convention).
+    pub fn quantile(&self, q: f64) -> f64 {
+        let n = self.sorted.len();
+        let idx = ((q.clamp(0.0, 1.0) * n as f64).ceil() as usize).clamp(1, n);
+        self.sorted[idx - 1]
+    }
+
+    /// Empirical share of observations <= x.
+    pub fn cdf(&self, x: f64) -> f64 {
+        self.sorted.iter().filter(|v| **v <= x).count() as f64 / self.sorted.len() as f64
+    }
+
+    /// Allowed value band for a quantile query with rank tolerance `tol`.
+    pub fn quantile_band(&self, q: f64, tol: f64) -> (f64, f64) {
+        (
+            self.quantile((q - tol).clamp(0.0, 1.0)),
+            self.quantile((q + tol).clamp(0.0, 1.0)),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers (panic with expected-vs-actual context)
+// ---------------------------------------------------------------------------
+
+pub fn assert_rel_close(actual: f64, expected: f64, rel_tol: f64, label: &str) {
+    let rel = if expected == 0.0 {
+        actual.abs()
+    } else {
+        ((actual - expected) / expected).abs()
+    };
+    assert!(
+        rel <= rel_tol,
+        "{label}: expected ~{expected:.6}, got {actual:.6} (rel err {rel:.5} > tol {rel_tol})"
+    );
+}
+
+pub fn assert_between(actual: f64, lo: f64, hi: f64, label: &str) {
+    assert!(
+        actual >= lo && actual <= hi,
+        "{label}: got {actual:.6}, outside allowed band [{lo:.6}, {hi:.6}]"
+    );
+}
+
+/// Quantile query must land inside the truth's rank-tolerance value band.
+pub fn assert_in_rank_band(est: f64, truth: &NumericTruth, q: f64, tol: f64, label: &str) {
+    let (lo, hi) = truth.quantile_band(q, tol);
+    assert!(
+        est >= lo && est <= hi,
+        "{label}: q={q} estimate {est:.4} outside rank band [{lo:.4}, {hi:.4}]"
+    );
+}

--- a/tests/conformance_kit.rs
+++ b/tests/conformance_kit.rs
@@ -1,0 +1,326 @@
+//! Reference wiring for the conformance kit: established sketches run
+//! through the same standard batteries every new sketch must pass. Copy an
+//! adapter from here when onboarding a new sketch (see tests/README.md).
+
+mod common;
+
+use common::conformance::{
+    self, CardinalityOps, CardinalitySpec, FrequencyOps, MergeOps, QuantileOps, QuantileSpec,
+    SignedFrequencyOps,
+};
+use common::{FreqTruth, zipf_u64};
+
+use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketch as PortableDds;
+use asap_sketchlib::message_pack_format::portable::hll::{HllSketch, HllVariant};
+use asap_sketchlib::{
+    CountMin, DataInput, FastPath, HyperLogLog, HyperLogLogHIP, KLL, KLLDynamic, RegularPath,
+    UnivMonQ, Vector2D,
+};
+
+// ---------------------------------------------------------------------------
+// Adapters: one small impl block per sketch is all it takes to onboard.
+// ---------------------------------------------------------------------------
+
+struct CountMinAdapter(CountMin<Vector2D<i64>, FastPath>);
+
+impl FrequencyOps<i64> for CountMinAdapter {
+    fn ingest(&mut self, key: &i64) {
+        self.0.insert(&DataInput::I64(*key));
+    }
+    fn estimate(&self, key: &i64) -> f64 {
+        self.0.estimate(&DataInput::I64(*key)) as f64
+    }
+}
+
+impl MergeOps for CountMinAdapter {
+    fn merge_from(&mut self, other: &Self) {
+        self.0.merge(&other.0);
+    }
+}
+
+struct CountSketchAdapter(asap_sketchlib::Count<Vector2D<i64>, RegularPath>);
+
+impl FrequencyOps<i64> for CountSketchAdapter {
+    fn ingest(&mut self, key: &i64) {
+        self.0.insert(&DataInput::I64(*key));
+    }
+    fn estimate(&self, key: &i64) -> f64 {
+        self.0.estimate(&DataInput::I64(*key))
+    }
+}
+
+impl SignedFrequencyOps<i64> for CountSketchAdapter {
+    fn ingest_weighted(&mut self, key: &i64, weight: i64) {
+        self.0.insert_many(&DataInput::I64(*key), weight);
+    }
+}
+
+impl MergeOps for CountSketchAdapter {
+    fn merge_from(&mut self, other: &Self) {
+        self.0.merge(&other.0);
+    }
+}
+
+struct HllClassicAdapter(HyperLogLog<asap_sketchlib::Classic>);
+
+impl CardinalityOps for HllClassicAdapter {
+    fn ingest(&mut self, key: &[u8]) {
+        self.0
+            .insert(&DataInput::U64(u64::from_be_bytes(key.try_into().unwrap())));
+    }
+    fn estimate(&self) -> f64 {
+        self.0.estimate() as f64
+    }
+}
+
+struct HllErtlAdapter(HyperLogLog<asap_sketchlib::ErtlMLE>);
+
+impl CardinalityOps for HllErtlAdapter {
+    fn ingest(&mut self, key: &[u8]) {
+        self.0
+            .insert(&DataInput::U64(u64::from_be_bytes(key.try_into().unwrap())));
+    }
+    fn estimate(&self) -> f64 {
+        self.0.estimate() as f64
+    }
+}
+
+struct HllHipAdapter(HyperLogLogHIP);
+
+impl CardinalityOps for HllHipAdapter {
+    fn ingest(&mut self, key: &[u8]) {
+        self.0
+            .insert(&DataInput::U64(u64::from_be_bytes(key.try_into().unwrap())));
+    }
+    fn estimate(&self) -> f64 {
+        self.0.estimate() as f64
+    }
+}
+
+struct PortableHllAdapter(HllSketch);
+
+impl CardinalityOps for PortableHllAdapter {
+    fn ingest(&mut self, key: &[u8]) {
+        self.0.update(key);
+    }
+    fn estimate(&self) -> f64 {
+        self.0.estimate()
+    }
+}
+
+struct KllAdapter(KLL);
+
+impl QuantileOps for KllAdapter {
+    fn update(&mut self, value: f64) {
+        KLL::update(&mut self.0, &value);
+    }
+    fn quantile(&self, q: f64) -> f64 {
+        self.0.quantile(q)
+    }
+}
+
+struct KllDynamicAdapter(KLLDynamic<f64>);
+
+impl QuantileOps for KllDynamicAdapter {
+    fn update(&mut self, value: f64) {
+        KLLDynamic::update(&mut self.0, &value);
+    }
+    fn quantile(&self, q: f64) -> f64 {
+        self.0.quantile(q)
+    }
+}
+
+struct PortableDdsAdapter(PortableDds);
+
+impl QuantileOps for PortableDdsAdapter {
+    fn update(&mut self, value: f64) {
+        self.0.update(value);
+    }
+    fn quantile(&self, q: f64) -> f64 {
+        self.0.quantile(q).expect("non-empty sketch")
+    }
+}
+
+struct UnivMonQAdapter(UnivMonQ);
+
+impl QuantileOps for UnivMonQAdapter {
+    fn update(&mut self, value: f64) {
+        UnivMonQ::update(&mut self.0, &value);
+    }
+    fn quantile(&self, q: f64) -> f64 {
+        self.0.quantile(q).expect("ordered samples enabled")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Battery runs
+// ---------------------------------------------------------------------------
+
+fn zipf_stream() -> Vec<i64> {
+    zipf_u64(60_000, 2048, 1.1, 9001)
+        .iter()
+        .map(|v| *v as i64)
+        .collect()
+}
+
+fn stream_truth(stream: &[i64]) -> FreqTruth {
+    let mut truth = FreqTruth::default();
+    for k in stream {
+        truth.observe(*k);
+    }
+    truth
+}
+
+#[test]
+fn countmin_passes_frequency_and_merge_conformance() {
+    let stream = zipf_stream();
+    let truth = stream_truth(&stream);
+    let spec = conformance::FrequencySpec {
+        one_sided: true,
+        rel_tol: 0.01,
+        abs_tol: 4.0,
+    };
+
+    conformance::frequency_battery(
+        "CountMin<FastPath>",
+        || {
+            CountMinAdapter(CountMin::<Vector2D<i64>, FastPath>::with_dimensions(
+                4, 4096,
+            ))
+        },
+        &stream,
+        &truth,
+        spec,
+    )
+    .assert_ok();
+
+    conformance::merge_equivalence_battery(
+        "CountMin<FastPath>",
+        || {
+            CountMinAdapter(CountMin::<Vector2D<i64>, FastPath>::with_dimensions(
+                4, 4096,
+            ))
+        },
+        &stream,
+        spec,
+    )
+    .assert_ok();
+}
+
+#[test]
+fn countsketch_passes_signed_frequency_conformance() {
+    let stream = zipf_stream();
+    let truth = stream_truth(&stream);
+    let spec = conformance::FrequencySpec {
+        one_sided: false,
+        rel_tol: 0.06,
+        abs_tol: 25.0,
+    };
+    let make = || {
+        CountSketchAdapter(
+            asap_sketchlib::Count::<Vector2D<i64>, RegularPath>::with_dimensions(5, 4096),
+        )
+    };
+
+    conformance::frequency_battery("Count<Regular>", make, &stream, &truth, spec).assert_ok();
+    conformance::turnstile_battery("Count<Regular>", make, 42i64).assert_ok();
+    conformance::merge_equivalence_battery("Count<Regular>", make, &stream, spec).assert_ok();
+}
+
+#[test]
+fn hll_variants_pass_cardinality_conformance() {
+    // Distinct u64 keys; encodings are byte-identical for every adapter.
+    let unique: Vec<u64> = (0..100_000u64)
+        .map(|i| i.wrapping_mul(0x9E37_79B9_7F4A_7C15))
+        .collect();
+    let spec = CardinalitySpec { rel_tol: 0.03 };
+
+    conformance::cardinality_battery(
+        "HyperLogLog<Classic>",
+        || HllClassicAdapter(HyperLogLog::<asap_sketchlib::Classic>::new()),
+        &unique,
+        100_000,
+        spec,
+    )
+    .assert_ok();
+
+    conformance::cardinality_battery(
+        "HyperLogLog<ErtlMLE>",
+        || HllErtlAdapter(HyperLogLog::<asap_sketchlib::ErtlMLE>::new()),
+        &unique,
+        100_000,
+        spec,
+    )
+    .assert_ok();
+
+    conformance::cardinality_battery(
+        "HyperLogLogHIP",
+        || HllHipAdapter(HyperLogLogHIP::new()),
+        &unique,
+        100_000,
+        spec,
+    )
+    .assert_ok();
+
+    conformance::cardinality_battery(
+        "portable HllSketch<p14>",
+        || PortableHllAdapter(HllSketch::new(HllVariant::Regular, 14)),
+        &unique,
+        100_000,
+        spec,
+    )
+    .assert_ok();
+}
+
+#[test]
+fn kll_family_passes_quantile_conformance() {
+    let values: Vec<f64> = common::normal_f64(40_000, 500.0, 80.0, 7001)
+        .into_iter()
+        .filter(|v| *v > 0.0)
+        .collect();
+
+    conformance::quantile_battery(
+        "KLL",
+        || KllAdapter(KLL::init_kll(200)),
+        &values,
+        QuantileSpec::default(),
+    )
+    .assert_ok();
+
+    conformance::quantile_battery(
+        "KLLDynamic",
+        || KllDynamicAdapter(KLLDynamic::<f64>::init_kll(200)),
+        &values,
+        QuantileSpec::default(),
+    )
+    .assert_ok();
+
+    conformance::quantile_battery(
+        "PortableDds",
+        || PortableDdsAdapter(PortableDds::new(0.01)),
+        &values,
+        QuantileSpec {
+            rank_tol: 0.02,
+            ..QuantileSpec::default()
+        },
+    )
+    .assert_ok();
+}
+
+#[test]
+fn univmonq_passes_quantile_conformance() {
+    let values: Vec<f64> = common::uniform_u64(30_000, 50_000, 7002)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    conformance::quantile_battery(
+        "UnivMonQ",
+        || UnivMonQAdapter(UnivMonQ::new(Default::default()).expect("config")),
+        &values,
+        QuantileSpec {
+            rank_tol: 0.04,
+            ..QuantileSpec::default()
+        },
+    )
+    .assert_ok();
+}

--- a/tests/e2e_cardinality.rs
+++ b/tests/e2e_cardinality.rs
@@ -1,0 +1,153 @@
+//! E2E cardinality pipelines on synthetic unique streams: core HLL variants
+//! (+ shard merge), the portable wire HLL, SetAggregator exactness, and a
+//! mixed HashSketchEnsemble layer.
+
+mod common;
+
+use common::{assert_between, uniform_u64};
+
+use asap_sketchlib::message_pack_format::portable::hll::{HllSketch, HllVariant};
+use asap_sketchlib::{
+    CountMin, DataInput, EnsembleSketch, FastPath, HashSketchEnsemble, HyperLogLog, HyperLogLogHIP,
+    SetAggregator, Vector2D,
+};
+
+#[test]
+fn hll_variants_checkpoints_and_shard_merge() {
+    let checkpoints = [10_000u64, 100_000, 1_000_000];
+    let mut classic = HyperLogLog::<asap_sketchlib::Classic>::new();
+    let mut ertl = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
+    let mut hip = HyperLogLogHIP::new();
+    // Even/odd shard split for the merge leg of the test.
+    let mut classic_even = HyperLogLog::<asap_sketchlib::Classic>::new();
+    let mut classic_odd = HyperLogLog::<asap_sketchlib::Classic>::new();
+
+    let mut seen = 0u64;
+    for &target in &checkpoints {
+        while seen < target {
+            let d = DataInput::U64(seen);
+            classic.insert(&d);
+            ertl.insert(&d);
+            hip.insert(&d);
+            if seen % 2 == 0 {
+                classic_even.insert(&d);
+            } else {
+                classic_odd.insert(&d);
+            }
+            seen += 1;
+        }
+        let t = target as f64;
+        for (label, est) in [
+            ("Classic", classic.estimate() as f64),
+            ("ErtlMLE", ertl.estimate() as f64),
+            ("HIP", hip.estimate() as f64),
+        ] {
+            assert_between(est, t * 0.98, t * 1.02, &format!("{label} @ {target}"));
+        }
+    }
+
+    classic_even.merge(&classic_odd);
+    let merged = classic_even.estimate() as f64;
+    assert_between(
+        merged,
+        1_000_000.0 * 0.98,
+        1_000_000.0 * 1.02,
+        "Classic shard-merge @ 1e6",
+    );
+}
+
+#[test]
+fn portable_hll_precisions_over_byte_keys() {
+    for (precision, tol) in [(12u32, 0.03f64), (14u32, 0.02f64)] {
+        let mut hll = HllSketch::new(HllVariant::Regular, precision);
+        let stream = uniform_u64(200_000, u64::MAX / 4, 2001 + precision as u64);
+        let mut truth = std::collections::HashSet::new();
+        for k in stream {
+            truth.insert(k);
+            hll.update(k.to_be_bytes().as_slice());
+        }
+        let t = truth.len() as f64;
+        let est = hll.estimate();
+        assert_between(
+            est,
+            t * (1.0 - tol),
+            t * (1.0 + tol),
+            &format!("portable HLL p{precision}"),
+        );
+
+        // Merge a second sketch over the SAME identities (byte-identical
+        // encodings): registers max, so distinct count must not change.
+        let mut other = HllSketch::new(HllVariant::Regular, precision);
+        for k in &truth {
+            other.update((*k).to_be_bytes().as_slice());
+        }
+        hll.merge(&other).expect("merge");
+        let rem = hll.estimate();
+        assert_between(
+            rem,
+            t * (1.0 - tol),
+            t * (1.0 + tol),
+            &format!("portable HLL p{precision} after duplicate-merge"),
+        );
+    }
+}
+
+#[test]
+fn set_aggregator_union_is_exact() {
+    let mut agg = SetAggregator::new();
+    let mut expected = std::collections::HashSet::new();
+    let stream = uniform_u64(20_000, 500, 2002);
+    for k in stream {
+        let s = format!("member-{k}");
+        expected.insert(s.clone());
+        agg.update(&s);
+    }
+    let mut other = SetAggregator::new();
+    for k in ["extra-a", "extra-b"] {
+        expected.insert((*k).to_string());
+        other.update(k);
+    }
+    agg.merge(&other).expect("merge");
+    assert_eq!(
+        agg.values.len(),
+        expected.len(),
+        "SetAggregator cardinality must be exact"
+    );
+    for k in &expected {
+        assert!(agg.values.contains(k), "missing member {k}");
+    }
+}
+
+#[test]
+fn ensemble_layer_mixed_cms_and_hll() {
+    let cms = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 4096);
+    let ertl = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
+    let mut ens: HashSketchEnsemble =
+        HashSketchEnsemble::new(vec![EnsembleSketch::from(cms), EnsembleSketch::from(ertl)])
+            .expect("ensemble");
+
+    // Dominant head: 6000 copies of key 0; tail: 15k uniform over 3000 keys.
+    let mut distinct = std::collections::HashSet::new();
+    let mut truth_hot0 = 0i64;
+    for k in common::uniform_u64(15_000, 3000, 2103) {
+        ens.insert(&DataInput::I64(k as i64));
+        distinct.insert(k as i64);
+    }
+    for _ in 0..6000 {
+        ens.insert(&DataInput::I64(0));
+        distinct.insert(0);
+        truth_hot0 += 1;
+    }
+
+    // CMS cell: one-sided frequency estimate for the dominant key.
+    let cm_est = ens.estimate(0, &DataInput::I64(0)).expect("cms estimate");
+    assert!(
+        cm_est >= truth_hot0 as f64 && cm_est <= truth_hot0 as f64 * 3.0,
+        "ensemble CMS estimate {cm_est} vs true {truth_hot0} (must be one-sided)"
+    );
+
+    // HLL cell: shared-hash cardinality within 3%.
+    let card = ens.cardinality(1).expect("hll cardinality");
+    let t = distinct.len() as f64;
+    assert_between(card, t * 0.97, t * 1.03, "ensemble HLL cardinality");
+}

--- a/tests/e2e_cardinality.rs
+++ b/tests/e2e_cardinality.rs
@@ -139,7 +139,10 @@ fn ensemble_layer_mixed_cms_and_hll() {
         truth_hot0 += 1;
     }
 
-    // CMS cell: one-sided frequency estimate for the dominant key.
+    // CMS cell: one-sided frequency estimate for the dominant key. Upper
+    // slack is generous (3x) because the shared-hash fan-out across the
+    // ensemble's 15k-tail stream can collide into key 0's cells; the lower
+    // bound carries the real one-sided guarantee.
     let cm_est = ens.estimate(0, &DataInput::I64(0)).expect("cms estimate");
     assert!(
         cm_est >= truth_hot0 as f64 && cm_est <= truth_hot0 as f64 * 3.0,

--- a/tests/e2e_experimental.rs
+++ b/tests/e2e_experimental.rs
@@ -1,0 +1,188 @@
+//! E2E suites for feature-gated (`experimental`) sketches: KMV cardinality,
+//! UniformSampling, CocoSketch over-attribution bounds, Elastic heavy-flow
+//! tracking, and the EHUnivOptimized exact map tier.
+//!
+//! Compiled only under `--features experimental`.
+
+#![cfg(feature = "experimental")]
+
+mod common;
+
+use common::{assert_between, uniform_u64};
+
+use asap_sketchlib::{Coco, DataInput, EHUnivOptimized, Elastic, KMV, UniformSampling};
+use std::collections::HashMap;
+
+#[test]
+fn kmv_cardinality_and_shard_merge() {
+    let mut a = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
+    let mut b = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
+    let mut full = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
+
+    let stream = uniform_u64(60_000, 500_000, 5001);
+    let truth: std::collections::HashSet<u64> = stream.iter().copied().collect();
+    let t = truth.len() as f64;
+
+    for (i, k) in stream.iter().enumerate() {
+        full.insert(&DataInput::U64(*k));
+        if i % 2 == 0 {
+            a.insert(&DataInput::U64(*k));
+        } else {
+            b.insert(&DataInput::U64(*k));
+        }
+    }
+
+    // KMV standard error ~ 1/sqrt(k-1); allow 4x that for single-seed runs.
+    assert_between(full.estimate(), t * 0.96, t * 1.04, "KMV cardinality");
+
+    a.merge(&mut b);
+    let merged = a.estimate();
+    assert_between(merged, t * 0.96, t * 1.04, "KMV after shard merge");
+}
+
+#[test]
+fn uniform_sampling_rate_and_merge() {
+    let rate = 0.1f64;
+    let mut us = UniformSampling::with_seed(rate, 42);
+    let stream: Vec<f64> = uniform_u64(10_000, u32::MAX as u64, 5002)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    for v in &stream {
+        us.update(*v);
+    }
+
+    assert_eq!(us.total_seen(), 10_000, "total_seen must count every input");
+    // target_size uses ceil, so retained is around n*rate within Poisson slack.
+    assert_between(us.len() as f64, 850.0, 1150.0, "retained sample count");
+    for s in us.samples().iter() {
+        assert!(
+            stream.contains(s),
+            "sample {s} not drawn from the input stream"
+        );
+    }
+
+    // Merging two same-rate sketches unions the samples and sums totals.
+    let mut other = UniformSampling::with_seed(rate, 43);
+    let other_stream: Vec<f64> = uniform_u64(5_000, u32::MAX as u64, 5003)
+        .into_iter()
+        .map(|v| v as f64 + 0.5)
+        .collect();
+    for v in &other_stream {
+        other.update(*v);
+    }
+    us.merge(&other).expect("same-rate merge");
+    assert_eq!(us.total_seen(), 15_000, "merge must sum totals");
+    assert!(
+        us.len() <= 1500 + 160,
+        "retained samples bounded by combined budget"
+    );
+}
+
+#[test]
+fn coco_over_attribution_bounds_with_disjoint_prefixes() {
+    // Table sized well above distinct-key count keeps eviction loss bounded;
+    // Coco remains an approximate estimator either way.
+    let mut coco = Coco::<asap_sketchlib::DefaultXxHasher>::init_with_size(256, 2);
+    let mut truth: HashMap<String, u64> = HashMap::new();
+    let mut total = 0u64;
+    for i in 0..3000u64 {
+        let key = format!("aaa{}", i % 50);
+        coco.insert(&key, 7);
+        *truth.entry("aaa".to_string()).or_insert(0) += 7;
+        total += 7;
+        let _ = i;
+    }
+    for i in 0..2000u64 {
+        let key = format!("zzz{}", i % 30);
+        coco.insert(&key, 3);
+        *truth.entry("zzz".to_string()).or_insert(0) += 3;
+        total += 3;
+    }
+
+    // Substring matching: "aaa" only matches aaa* buckets, never zzz*.
+    let got_aaa = coco.estimate("aaa");
+    let true_aaa = truth["aaa"];
+    assert!(
+        got_aaa >= true_aaa * 3 / 4 && got_aaa <= total,
+        "coco 'aaa' estimate {got_aaa} outside [{}, {total}]",
+        true_aaa * 3 / 4
+    );
+
+    // Exact-match UDF pins down the precise family sum.
+    let exact =
+        coco.estimate_with_udf("zzz", |full: &str, partial: &str| full.starts_with(partial));
+    let true_zzz = truth["zzz"];
+    assert!(
+        exact >= true_zzz * 3 / 4 && exact <= total,
+        "coco 'zzz' estimate {exact} outside [{}, {total}]",
+        true_zzz * 3 / 4
+    );
+}
+
+#[test]
+fn elastic_tracks_hot_flows() {
+    let mut sk = Elastic::<asap_sketchlib::DefaultXxHasher>::init_with_length(64);
+
+    // Three hot flows amid background chatter.
+    let mut expected: HashMap<String, i64> = HashMap::new();
+    for i in 0..12_000u64 {
+        let id = match i % 10 {
+            0 => "hot-alpha".to_string(),
+            1 => "hot-beta".to_string(),
+            2 => "hot-gamma".to_string(),
+            _ => format!("bg{}", i % 977),
+        };
+        sk.insert(id.clone());
+        *expected.entry(id).or_insert(0) += 1;
+    }
+
+    for hot in ["hot-alpha", "hot-beta", "hot-gamma"] {
+        let c = sk.query(hot.to_string()) as i64;
+        let t = expected[hot];
+        assert_between(
+            c as f64,
+            t as f64 * 0.80,
+            t as f64 * 1.20,
+            &format!("elastic flow {hot}"),
+        );
+    }
+}
+
+#[test]
+fn eh_univ_optimized_map_tier_exact_windows() {
+    let window = 100u64;
+    let mut eh = EHUnivOptimized::with_defaults(2, window);
+
+    for t in 0..150u64 {
+        eh.update(t, &DataInput::U32((t % 10) as u32), (t as i64 % 3) + 1);
+    }
+
+    // Interval fully inside the retained range: map tier answers EXACTLY.
+    match eh.query_interval(120, 149) {
+        Some(asap_sketchlib::EHUnivQueryResult::Map {
+            freq_map,
+            total_count,
+        }) => {
+            let expect_total: usize = (120..=149u64).map(|t| (t as i64 % 3 + 1) as usize).sum();
+            assert_eq!(total_count, expect_total, "interval total");
+            let mut expect_freq: HashMap<u32, i64> = HashMap::new();
+            for t in 120..=149 {
+                *expect_freq.entry((t % 10) as u32).or_insert(0) += (t as i64 % 3) + 1;
+            }
+            assert_eq!(
+                expect_freq.len(),
+                freq_map.len(),
+                "distinct keys in interval"
+            );
+            for (k, v) in expect_freq {
+                assert_eq!(
+                    freq_map.get(&asap_sketchlib::HeapItem::U32(k)),
+                    Some(&v),
+                    "interval count for key {k}"
+                );
+            }
+        }
+        _ => panic!("expected exact Map-tier result"),
+    }
+}

--- a/tests/e2e_frameworks.rs
+++ b/tests/e2e_frameworks.rs
@@ -1,0 +1,374 @@
+//! E2E composition-layer pipelines: Hydra multi-label queries across counter
+//! types, MultiHeadHydra routing, UnivMon/UnivMonPyramid weighted metrics,
+//! Nitro sampling, ExponentialHistogram sliding windows, and TumblingWindow
+//! over FoldCMS.
+
+mod common;
+
+use common::{assert_between, zipf_u64};
+
+use asap_sketchlib::input::{HydraCounter, HydraQuery};
+use asap_sketchlib::sketch_framework::hydra::MultiHeadHydra;
+use asap_sketchlib::{
+    CountMin, DataInput, EHSketchList, ExponentialHistogram, FoldCMS, FoldCMSConfig, Hydra, KLL,
+    TumblingWindow, UnivMon, UnivMonPyramid, Vector2D,
+};
+
+// ------------------------------------------------------------------- Hydra
+
+#[test]
+fn hydra_cm_multilabel_frequencies() {
+    // Sparse dims keep full-key counts collision-free => near-exact.
+    let mut hydra = Hydra::with_schema(
+        4,
+        4096,
+        ["region", "user"],
+        HydraCounter::CM(
+            CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(4, 4096),
+        ),
+    )
+    .expect("schema");
+
+    let regions = ["eu", "us"];
+    let users = ["alice", "bob"];
+    for r in regions {
+        for u in users {
+            for _ in 0..25 {
+                hydra
+                    .update(&[r, u], &DataInput::Str("event"), None)
+                    .expect("update");
+            }
+        }
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+    // Wildcards are expressed with None at the trailing positions; truncated
+    // slices are an arity error. Generalized (wildcard) keys accumulate
+    // sibling traffic through the fan-out, so they get one-sided slack.
+    for (key, expected, exact) in [
+        (vec![Some("eu"), Some("alice")], 25i64, true),
+        (vec![Some("us"), Some("bob")], 25, true),
+        (vec![Some("eu"), None], 50, false),
+        (vec![None, Some("bob")], 50, false),
+        (vec![Some("apac"), None], 0, false),
+    ] {
+        let v = hydra
+            .query_key(&key, &HydraQuery::Frequency(DataInput::Str("event")))
+            .expect("CM frequency query");
+        let ok = if exact {
+            (v - expected as f64).abs() <= 2.0
+        } else {
+            v >= expected as f64 && v <= expected as f64 * 1.2 + 1.0
+        };
+        if !ok {
+            failures.push(format!("{key:?} expected {expected} exact={exact} got {v}"));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "hydra CM frequencies off: {failures:?}"
+    );
+}
+
+#[test]
+fn hydra_kll_head_quantile_and_cdf() {
+    let mut hydra = Hydra::with_schema(4, 512, ["shard"], HydraCounter::KLL(KLL::init_kll(200)))
+        .expect("schema");
+    let values: Vec<f64> = common::uniform_u64(20_000, 1_000_000, 4001)
+        .iter()
+        .map(|v| *v as f64)
+        .collect();
+    let truth = common::NumericTruth::new(values.clone());
+    for v in &values {
+        hydra
+            .update(&["s0"], &DataInput::F64(*v), None)
+            .expect("update");
+    }
+
+    let med = hydra
+        .query_key(&[Some("s0")], &HydraQuery::Quantile(0.5))
+        .expect("quantile");
+    assert_between(
+        med,
+        truth.quantile(0.47),
+        truth.quantile(0.53),
+        "Hydra KLL median",
+    );
+
+    // Cdf(x) returns the empirical fraction <= x.
+    let x = 500_000.0;
+    let cdf = hydra
+        .query_key(&[Some("s0")], &HydraQuery::Cdf(x))
+        .expect("cdf");
+    assert_between(
+        cdf,
+        truth.cdf(x) - 0.03,
+        truth.cdf(x) + 0.03,
+        "Hydra KLL CDF",
+    );
+
+    // Unseen population reports zero rather than erroring.
+    let none = hydra
+        .query_key(&[Some("ghost")], &HydraQuery::Cdf(x))
+        .expect("empty cell");
+    assert_eq!(none, 0.0, "empty subpopulation must be 0");
+}
+
+#[test]
+fn hydra_hll_head_cardinality() {
+    let mut hydra = Hydra::with_schema(4, 512, ["tenant"], HydraCounter::HLL(Default::default()))
+        .expect("schema");
+    for t in ["t1", "t2"] {
+        for i in 0..500u32 {
+            hydra
+                .update(&[t], &DataInput::U32(i), None)
+                .expect("update");
+        }
+    }
+    for t in ["t1", "t2"] {
+        let card = hydra
+            .query_key(&[Some(t)], &HydraQuery::Cardinality)
+            .expect("card");
+        assert_between(card, 450.0, 550.0, &format!("tenant {t} cardinality"));
+    }
+}
+
+#[test]
+fn multihead_hydra_routes_values_to_named_heads() {
+    let heads = vec![
+        ("events".to_string(), HydraCounter::CM(Default::default())),
+        ("latency".to_string(), HydraCounter::KLL(KLL::init_kll(200))),
+    ];
+    let mut mh = MultiHeadHydra::with_schema(4, 1024, ["svc"], heads).expect("schema");
+
+    let latencies: Vec<f64> = common::uniform_u64(2000, 500, 4002)
+        .iter()
+        .map(|v| *v as f64)
+        .collect();
+    let latency_truth = common::NumericTruth::new(latencies.clone());
+    for v in &latencies {
+        mh.update(
+            &["svc-a"],
+            &[
+                (&DataInput::F64(*v), &["latency"]),
+                (&DataInput::Str("hit"), &["events"]),
+            ],
+            None,
+        )
+        .expect("update");
+    }
+
+    let freq = mh
+        .query_key(
+            &[Some("svc-a")],
+            "events",
+            &HydraQuery::Frequency(DataInput::Str("hit")),
+        )
+        .expect("freq");
+    assert_between(freq, 1998.0, 2002.0, "events head frequency");
+
+    let med = mh
+        .query_key(&[Some("svc-a")], "latency", &HydraQuery::Quantile(0.5))
+        .expect("med");
+    assert_between(
+        med,
+        latency_truth.quantile(0.46),
+        latency_truth.quantile(0.54),
+        "latency head median",
+    );
+
+    // Unknown head name is an error, not a silent zero.
+    assert!(
+        mh.query_key(&[Some("svc-a")], "nope", &HydraQuery::Cardinality)
+            .is_err()
+    );
+}
+
+// ----------------------------------------------------------------- UnivMon
+
+#[test]
+fn univmon_weighted_metrics_and_fast_insert_parity() {
+    let build = || UnivMon::init_univmon(32, 5, 2048, 8);
+    let mut um = build();
+    let mut fast = build();
+    let mut truth = common::FreqTruth::default();
+
+    let stream = zipf_u64(20_000, 1000, 1.2, 4003);
+    for (i, k) in stream.iter().enumerate() {
+        let w = 1 + (i % 7) as i64;
+        um.insert(&DataInput::U32(*k as u32), w);
+        fast.fast_insert(&DataInput::U32(*k as u32), w);
+        truth.observe_weighted(*k as i64, w);
+    }
+
+    let total = truth.total();
+    assert_eq!(um.calc_l1(), total as f64, "L1 must be exact");
+    assert_eq!(fast.calc_l1(), total as f64, "fast-insert L1 must be exact");
+
+    let l2_truth = truth.l2_norm();
+    assert_between(um.calc_l2(), l2_truth * 0.95, l2_truth * 1.05, "L2");
+    let h_truth = truth.entropy(true);
+    // UnivMon entropy is a ~10%-accurate estimator (repo tests allow 15%).
+    assert_between(
+        um.calc_entropy(),
+        h_truth * 0.88,
+        h_truth * 1.12,
+        "entropy (bits)",
+    );
+    let card_truth = truth.distinct() as f64;
+    assert_between(
+        um.calc_card(),
+        card_truth * 0.94,
+        card_truth * 1.06,
+        "cardinality",
+    );
+
+    // fast_insert path tracks the standard estimator within loose bounds.
+    assert_between(
+        fast.calc_l2(),
+        l2_truth * 0.85,
+        l2_truth * 1.15,
+        "fast L2 parity",
+    );
+}
+
+#[test]
+fn univmon_pyramid_weighted_metrics() {
+    let mut up = UnivMonPyramid::with_defaults();
+    let mut truth = common::FreqTruth::default();
+    let stream = zipf_u64(15_000, 800, 1.3, 4004);
+    for (i, k) in stream.iter().enumerate() {
+        let w = 1 + (i % 3) as i64;
+        up.insert(&DataInput::U32(*k as u32), w);
+        truth.observe_weighted(*k as i64, w);
+    }
+    assert_eq!(
+        up.calc_l1(),
+        truth.total() as f64,
+        "pyramid L1 must be exact"
+    );
+    let l2_truth = truth.l2_norm();
+    assert_between(up.calc_l2(), l2_truth * 0.85, l2_truth * 1.15, "pyramid L2");
+    let card_truth = truth.distinct() as f64;
+    assert_between(
+        up.calc_card(),
+        card_truth * 0.80,
+        card_truth * 1.20,
+        "pyramid cardinality",
+    );
+}
+
+// ------------------------------------------------------------------- Nitro
+
+#[test]
+fn nitro_unbiased_across_rates_cm_and_cs_targets() {
+    let n = 100_000i64;
+    for rate in [1.0f64, 0.5] {
+        let mut cm_batch = asap_sketchlib::NitroBatch::with_target(
+            rate,
+            CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(5, 2048),
+        );
+        cm_batch.insert(&vec![42i64; n as usize]);
+        let est = cm_batch.estimate_median(&DataInput::I64(42));
+        assert_between(
+            est,
+            n as f64 * 0.95,
+            n as f64 * 1.05,
+            &format!("Nitro CM rate={rate}"),
+        );
+
+        let mut cs_batch = asap_sketchlib::NitroBatch::with_target(
+            rate,
+            asap_sketchlib::Count::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(
+                5, 2048,
+            ),
+        );
+        cs_batch.insert(&vec![42i64; n as usize]);
+        let cs_est = cs_batch.estimate_median(&DataInput::I64(42));
+        assert_between(
+            cs_est,
+            n as f64 * 0.90,
+            n as f64 * 1.10,
+            &format!("Nitro CS rate={rate}"),
+        );
+    }
+}
+
+// -------------------------------------------------- ExponentialHistogram
+
+#[test]
+fn exponential_histogram_sliding_window_counts() {
+    // Single event type: merged-bucket count is additive and one-sided.
+    let window = 100u64;
+    let eh_type = EHSketchList::CM(
+        CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(3, 2048),
+    );
+    let mut eh = ExponentialHistogram::new(8, window, eh_type);
+
+    for t in 0..500u64 {
+        if t % 3 == 0 {
+            eh.update(t, &DataInput::Str("req"));
+        }
+    }
+    // Multiples of 3 in [400, 499]: 402..498 -> 33 events. Bucket-boundary
+    // snapping makes interval merges approximate in both directions; allow
+    // granularity slack around the exact figure.
+    let merged = eh.query_interval_merge(400, 499).expect("interval covered");
+    let est = merged.query(&DataInput::Str("req")).expect("CM query");
+    assert!(
+        (26.0..=40.0).contains(&est),
+        "window count {est} outside [26, 40]"
+    );
+
+    // Window expiry retains only recent buckets (window=100): the retained
+    // span must be covered, anything past the observed max must not be.
+    let retained_min = eh.get_min_time().expect("buckets present");
+    let retained_max = eh.get_max_time().expect("buckets present");
+    assert_eq!(retained_max, 498);
+    assert!(eh.cover(retained_min, 498), "must cover retained span");
+    assert!(!eh.cover(500, 600), "cannot cover beyond observed span");
+}
+
+// ------------------------------------------------------------ TumblingWindow
+
+#[test]
+fn tumbling_foldcms_weighted_windows_exact_counts() {
+    let cfg = FoldCMSConfig {
+        rows: 3,
+        full_cols: 2048,
+        fold_level: 0,
+        top_k: 32,
+    };
+    let mut tw: TumblingWindow<FoldCMS> = TumblingWindow::new(10, 16, cfg, 4);
+
+    for t in 0..35u64 {
+        tw.insert(t, &DataInput::Str("A"), 2);
+        tw.insert(t, &DataInput::Str("B"), 1);
+    }
+    assert_eq!(
+        tw.closed_count(),
+        3,
+        "windows [0,10) [10,20) [20,30) closed at t=34"
+    );
+
+    let all = tw.query_all();
+    assert_eq!(all.query(&DataInput::Str("A")), 70);
+    assert_eq!(all.query(&DataInput::Str("B")), 35);
+
+    // Last two windows + active cover t in [10,35): 25 inserts.
+    let recent = tw.query_recent(2);
+    assert_eq!(recent.query(&DataInput::Str("A")), 50);
+    assert_eq!(recent.query(&DataInput::Str("B")), 25);
+
+    // flush() closes the active window unconditionally (even if partially
+    // filled or empty), so [30,40) and an empty [40,50) both land in closed.
+    tw.flush(40);
+    assert_eq!(
+        tw.closed_count(),
+        5,
+        "flush closes active + opens/closes empty"
+    );
+    let post = tw.query_all();
+    assert_eq!(post.query(&DataInput::Str("A")), 70);
+    assert_eq!(post.query(&DataInput::Str("B")), 35);
+}

--- a/tests/e2e_frequency.rs
+++ b/tests/e2e_frequency.rs
@@ -1,0 +1,283 @@
+//! E2E frequency-sketch pipelines on synthetic streams with exact ground
+//! truth: CountMin (regular/fast + shard merge), CountSketch turnstile,
+//! top-k heaps, CountL2HH weighted F2, FoldCMS/FoldCS counts and hierarchical
+//! merge, portable wire twins (string keys).
+
+mod common;
+
+use common::{FreqTruth, zipf_u64};
+use std::collections::HashMap;
+
+use asap_sketchlib::message_pack_format::portable::countminsketch::CountMinSketch;
+use asap_sketchlib::message_pack_format::portable::countsketch::CountSketch;
+use asap_sketchlib::{
+    CMSHeap, CSHeap, CountL2HH, CountMin, DataInput, DefaultXxHasher, FastPath, FoldCMS, FoldCS,
+    HeapItem, RegularPath, Vector2D,
+};
+
+// ----------------------------------------------------------------- CountMin
+
+#[test]
+fn countmin_zipf_one_sided_bound_and_shard_merge() {
+    let (rows, cols) = (4usize, 4096usize);
+    let stream = zipf_u64(100_000, 8192, 1.1, 1001);
+
+    let mut single = CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols);
+    let (mut shard_a, mut shard_b, mut shard_c) = (
+        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols),
+        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols),
+        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols),
+    );
+    let mut truth = FreqTruth::default();
+    for (i, k) in stream.iter().enumerate() {
+        let d = DataInput::I64(*k as i64);
+        truth.observe(*k as i64);
+        single.insert(&d);
+        match i % 3 {
+            0 => shard_a.insert(&d),
+            1 => shard_b.insert(&d),
+            _ => shard_c.insert(&d),
+        }
+    }
+    shard_b.merge(&shard_c);
+    shard_a.merge(&shard_b);
+    let merged = &shard_a;
+
+    // One-sided guarantee: est >= true, excess within eps*N (eps = e/cols).
+    let eps_n = std::f64::consts::E / cols as f64 * truth.total() as f64;
+    for (k, c) in truth.pairs() {
+        if c < 50 {
+            continue; // only assert keys dense enough to be meaningful
+        }
+        let est_single = single.estimate(&DataInput::I64(k));
+        let est_merged = merged.estimate(&DataInput::I64(k));
+        assert!(
+            est_single >= c && est_merged >= c,
+            "underestimate: key {k} true {c} single {est_single} merged {est_merged}"
+        );
+        assert!(
+            (est_single - c) as f64 <= eps_n && (est_merged - c) as f64 <= eps_n,
+            "excess beyond eps*N: key {k} true {c} single {est_single} merged {est_merged}"
+        );
+    }
+
+    // Shard-merge must equal the single-pass estimate on hot keys.
+    for (k, _) in truth.top_k(50) {
+        let a = single.estimate(&DataInput::I64(k));
+        let b = merged.estimate(&DataInput::I64(k));
+        assert_eq!(a, b, "merged counters diverge from single pass for key {k}");
+    }
+}
+
+#[test]
+fn countmin_regular_fast_paths_agree_on_stream() {
+    let mut reg = CountMin::<Vector2D<i64>, RegularPath>::with_dimensions(3, 2048);
+    let mut fast = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 2048);
+    let stream = zipf_u64(20_000, 512, 1.2, 1002);
+    for k in &stream {
+        reg.insert(&DataInput::I64(*k as i64));
+        fast.insert(&DataInput::I64(*k as i64));
+    }
+    for k in [0i64, 7, 42, 511] {
+        assert_eq!(
+            reg.estimate(&DataInput::I64(k)),
+            fast.estimate(&DataInput::I64(k)) as i64,
+            "regular/fast paths disagree for key {k}"
+        );
+    }
+}
+
+// -------------------------------------------------------------- CountSketch
+
+#[test]
+fn countsketch_turnstile_net_zero_and_median_bound() {
+    // True turnstile: +500 then -500 must net to zero.
+    let mut cs = asap_sketchlib::Count::<Vector2D<i64>, RegularPath>::with_dimensions(4, 1024);
+    cs.insert_many(&DataInput::U32(9), 500);
+    cs.insert_many(&DataInput::U32(9), -500);
+    assert_eq!(
+        cs.estimate(&DataInput::U32(9)),
+        0.0,
+        "turnstile did not cancel"
+    );
+
+    // Median estimator bound |est - true| <= sqrt(e/cols) * L2.
+    let (rows, cols) = (5usize, 4096usize);
+    let mut cs = asap_sketchlib::Count::<Vector2D<i64>, RegularPath>::with_dimensions(rows, cols);
+    let stream = zipf_u64(200_000, 8192, 1.1, 1003);
+    let mut truth = FreqTruth::default();
+    for k in &stream {
+        truth.observe(*k as i64);
+        cs.insert(&DataInput::I64(*k as i64));
+    }
+    let bound = (std::f64::consts::E / cols as f64).sqrt() * truth.l2_norm();
+    for (k, c) in truth.top_k(100) {
+        let est = cs.estimate(&DataInput::I64(k));
+        assert!(
+            (est - c as f64).abs() <= 1.5 * bound,
+            "key {k}: |{est:.0} - {c}| > 1.5 * median bound {:.0}",
+            1.5 * bound
+        );
+    }
+}
+
+// ------------------------------------------------------------- Top-k heaps
+
+#[test]
+fn heaps_top_k_recall_and_consistency() {
+    let (top_k, domain) = (16usize, 1024usize);
+    let mut cms_heap = CMSHeap::<Vector2D<i64>, RegularPath>::new(3, 4096, top_k);
+    let mut cs_heap = CSHeap::<Vector2D<i64>, RegularPath>::new(5, 4096, top_k);
+    let stream = zipf_u64(20_000, domain, 1.1, 1004);
+    let mut truth = FreqTruth::default();
+    for k in &stream {
+        let d = DataInput::I64(*k as i64);
+        truth.observe(*k as i64);
+        cms_heap.insert(&d);
+        cs_heap.insert(&d);
+    }
+    let expected_min_count = truth.top_k(top_k)[top_k - 1].1;
+
+    for (label, items, cms) in [
+        ("CMSHeap", cms_heap.heap().heap().to_vec(), true),
+        ("CSHeap", cs_heap.heap().heap().to_vec(), false),
+    ] {
+        assert!(items.len() <= top_k, "{label} heap exceeded capacity");
+        let mut recall = 0usize;
+        for it in &items {
+            let key = match &it.key {
+                HeapItem::I64(v) => *v,
+                other => panic!("{label}: unexpected heap key {other:?}"),
+            };
+            let est = if cms {
+                cms_heap.estimate(&DataInput::I64(key))
+            } else {
+                cs_heap.estimate(&DataInput::I64(key)) as i64
+            };
+            // Invariant: heap entry must always equal the sketch estimate.
+            assert_eq!(
+                it.count, est,
+                "{label}: heap {} != estimate {est} for key {key}",
+                it.count
+            );
+            if truth.get(key) >= expected_min_count {
+                recall += 1;
+            }
+        }
+        assert!(
+            recall >= top_k - 1,
+            "{label} recovered only {recall}/{top_k} heavy hitters"
+        );
+    }
+}
+
+// -------------------------------------------------------------- CountL2HH
+
+#[test]
+fn countl2hh_weighted_f2_with_decrements() {
+    let mut sk = CountL2HH::<DefaultXxHasher>::with_dimensions_and_seed(4, 2048, 11);
+    let mut truth = FreqTruth::default();
+    let stream = zipf_u64(30_000, 512, 1.3, 1005);
+    for (i, k) in stream.iter().enumerate() {
+        let w = 1 + (i % 5) as i64;
+        sk.fast_insert_with_count(&DataInput::I64(*k as i64), w);
+        truth.observe_weighted(*k as i64, w);
+    }
+    // Turnstile decrement on the hottest key must track through the median path.
+    let hot = truth.top_k(1)[0].0;
+    sk.fast_insert_with_count(&DataInput::I64(hot), -10);
+    truth.observe_weighted(hot, -10);
+    let est_hot = sk.fast_update_and_est(&DataInput::I64(hot), 0);
+    let rel = ((est_hot - truth.get(hot) as f64) / truth.get(hot) as f64).abs();
+    assert!(
+        rel <= 0.02,
+        "hot-key frequency after decrement: {est_hot} vs {}",
+        truth.get(hot)
+    );
+
+    assert!(
+        (sk.get_l2_sqr() - truth.f2()).abs() / truth.f2() <= 0.10,
+        "F2 over weighted turnstile stream off by >10%"
+    );
+}
+
+// ------------------------------------------- FoldCMS / FoldCS counts + merge
+
+#[test]
+fn fold_cms_foldcs_counts_and_hierarchical_merge() {
+    // Weighted per-key counts stay exact on sparse dims.
+    let mut a = FoldCMS::<DefaultXxHasher>::new(3, 2048, 0, 32);
+    let mut b = FoldCMS::<DefaultXxHasher>::new(3, 2048, 0, 32);
+    for _ in 0..100 {
+        a.insert(&DataInput::Str("alpha"), 2);
+        b.insert(&DataInput::Str("alpha"), 2);
+        b.insert(&DataInput::Str("beta"), 1);
+    }
+    assert_eq!(a.query(&DataInput::Str("alpha")), 200);
+    assert_eq!(b.query(&DataInput::Str("alpha")), 200);
+    assert_eq!(b.query(&DataInput::Str("beta")), 100);
+
+    // Same-level merge sums disjoint contributions.
+    a.merge_same_level(&b);
+    assert_eq!(a.query(&DataInput::Str("alpha")), 400);
+    assert_eq!(a.query(&DataInput::Str("beta")), 100);
+
+    // Signed weighted updates through FoldCS.
+    let mut fs = FoldCS::<DefaultXxHasher>::new(3, 2048, 0, 32);
+    fs.insert(&DataInput::Str("gamma"), 60);
+    fs.insert(&DataInput::Str("gamma"), -20);
+    assert_eq!(fs.query(&DataInput::Str("gamma")), 40);
+
+    // Hierarchical merge of level-matched sketches preserves totals.
+    let s1 = build_fold_cms("s1", 30);
+    let s2 = build_fold_cms("s2", 45);
+    let merged = FoldCMS::hierarchical_merge(&[s1, s2]);
+    assert_eq!(merged.query(&DataInput::Str("s1")), 90);
+    assert_eq!(merged.query(&DataInput::Str("s2")), 135);
+}
+
+fn build_fold_cms(key: &'static str, n: usize) -> FoldCMS<DefaultXxHasher> {
+    let mut s = FoldCMS::<DefaultXxHasher>::new(3, 2048, 0, 32);
+    for _ in 0..n {
+        s.insert(&DataInput::Str(key), 3);
+    }
+    s
+}
+
+// ------------------------------------------------------ Portable wire twins
+
+#[test]
+fn portable_cms_and_cs_string_keys_zipf_bound() {
+    let stream = zipf_u64(50_000, 2048, 1.1, 1006);
+    let mut truth: HashMap<String, i64> = HashMap::new();
+
+    let mut pcs = CountMinSketch::new(3, 4096);
+    let mut pcss = CountSketch::new(5, 4096);
+    for k in &stream {
+        let key = format!("k{k}");
+        *truth.entry(key.clone()).or_insert(0) += 1;
+        pcs.update(&key, 1.0);
+        pcss.update(&key, 1.0);
+    }
+    let l2sq: f64 = truth.values().map(|c| (*c as f64) * (*c as f64)).sum();
+    let l2 = l2sq.sqrt();
+    let total = truth.values().sum::<i64>() as f64;
+    let cm_bound = std::f64::consts::E / 4096.0 * total;
+    let cs_bound = (std::f64::consts::E / 4096.0).sqrt() * l2;
+
+    let mut by_freq: Vec<(String, i64)> = truth.into_iter().collect();
+    by_freq.sort_by_key(|(_, c)| -*c);
+    for (k, c) in by_freq.iter().take(60) {
+        let cm_est = pcs.estimate(k);
+        assert!(
+            cm_est >= *c as f64 && cm_est <= *c as f64 + cm_bound,
+            "portable CM key {k}: est {cm_est} vs true {c}"
+        );
+        let cs_est = pcss.estimate(k);
+        assert!(
+            (cs_est - *c as f64).abs() <= 1.5 * cs_bound,
+            "portable CS key {k}: est {cs_est} vs true {c} (bound {:.0})",
+            1.5 * cs_bound
+        );
+    }
+}

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -272,7 +272,11 @@ fn univmonq_full_metric_suite() {
 
 #[test]
 fn tumbling_kll_window_queries() {
-    let cfg = KLLConfig { k: 200, m: 8 };
+    let cfg = KLLConfig {
+        k: 200,
+        m: 8,
+        seed: None,
+    };
     let mut tw: TumblingWindow<KLL> = TumblingWindow::new(100, 16, cfg, 4);
 
     let all: Vec<f64> = uniform_u64(1000, 1_000_000, 3009)
@@ -335,9 +339,10 @@ fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
 
     // Non-finite / non-positive / beyond-indexable-range values must be
     // dropped by BOTH implementations: silently, without corrupting bucket 0
-    // (NaN floor-casts to 0) and without forcing a distant-bucket allocation
-    // (1e308 maps to an index near i32::MAX; the portable dense store would
-    // previously have attempted a multi-gigabyte grow). #70 items 3/4.
+    // (NaN floor-casts to 0) and without letting one sample force a distant-
+    // bucket allocation (unguarded, f64::MAX mapped ~35k buckets away at
+    // alpha=0.01 — ~277 KiB of amplification per sample, scaling with 1/lnγ;
+    // #70 item 4).
     for v in [
         f64::NAN,
         f64::NEG_INFINITY,
@@ -465,4 +470,48 @@ fn portable_hydra_kll_per_key_medians() {
             assert_in_rank_band(est, &truth, qq, 0.04, &format!("HydraKll {name}"));
         }
     }
+}
+
+#[test]
+fn portable_ddsketch_rejects_hostile_delta_spans() {
+    use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketchDelta;
+
+    let alpha = 0.01;
+    let mut base = PortableDds::new(alpha);
+    base.update(1.0);
+    let (len_before, offset_before) = (base.store_counts.len(), base.store_offset);
+
+    // A corrupt/hostile delta pointing near i32::MAX must be rejected with an
+    // error BEFORE any allocation: the naive pad would be ~2e9 buckets.
+    let hostile = DdSketchDelta {
+        buckets: vec![(i32::MAX - 1, 1), (7, 3)],
+        ..DdSketchDelta::default()
+    };
+    assert!(
+        base.apply_delta(&hostile).is_err(),
+        "hostile far-span delta must be rejected"
+    );
+    assert_eq!(
+        base.store_counts.len(),
+        len_before,
+        "state untouched on rejection"
+    );
+    assert_eq!(
+        base.store_offset, offset_before,
+        "offset untouched on rejection"
+    );
+
+    // Benign deltas still apply: bucket index 6 carries count 5 afterward,
+    // and its representative gamma^6*(1+alpha) becomes visible in queries.
+    let benign = DdSketchDelta {
+        buckets: vec![(6, 5)],
+        ..DdSketchDelta::default()
+    };
+    base.apply_delta(&benign).expect("benign delta");
+    let gamma = (1.0 + alpha) / (1.0 - alpha);
+    assert_eq!(
+        base.quantile(0.9),
+        Some(gamma.powf(6.0) * (1.0 + alpha)),
+        "applied delta count visible through queries"
+    );
 }

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -383,16 +383,9 @@ fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
 
     // Boundary acceptance: values just INSIDE the indexable range must still
     // be tracked, so the guards reject only genuinely unmappable extremes.
-    // Replicate the mapping formulas here (they are private) for alpha=0.01.
-    let gamma = (1.0 + alpha) / (1.0 - alpha);
-    let inv_log_gamma = 1.0 / gamma.ln();
-    let min_idx = ((i32::MIN as f64) * inv_log_gamma + 1.0)
-        .exp()
-        .max(f64::MIN_POSITIVE * gamma);
-    const EXP_OVERFLOW: f64 = 709.0;
-    let max_idx = ((i32::MAX as f64) * inv_log_gamma - 1.0)
-        .exp()
-        .min(EXP_OVERFLOW.exp() / (2.0 * gamma) * (gamma + 1.0));
+    // Bounds come from the shared production helper — core and portable MUST
+    // agree because they compute from the same function.
+    let (min_idx, max_idx) = asap_sketchlib::sketches::ddsketch::ddsketch_indexable_bounds(alpha);
 
     let mut port_boundary = PortableDds::new(alpha);
     let mut core_boundary = DDSketch::new(alpha);
@@ -439,6 +432,30 @@ fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
     assert!(
         port.merge(&port_other).is_err(),
         "portable merge must reject alpha mismatch"
+    );
+
+    // Tiny-alpha regression: at alpha=1e-9 ln(gamma) ~ 2e-9, and naive
+    // reciprocal-multiplied guard formulas diverge from core's — admitting
+    // v=1e-300 whose bucket index saturates i32 and overflows ensure_bucket.
+    // Both implementations must drop it identically via the shared helper.
+    let mut tiny = PortableDds::new(1e-9);
+    let mut tiny_core = DDSketch::new(1e-9);
+    tiny.update(1e-300);
+    tiny_core.add(&1e-300);
+    assert_eq!(
+        tiny.total_count(),
+        0,
+        "portable drops sub-indexable value at tiny alpha"
+    );
+    assert_eq!(
+        tiny_core.get_count(),
+        0,
+        "core drops sub-indexable value at tiny alpha"
+    );
+    assert_eq!(
+        tiny.store_counts.len(),
+        0,
+        "no allocation may occur for rejected values"
     );
 }
 

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -327,6 +327,76 @@ fn tumbling_kll_window_queries() {
     );
 }
 
+#[test]
+fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
+    let alpha = 0.01;
+    let mut core = DDSketch::new(alpha);
+    let mut port = PortableDds::new(alpha);
+
+    // Non-finite / non-positive / beyond-indexable-range values must be
+    // dropped by BOTH implementations: silently, without corrupting bucket 0
+    // (NaN floor-casts to 0) and without forcing a distant-bucket allocation
+    // (1e308 maps to an index near i32::MAX; the portable dense store would
+    // previously have attempted a multi-gigabyte grow). #70 items 3/4.
+    for v in [
+        f64::NAN,
+        f64::NEG_INFINITY,
+        f64::INFINITY,
+        -5.0,
+        0.0,
+        f64::MIN_POSITIVE, // below min-indexable
+        5e-324,            // smallest subnormal
+        f64::MAX,          // above max-indexable
+        1e308,
+    ] {
+        core.add(&v);
+        port.update(v);
+    }
+    assert_eq!(core.get_count(), 0, "core must drop untrackable extremes");
+    assert_eq!(
+        port.total_count(),
+        0,
+        "portable must drop untrackable extremes"
+    );
+    assert!(
+        port.store_counts.len() < 10_000,
+        "portable store grew to {} buckets from untrackable input",
+        port.store_counts.len()
+    );
+    assert_eq!(port.quantile(0.5), None, "nothing trackable was added");
+
+    // Normal samples still work after the rejected inputs.
+    let good = [1.0f64, 2.0, 4.0, 8.0, 16.0];
+    for v in good {
+        core.add(&v);
+        port.update(v);
+    }
+    assert_eq!(core.get_count(), 5);
+    assert_eq!(port.total_count(), 5);
+    assert_between(
+        port.store_counts.len() as f64,
+        1.0,
+        2.0 * 256.0, // initial GROW_CHUNK seed + at most one more
+        "store stays compact",
+    );
+
+    // Item 2 contract: mismatched mappings are a runtime error in BOTH types,
+    // not a debug-only assertion.
+    let other_alpha = 0.05;
+    let mut core_other = DDSketch::new(other_alpha);
+    core_other.add(&1.0);
+    assert!(
+        core.merge(&core_other).is_err(),
+        "core merge must reject alpha mismatch"
+    );
+    let mut port_other = PortableDds::new(other_alpha);
+    port_other.update(1.0);
+    assert!(
+        port.merge(&port_other).is_err(),
+        "portable merge must reject alpha mismatch"
+    );
+}
+
 // --------------------------------------------- Portable HydraKll per-key
 
 #[test]

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -272,11 +272,7 @@ fn univmonq_full_metric_suite() {
 
 #[test]
 fn tumbling_kll_window_queries() {
-    let cfg = KLLConfig {
-        k: 200,
-        m: 8,
-        seed: None,
-    };
+    let cfg = KLLConfig { k: 200, m: 8 };
     let mut tw: TumblingWindow<KLL> = TumblingWindow::new(100, 16, cfg, 4);
 
     let all: Vec<f64> = uniform_u64(1000, 1_000_000, 3009)

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -272,7 +272,11 @@ fn univmonq_full_metric_suite() {
 
 #[test]
 fn tumbling_kll_window_queries() {
-    let cfg = KLLConfig { k: 200, m: 8 };
+    let cfg = KLLConfig {
+        k: 200,
+        m: 8,
+        seed: None,
+    };
     let mut tw: TumblingWindow<KLL> = TumblingWindow::new(100, 16, cfg, 4);
 
     let all: Vec<f64> = uniform_u64(1000, 1_000_000, 3009)

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -1,0 +1,354 @@
+//! E2E quantile pipelines on synthetic numeric streams: KLL / KLLDynamic
+//! (typed + shard merge), DDSketch core & portable across distributions,
+//! UnivMon-Q's full metric surface, TumblingWindow<KLL> window queries, and
+//! the portable HydraKll per-key medians.
+
+mod common;
+
+use common::{
+    NumericTruth, assert_between, assert_in_rank_band, exponential_f64, log_uniform_f64,
+    normal_f64, uniform_u64,
+};
+
+use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketch as PortableDds;
+use asap_sketchlib::message_pack_format::portable::hydra_kll::HydraKllSketch;
+use asap_sketchlib::{
+    DDSketch, DataInput, KLL, KLLConfig, TumblingWindow, UnivMonQ, UnivMonQPoint,
+};
+use std::collections::HashMap;
+
+const QS: [f64; 5] = [0.1, 0.25, 0.5, 0.75, 0.9];
+
+// --------------------------------------------------------------------- KLL
+
+#[test]
+fn kll_quantile_rank_bands_and_shard_merge() {
+    let values: Vec<f64> = uniform_u64(80_000, 1_000_000, 3001)
+        .into_iter()
+        .map(|v| v as f64)
+        .chain(normal_f64(20_000, 500_000.0, 120_000.0, 3002))
+        .collect();
+    let truth = NumericTruth::new(values.clone());
+
+    let mut kll = KLL::init_kll(200);
+    let mut left = KLL::init_kll_with_seed(200, 77);
+    let mut right = KLL::init_kll_with_seed(200, 99);
+    for (i, v) in values.iter().enumerate() {
+        kll.update(v);
+        if i % 2 == 0 {
+            left.update(v);
+        } else {
+            right.update(v);
+        }
+    }
+    for &q in &QS {
+        assert_in_rank_band(kll.quantile(q), &truth, q, 0.03, "KLL");
+    }
+
+    // Merging shards must preserve the merged distribution.
+    let sum_pre_merge = left.count() + right.count();
+    assert!(
+        (sum_pre_merge as f64 - values.len() as f64).abs() / values.len() as f64 <= 0.005,
+        "shard counts {sum_pre_merge} must approximate stream length {}",
+        values.len()
+    );
+    left.merge(&right);
+    assert!(
+        (left.count() as f64 - values.len() as f64).abs() / values.len() as f64 <= 0.005,
+        "merged count {} must approximate stream length {}",
+        left.count(),
+        values.len()
+    );
+    for &q in &QS {
+        assert_in_rank_band(left.quantile(q), &truth, q, 0.03, "KLL after shard merge");
+    }
+}
+
+#[test]
+fn kll_i64_generic_typed_path() {
+    let mut kll: KLL<i64> = KLL::init_kll(200);
+    let mut truth: Vec<i64> = Vec::new();
+    for v in common::uniform_u64(50_000, 10_000_000, 3003) {
+        let x = v as i64;
+        kll.update(&x);
+        truth.push(x);
+    }
+    truth.sort();
+    for q in [0.25f64, 0.5, 0.9] {
+        let lo = truth[((q - 0.02) * truth.len() as f64) as usize];
+        let hi = truth[(((q + 0.02) * truth.len() as f64) as usize).min(truth.len() - 1)];
+        let est = kll.quantile(q);
+        assert!(
+            est >= lo as f64 && est <= hi as f64,
+            "KLL<i64> q={q}: {est} outside [{lo}, {hi}]"
+        );
+    }
+}
+
+#[test]
+fn kll_dynamic_parity_with_kll() {
+    let values: Vec<f64> = normal_f64(40_000, 100.0, 15.0, 3004)
+        .into_iter()
+        .filter(|v| *v > 0.0)
+        .collect();
+    let truth = NumericTruth::new(values.clone());
+
+    let mut a = KLL::init_kll(200);
+    let mut b = asap_sketchlib::KLLDynamic::<f64>::init_kll(200);
+    for v in &values {
+        a.update(v);
+        b.update(v);
+    }
+    for &q in &QS {
+        assert_in_rank_band(a.quantile(q), &truth, q, 0.03, "KLL normal");
+        assert_in_rank_band(b.quantile(q), &truth, q, 0.03, "KLLDynamic normal");
+    }
+}
+
+// ---------------------------------------------------------------- DDSketch
+
+#[test]
+fn ddsketch_alpha_across_distributions_core_and_portable() {
+    let alpha = 0.01;
+
+    // Adversarial log-uniform stream straddling bucket edges.
+    let gamma = (1.0 + alpha) / (1.0 - alpha);
+    let adversarial = log_uniform_f64(30_000, gamma, 5..40, 3005);
+    // Smooth heavy-tail streams.
+    let normal = normal_f64(20_000, 1000.0, 250.0, 3006)
+        .into_iter()
+        .filter(|v| *v > 0.0);
+    let exponential = exponential_f64(20_000, 1e-3, 3007);
+
+    for (label, values) in [
+        ("adversarial", adversarial),
+        ("normal", normal.collect()),
+        ("exponential", exponential),
+    ] {
+        let truth = NumericTruth::new(values.clone());
+        let mut core = DDSketch::new(alpha);
+        let mut port = PortableDds::new(alpha);
+        for v in &values {
+            core.add(v);
+            port.update(*v);
+        }
+        assert_eq!(
+            core.get_count() as usize,
+            truth.len(),
+            "{label}: dropped samples"
+        );
+
+        for &q in &QS {
+            // Contract: relative error <= alpha vs the TRUE order statistic.
+            let t = truth.quantile(q);
+            if t <= 0.0 {
+                continue;
+            }
+            let qc = core.get_value_at_quantile(q).unwrap();
+            let qp = port.quantile(q).unwrap();
+            assert!(
+                ((qc - t) / t).abs() <= alpha * 1.05,
+                "core {label} q={q}: {qc} vs {t} exceeds alpha={alpha}"
+            );
+            assert!(
+                ((qp - t) / t).abs() <= alpha * 1.05,
+                "portable {label} q={q}: {qp} vs {t} exceeds alpha={alpha}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------- UnivMonQ
+
+#[test]
+fn univmonq_full_metric_suite() {
+    let mut q = UnivMonQ::new(Default::default()).expect("default config valid");
+    let mut freq: HashMap<u64, u64> = HashMap::new();
+
+    // Well-separated heavy hitters plus uniform background.
+    for i in 0..40u64 {
+        let weight = (i + 1) * 60;
+        for _ in 0..weight {
+            q.update(&(i as f64));
+            *freq.entry(i).or_insert(0) += 1;
+        }
+    }
+    let bg = uniform_u64(20_000, 900, 3008);
+    let mut values: Vec<f64> = Vec::with_capacity(20_000 + 49_200);
+    for k in bg {
+        let key = 100u64 + k % 800;
+        q.update(&(key as f64));
+        *freq.entry(key).or_insert(0) += 1;
+        values.push(key as f64);
+    }
+    for (k, c) in &freq {
+        if *k < 40 {
+            values.extend(std::iter::repeat_n(*k as f64, *c as usize));
+        }
+    }
+    let n = values.len() as f64;
+    let mut sorted = values.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let truth = NumericTruth::new(values.clone());
+
+    // Exact aggregates.
+    assert_eq!(q.count() as usize, values.len(), "count");
+    assert_eq!(q.min(), Some(sorted[0]), "min");
+    assert_eq!(q.max(), Some(sorted[sorted.len() - 1]), "max");
+
+    // Frequency of the heaviest separated key.
+    let heaviest_key = 39u64;
+    let hot_est = q.estimate_frequency(heaviest_key as f64) as f64;
+    assert_between(
+        hot_est,
+        freq[&heaviest_key] as f64 * 0.95,
+        freq[&heaviest_key] as f64 * 1.05,
+        "frequency of heaviest key",
+    );
+
+    // Distinct / F2 / entropy.
+    assert_between(
+        q.estimate_distinct(),
+        freq.len() as f64 * 0.90,
+        freq.len() as f64 * 1.10,
+        "distinct",
+    );
+    let f2_truth: f64 = freq.values().map(|c| (*c as f64).powi(2)).sum();
+    assert_between(q.estimate_f2(), f2_truth * 0.85, f2_truth * 1.15, "F2");
+    let p: Vec<f64> = freq.values().map(|c| *c as f64 / n).collect();
+    let h_truth: f64 = -p.iter().map(|p| p * p.ln()).sum::<f64>();
+    assert_between(
+        q.estimate_entropy(),
+        h_truth * 0.90,
+        h_truth * 1.10,
+        "entropy (nats)",
+    );
+
+    // Ordered queries: rank bands + monotone CDF + rank()/quantile() inverse pair.
+    for &qq in &QS {
+        match q.quantile(qq) {
+            Some(est) => assert_in_rank_band(est, &truth, qq, 0.04, "UnivMonQ quantile"),
+            None => panic!("quantile({qq}) returned None with ordered_samples enabled"),
+        }
+    }
+    let cdf_pts: Vec<UnivMonQPoint> = q.cdf();
+    assert!(!cdf_pts.is_empty(), "cdf must not be empty");
+    for w in cdf_pts.windows(2) {
+        assert!(w[0].rank <= w[1].rank + 1e-9, "cdf ranks not monotone");
+    }
+    let probe = sorted[sorted.len() / 3];
+    let r = q.rank(probe).expect("rank") as f64;
+    let true_rank = truth.cdf(probe) * n;
+    assert_between(
+        r,
+        true_rank * 0.94,
+        true_rank * 1.06,
+        "rank() vs empirical count",
+    );
+
+    // Heavy hitters among the well-separated keys (weights 1800..2400).
+    let hh = q.heavy_hitters(10);
+    let top_true: std::collections::HashSet<u64> = freq
+        .iter()
+        .filter(|(k, c)| **k >= 30 && **c >= 30 * 60)
+        .map(|(k, _)| *k)
+        .collect();
+    assert_eq!(
+        top_true.len(),
+        10,
+        "test setup: expected 10 separated heavy keys"
+    );
+    let hits = hh
+        .iter()
+        .filter(|(v, _)| top_true.contains(&(*v as u64)))
+        .count();
+    assert!(
+        hits >= 8,
+        "heavy hitters recovered only {hits}/10 known keys"
+    );
+}
+
+// -------------------------------------------------------- TumblingWindow<KLL>
+
+#[test]
+fn tumbling_kll_window_queries() {
+    let cfg = KLLConfig { k: 200, m: 8 };
+    let mut tw: TumblingWindow<KLL> = TumblingWindow::new(100, 16, cfg, 4);
+
+    let all: Vec<f64> = uniform_u64(1000, 1_000_000, 3009)
+        .iter()
+        .map(|v| *v as f64)
+        .collect();
+    for (t, v) in all.iter().enumerate() {
+        tw.insert(t as u64, &DataInput::F64(*v), 999); // value param ignored for KLL
+    }
+    assert_eq!(
+        tw.closed_count(),
+        9,
+        "windows [0,900) should be closed at t=999"
+    );
+
+    // query_all covers every observation.
+    let merged_all = tw.query_all();
+    let full_truth = NumericTruth::new(all.clone());
+    for &qq in &[0.5f64, 0.9] {
+        assert_in_rank_band(
+            merged_all.quantile(qq),
+            &full_truth,
+            qq,
+            0.05,
+            "tumbling query_all",
+        );
+    }
+
+    // query_recent(1) = active window [900,1000) + last closed [800,900).
+    let recent: Vec<f64> = all[800..].to_vec();
+    let recent_truth = NumericTruth::new(recent);
+    let merged_recent = tw.query_recent(1);
+    for &qq in &[0.5f64, 0.9] {
+        assert_in_rank_band(
+            merged_recent.quantile(qq),
+            &recent_truth,
+            qq,
+            0.05,
+            "tumbling query_recent(1)",
+        );
+    }
+
+    // The active window alone is the exact last-100 slice.
+    let active_truth = NumericTruth::new(all[900..].to_vec());
+    let active_median = tw.active_sketch().quantile(0.5);
+    assert_in_rank_band(
+        active_median,
+        &active_truth,
+        0.5,
+        0.06,
+        "active window median",
+    );
+}
+
+// --------------------------------------------- Portable HydraKll per-key
+
+#[test]
+fn portable_hydra_kll_per_key_medians() {
+    let mut hk = HydraKllSketch::new(3, 256, 200);
+    let mut truths: HashMap<&str, NumericTruth> = HashMap::new();
+    for (name, base) in [("svc-a", 100.0f64), ("svc-b", 900.0)] {
+        let vals = normal_f64(
+            4000,
+            base,
+            base * 0.05,
+            if name == "svc-a" { 3010 } else { 3011 },
+        );
+        truths.insert(name, NumericTruth::new(vals.clone()));
+        for v in vals {
+            hk.update(name, v.abs()); // HydraKll cells are KLL: positive domain
+        }
+    }
+    for (name, truth) in truths {
+        for &qq in &[0.25f64, 0.5, 0.75] {
+            let est = hk.quantile(name, qq);
+            assert_in_rank_band(est, &truth, qq, 0.04, &format!("HydraKll {name}"));
+        }
+    }
+}

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -380,6 +380,50 @@ fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
         "store stays compact",
     );
 
+    // Boundary acceptance: values just INSIDE the indexable range must still
+    // be tracked, so the guards reject only genuinely unmappable extremes.
+    // Replicate the mapping formulas here (they are private) for alpha=0.01.
+    let gamma = (1.0 + alpha) / (1.0 - alpha);
+    let inv_log_gamma = 1.0 / gamma.ln();
+    let min_idx = ((i32::MIN as f64) * inv_log_gamma + 1.0)
+        .exp()
+        .max(f64::MIN_POSITIVE * gamma);
+    const EXP_OVERFLOW: f64 = 709.0;
+    let max_idx = ((i32::MAX as f64) * inv_log_gamma - 1.0)
+        .exp()
+        .min(EXP_OVERFLOW.exp() / (2.0 * gamma) * (gamma + 1.0));
+
+    let mut port_boundary = PortableDds::new(alpha);
+    let mut core_boundary = DDSketch::new(alpha);
+    let just_inside_min = min_idx * (1.0 + 1e-9); // a hair above the floor
+    let just_inside_max = max_idx * (1.0 - 1e-9); // a hair below the ceiling
+    port_boundary.update(just_inside_min);
+    port_boundary.update(just_inside_max);
+    core_boundary.add(&just_inside_min);
+    core_boundary.add(&just_inside_max);
+    assert_eq!(
+        port_boundary.total_count(),
+        2,
+        "in-range extremes near boundaries must be kept"
+    );
+    assert_eq!(core_boundary.get_count(), 2, "core boundary agreement");
+    assert_eq!(port_boundary.total_count(), core_boundary.get_count());
+
+    // And one step past each boundary must be rejected by both.
+    port_boundary.update(min_idx * 0.5);
+    port_boundary.update(max_idx * (1.0 + 1e-6));
+    core_boundary.add(&(min_idx * 0.5));
+    assert_eq!(
+        port_boundary.total_count(),
+        2,
+        "out-of-range neighbors rejected"
+    );
+    assert_eq!(
+        core_boundary.get_count(),
+        2,
+        "core rejects out-of-range neighbor"
+    );
+
     // Item 2 contract: mismatched mappings are a runtime error in BOTH types,
     // not a debug-only assertion.
     let other_alpha = 0.05;


### PR DESCRIPTION
## What this PR does

It adds an end-to-end testing harness that feeds synthetic data into every sketch in this library and compares the answers against exactly-known ground truth. Building that harness uncovered four real bugs, which are fixed here too. Finally, it packages the harness so that any sketch added in the future gets put through the same standard checks.

## The bugs the harness found

**Nitro's frequency estimates were basically useless.** Three separate problems stacked on top of each other:

1. Records were written using one hash function but read back using another. Queries looked in buckets that inserts never touched, so every estimate came back as zero.
2. Each sampled record updated only one of the five rows, so every row ended up holding roughly a fifth of the true count.
3. The "how far should I skip ahead?" calculation rounded the wrong way, so a sketch configured to sample half the stream actually sampled about a third.

After the fixes, estimates land within about 1% of the truth at any sampling rate. There were existing tests for Nitro, but they worked around the estimator by reimplementing it inside the test — which is exactly why none of this was caught. Those tests now exercise the public API like a real user would.

**Portable DDSketch broke its accuracy promise at bucket edges.** For a value sitting right at the bottom of a bucket, it reported the middle of that bucket, which is off by slightly *more* than the advertised relative error. It now reports the bottom edge scaled by (1 + α) — the same thing the core Rust implementation and DataDog's reference do. No saved data needs to change; only query output shifts, by at most α.

**CountL2HH's F2 counter overflowed silently.** Squaring large counts in a plain i64 wrapped around to nonsense on big streams (debug builds panicked instead). It now saturates gracefully, matching how merges already handled the same situation.

A note for anyone upgrading: sketches built with the old Nitro (at any sampling rate below 100%) and portable DDSketch snapshots will give different numbers after this change than they did before. That is the point — the old numbers were wrong — but plan for it if you have stored state.

## The harness itself

- **`tests/common`** — shared building blocks: seeded stream generators (Zipf, uniform, normal, exponential, plus adversarial log-uniform values aimed at DDSketch bucket edges), exact ground-truth trackers, and assertion helpers that print expected vs actual on failure.
- **`tests/e2e_frequency.rs`, `e2e_cardinality.rs`, `e2e_quantiles.rs`, `e2e_frameworks.rs`, `e2e_experimental.rs`** — deep suites per family. Every public sketch runs through realistic pipelines: ingest a stream, query, check against ground truth, merge shards and check again. Experimental sketches are gated behind `--features experimental`.
- **`tests/bug_verification.rs`** — small deterministic regression tests, one per bug above.
- **`examples/accuracy_probe.rs`** — a release-mode companion probe for checks too heavy for CI (for example, HLL's large-range correction at 170 million distinct values).

## So new sketches get tested the same way

`tests/common/conformance.rs` turns the harness into a checklist. A new sketch implements one or two tiny traits describing what it promises (`FrequencyOps`, `CardinalityOps`, `QuantileOps`, signed updates, merging), then calls the matching batteries. The batteries cover hot-key accuracy, never-underestimate guarantees, turnstile cancellation, cardinality with duplicate-replay invariance, quantile rank bands, and shard-merge equivalence. They collect every failure in one run rather than stopping at the first.

`tests/conformance_kit.rs` shows existing sketches wired up as copy-paste reference adapters, and `tests/README.md` walks through the whole recipe.

The harness also pins down a few API behaviors that used to live only in people's heads: Hydra requires full-length keys (wildcards are `None` slots), tumbling `flush` closes even an empty window, EH interval queries are approximate at bucket boundaries, and KLL's weighted count drifts slightly after compaction.

## Try it

```bash
cargo test --all-features --locked    # everything, including experimental
cargo test --test conformance_kit     # the reusable battery kit
```

## Issue links

- Fixes #85 — NitroBatch undercounts by 1/rows (each sample updated one row)
- Fixes #84 — vacuous Nitro error-bound test (estimator returning 0 passed it)
- Addresses #24 — synthetic-data correctness/merge test suite for every sketch family
- Addresses the representative-formula item of #70: the portable twin now uses γᵏ(1+α) like core and DataDog; that issue's other items (release-mode merge-check gap, positive-only handling) stay open
