### PR TITLE
test(hydra): cover every counter variant across the subpopulation lattice

### DIFF
--- a/tests/e2e_frameworks.rs
+++ b/tests/e2e_frameworks.rs
@@ -439,12 +439,11 @@ fn hydra_subpopulation_counts_are_exact_on_a_sparse_grid() {
     );
 }
 
-/// `Hydra::update`'s `count` reaches the per-cell counter, so a subpopulation's
-/// frequency is its weighted total rather than its record count.
-#[test]
-fn hydra_weighted_updates_reach_the_cell_counter() {
+/// `Hydra::update`'s `count` reaches the per-cell counter, so a
+/// subpopulation's frequency is its weighted total, not its record count.
+fn assert_weighted_updates_reach_the_cell(counter: HydraCounter, slack: impl Fn(i64) -> f64) {
     let stream = labelled_stream(12_000, 4_240);
-    let mut hydra = lattice_hydra(4096);
+    let mut hydra = Hydra::with_schema(5, 4096, SCHEMA, counter).expect("three-column schema");
     let mut truth: HashMap<LatticeKey, i64> = HashMap::new();
 
     for (i, rec) in stream.iter().enumerate() {
@@ -461,18 +460,186 @@ fn hydra_weighted_updates_reach_the_cell_counter() {
     }
 
     let mut checked = 0usize;
+    let mut failures: Vec<String> = Vec::new();
     for ((key, endpoint), total) in &truth {
         if *total < 100 {
             continue;
         }
         checked += 1;
-        assert_eq!(
-            freq(&hydra, key, endpoint),
-            *total as f64,
-            "{key:?} x {endpoint}: weighted total"
-        );
+        let est = freq(&hydra, key, endpoint);
+        if (est - *total as f64).abs() > slack(*total) {
+            failures.push(format!(
+                "{key:?} x {endpoint}: weighted total {total}, est {est}"
+            ));
+        }
     }
+    failures.sort();
     assert!(checked > 200, "lattice too sparse to be meaningful");
+    assert!(
+        failures.is_empty(),
+        "{} of {checked} weighted subpopulations wrong:\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+#[test]
+fn hydra_cm_weighted_updates_reach_the_cell_counter() {
+    assert_weighted_updates_reach_the_cell(cell_cm(), |_| 0.0);
+}
+
+#[test]
+fn hydra_cs_weighted_updates_reach_the_cell_counter() {
+    // The kit's Count spec.
+    assert_weighted_updates_reach_the_cell(cell_cs(), |t| t as f64 * 0.06 + 25.0);
+}
+
+/// KLL treats `count` as multiplicity, so a weighted stream must answer the
+/// quantiles of the stream with each value repeated `count` times.
+#[test]
+fn hydra_kll_weighted_updates_repeat_the_value() {
+    let n = 20_000usize;
+    let keys = h2_keys(n, 4_760);
+    let values = common::normal_f64(n, 500.0, 80.0, 4_765);
+    let mut hydra = Hydra::with_schema(
+        5,
+        128,
+        ["region", "service"],
+        HydraCounter::KLL(KLL::init_kll_with_seed(200, 4_766)),
+    )
+    .expect("two-column schema");
+    let mut truth: HashMap<Vec<Option<&str>>, Vec<f64>> = HashMap::new();
+
+    for (i, (region, service)) in keys.iter().enumerate() {
+        let weight = 1 + (i % 4) as i64;
+        hydra
+            .update(
+                &[region, service],
+                &DataInput::F64(values[i]),
+                Some(weight as i32),
+            )
+            .expect("arity 2");
+        for key in h2_masks(region, service) {
+            let slot = truth.entry(key.to_vec()).or_default();
+            for _ in 0..weight {
+                slot.push(values[i]);
+            }
+        }
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+    for (key, vals) in truth {
+        let exact = common::NumericTruth::new(vals);
+        for q in conformance::DEFAULT_QUANTILE_QS {
+            let est = hydra
+                .query_key(&key, &HydraQuery::Quantile(q))
+                .expect("quantile");
+            let (lo, hi) = exact.quantile_band(q, 0.03);
+            if est < lo || est > hi {
+                failures.push(format!(
+                    "{key:?} q={q}: {est:.3} outside [{lo:.3}, {hi:.3}]"
+                ));
+            }
+        }
+    }
+    failures.sort();
+    assert!(
+        failures.is_empty(),
+        "weighted KLL quantiles out of rank band:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+/// HLL cells answer per-subpopulation distinct counts across the lattice.
+#[test]
+fn hydra_hll_head_subpopulation_cardinalities() {
+    let n = 40_000usize;
+    let keys = h2_keys(n, 4_730);
+    let ids = zipf_u64(n, 20_000, 0.2, 4_735);
+    let mut hydra = Hydra::with_schema(
+        5,
+        128,
+        ["region", "service"],
+        HydraCounter::HLL(Default::default()),
+    )
+    .expect("two-column schema");
+    let mut truth: HashMap<Vec<Option<&str>>, std::collections::HashSet<u64>> = HashMap::new();
+
+    for (i, (region, service)) in keys.iter().enumerate() {
+        hydra
+            .update(&[region, service], &DataInput::U32(ids[i] as u32), None)
+            .expect("arity 2");
+        for key in h2_masks(region, service) {
+            truth.entry(key.to_vec()).or_default().insert(ids[i]);
+        }
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+    for (key, distinct) in &truth {
+        let t = distinct.len() as f64;
+        let est = hydra
+            .query_key(key, &HydraQuery::Cardinality)
+            .expect("cardinality");
+        // CardinalitySpec::default() from the conformance kit.
+        if est < t * 0.97 || est > t * 1.03 {
+            failures.push(format!("{key:?}: distinct {t}, est {est:.0}"));
+        }
+    }
+    failures.sort();
+    assert_eq!(truth.len(), 8, "the 2^2-1 lattice over 2x2 domains");
+    assert!(
+        failures.is_empty(),
+        "HLL subpopulation cardinalities out of band:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+/// KLL cells answer per-subpopulation quantiles across the lattice.
+#[test]
+fn hydra_kll_head_subpopulation_quantiles() {
+    let n = 40_000usize;
+    let keys = h2_keys(n, 4_740);
+    let values = common::normal_f64(n, 500.0, 80.0, 4_745);
+    let mut hydra = Hydra::with_schema(
+        5,
+        128,
+        ["region", "service"],
+        HydraCounter::KLL(KLL::init_kll_with_seed(200, 4_746)),
+    )
+    .expect("two-column schema");
+    let mut truth: HashMap<Vec<Option<&str>>, Vec<f64>> = HashMap::new();
+
+    for (i, (region, service)) in keys.iter().enumerate() {
+        hydra
+            .update(&[region, service], &DataInput::F64(values[i]), None)
+            .expect("arity 2");
+        for key in h2_masks(region, service) {
+            truth.entry(key.to_vec()).or_default().push(values[i]);
+        }
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+    for (key, vals) in truth {
+        let exact = common::NumericTruth::new(vals);
+        for q in conformance::DEFAULT_QUANTILE_QS {
+            let est = hydra
+                .query_key(&key, &HydraQuery::Quantile(q))
+                .expect("quantile");
+            // QuantileSpec::default() from the conformance kit.
+            let (lo, hi) = exact.quantile_band(q, 0.03);
+            if est < lo || est > hi {
+                failures.push(format!(
+                    "{key:?} q={q}: {est:.3} outside [{lo:.3}, {hi:.3}]"
+                ));
+            }
+        }
+    }
+    failures.sort();
+    assert!(
+        failures.is_empty(),
+        "KLL subpopulation quantiles out of rank band:\n  {}",
+        failures.join("\n  ")
+    );
 }
 
 #[test]
@@ -1162,6 +1329,19 @@ fn assert_head_routes_to_the_right_cell<F>(
 }
 
 #[test]
+fn hydra_cs_head_routes_records_to_the_right_cell() {
+    let values = zipf_u64(30_000, ENDPOINTS.len(), 0.5, 4_615);
+    assert_head_routes_to_the_right_cell(
+        "CS",
+        cell_cs(),
+        30_000,
+        4_612,
+        move |i| DataInput::Str(ENDPOINTS[values[i] as usize]),
+        &[HydraQuery::Frequency(DataInput::Str(ENDPOINTS[0]))],
+    );
+}
+
+#[test]
 fn hydra_hll_head_routes_records_to_the_right_cell() {
     assert_head_routes_to_the_right_cell(
         "HLL",
@@ -1195,12 +1375,83 @@ fn hydra_univmon_head_routes_records_to_the_right_cell() {
         30_000,
         4_650,
         move |i| DataInput::U32(items[i] as u32),
-        &[HydraQuery::L1Norm],
+        &[HydraQuery::L1Norm, HydraQuery::Cardinality],
     );
 }
 
 /// L1 is a weighted record count, preserved exactly by the fan-out and the
 /// per-cell UnivMon.
+/// UnivMon cells answer L1, L2 and entropy per subpopulation across the
+/// lattice, over a weighted stream.
+#[test]
+fn hydra_univmon_head_subpopulation_metrics() {
+    let n = 40_000usize;
+    let keys = h2_keys(n, 4_770);
+    let items = zipf_u64(n, 1000, 1.2, 4_775);
+    let mut hydra = Hydra::with_schema(
+        5,
+        128,
+        ["region", "service"],
+        HydraCounter::UNIVERSAL(UnivMon::init_univmon(32, 5, 256, 8)),
+    )
+    .expect("two-column schema");
+    let mut truth: HashMap<Vec<Option<&str>>, FreqTruth> = HashMap::new();
+
+    for (i, (region, service)) in keys.iter().enumerate() {
+        let weight = 1 + (i % 7) as i64;
+        hydra
+            .update(
+                &[region, service],
+                &DataInput::U32(items[i] as u32),
+                Some(weight as i32),
+            )
+            .expect("arity 2");
+        for key in h2_masks(region, service) {
+            truth
+                .entry(key.to_vec())
+                .or_default()
+                .observe_weighted(items[i] as i64, weight);
+        }
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+    for (key, exact) in &truth {
+        let l1 = hydra.query_key(key, &HydraQuery::L1Norm).expect("L1");
+        if l1 != exact.total() as f64 {
+            failures.push(format!("{key:?}: L1 {l1} != exact {}", exact.total()));
+        }
+        // Bands from `univmon_weighted_metrics_and_fast_insert_parity`.
+        for (label, est, want, tol) in [
+            (
+                "L2",
+                hydra.query_key(key, &HydraQuery::L2Norm).expect("L2"),
+                exact.l2_norm(),
+                0.05,
+            ),
+            (
+                "entropy",
+                hydra.query_key(key, &HydraQuery::Entropy).expect("entropy"),
+                exact.entropy(true),
+                0.12,
+            ),
+        ] {
+            if est < want * (1.0 - tol) || est > want * (1.0 + tol) {
+                failures.push(format!(
+                    "{key:?}: {label} {est:.3} vs exact {want:.3} (tol {:.0}%)",
+                    tol * 100.0
+                ));
+            }
+        }
+    }
+    failures.sort();
+    assert_eq!(truth.len(), 8, "the 2^2-1 lattice over 2x2 domains");
+    assert!(
+        failures.is_empty(),
+        "UnivMon subpopulation metrics out of band:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
 #[test]
 fn hydra_univmon_head_l1_is_exact_per_subpopulation() {
     let n = 30_000usize;
@@ -1565,7 +1816,7 @@ fn tumbling_foldcms_weighted_windows_exact_counts() {
 
 #[test]
 fn ensemble_layer_mixed_cms_and_hll() {
-    let cms = CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(3, 4096);
+    let cms = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 4096);
     let ertl = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
     let mut ens: HashSketchEnsemble =
         HashSketchEnsemble::new(vec![EnsembleSketch::from(cms), EnsembleSketch::from(ertl)])


### PR DESCRIPTION
Follow-up to #100, which left only Count-Min at the full depth of the suite.
The other four `HydraCounter` variants had serde, merge and routing but no
per-subpopulation accuracy, and `Hydra::update`'s `count` argument was not
covered at all.

## Coverage after this PR

| | multi-column subpopulations | additive bound | merge | serde | routing | weights |
| --- | --- | --- | --- | --- | --- | --- |
| CM | exact | sparse + overloaded | exact | yes | yes | exact |
| Count Sketch | kit band | — | exact | yes | exact | kit band |
| HLL | ±3% | — | exact | yes | exact | n/a (ignores `count`) |
| KLL | rank 0.03 | — | rank band | yes | exact | rank 0.03 |
| UnivMon | L1 exact, L2 ±5%, entropy ±12%, cardinality exact vs standalone | — | L1 exact, L2 band | yes | exact | weighted stream |

The additive-bound column stays Count-Min-only by construction: it rests on
Count-Min never undercounting, which does not hold for a signed estimator.

## Added

- HLL per-subpopulation distinct counts across the `2^D - 1` lattice
- KLL per-subpopulation quantiles across the lattice
- UnivMon per-subpopulation L1, L2 and entropy over a weighted stream
- weighted updates for CM, Count Sketch and KLL
- Count Sketch routing

## Tolerances

Both new bands are the conformance kit's existing specs, with room to spare;
UnivMon's are the ones already used by
`univmon_weighted_metrics_and_fast_insert_parity`:

| Assertion | Band | Source | Worst measured |
| --- | --- | --- | --- |
| HLL subpopulation cardinality | ±3% | `CardinalitySpec::default()` | 1.32% |
| KLL subpopulation quantiles | rank 0.03 | `QuantileSpec::default()` | 0.0104 |
| UnivMon L2 | ±5% | `univmon_weighted_metrics_and_fast_insert_parity` | 0.12% |
| UnivMon entropy | ±12% | same | 3.09% |
| CM weighted updates | exact | — | 0 |
| Count Sketch weighted updates | `0.06·c + 25` | the Count spec in `conformance_kit.rs` | — |

## Why UnivMon cardinality has no numeric band

Feeding one stream to a Hydra cell and to a standalone `UnivMon` gives
byte-identical answers for all eight subpopulations, while both sit 1.5% to
11% off exact truth:

```
subpopulation                    truth     hydra      solo  hydra vs solo  solo vs truth
[Some("eu-west"), None]            982       875       875          0.00%        -10.90%
[Some("us-east"), None]            966       907       907          0.00%         -6.11%
[None, Some("auth")]               986       907       907          0.00%         -8.01%
[Some("us-east"), Some("auth")]    894       907       907          0.00%         +1.45%
```

So the error is `calc_card`'s, not the framework's, and a numeric band here
would be fitted to a seed rather than derived. Cardinality is held to the
routing property instead: the cell must answer exactly what a standalone
counter over the same records answers.

Two observations about `UnivMon::calc_card`, reported rather than acted on —
no UnivMon code is touched by this PR:

1. **Systematic underestimate.** Seven of eight subpopulations are negative.
2. **Quantised output.** `875`, `907` and `811` recur across subpopulations
   with different true cardinalities — `[eu-west, None]` (982 distinct) and
   `[eu-west, auth]` (944) both return 875; three subpopulations with truths of
   966, 986 and 894 all return 907.

## Verification

The commands from `.github/workflows/ci.yml`, verbatim:

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --all-features --locked --verbose` — pass (`e2e_frameworks` 34 tests)

All 43 tests introduced by #97 are byte-identical to their original form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
