### PR TITLE
Octo: close the gaps against the paper, and end the borrow before it crosses a thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ xxhash-rust = { version = "0.8", features = ["xxh32"] }
 core_affinity = { version = "0.8", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 
+[dev-dependencies]
+core_affinity = "0.8"
+
 [features]
 default = []
 experimental = []

--- a/docs/api/api_octo.md
+++ b/docs/api/api_octo.md
@@ -329,10 +329,55 @@ by one per Equation 2: down when the prediction falls below
 `(1−α)·Q`, up when it rises above `(1+α)·Q`, unchanged in between. Set
 `min_threshold` from `threshold_for_error` to hold an accuracy floor.
 
+### Plans: nothing borrowed crosses a thread
+
+A `DataInput` may borrow, and a worker runs on another thread, so the
+borrow has to end before the hand-off. An `OctoPlan` is the object that
+makes that possible: it stays on the dispatching thread and holds the
+geometry, which both of its jobs need — building workers, and converting
+an input into the borrow-free payload that actually crosses.
+
+```rust
+pub trait OctoPlan: Send + 'static {
+    type Worker: OctoWorker;
+    fn worker(&self, worker_id: usize) -> Self::Worker;
+    fn prepare(&self, input: &DataInput<'_>) -> <Self::Worker as OctoWorker>::Payload;
+}
+```
+
+`insert` hashes for partitioning and calls `prepare`, both on the calling
+thread, so a borrowed key is finished with by the time it returns — the
+key's owner never has to outlive the runtime.
+
+What crosses follows from what the worker needs. A worker that only
+hashes gets hashes and no copy; one that must store the key gets an owned
+copy, made once at the hand-off.
+
+| Worker | Payload | Copies the key |
+| --- | --- | --- |
+| CountMin, Count | `RowHashes` (`SmallVec<[u64; 8]>`) | no — inline for any realistic row count |
+| HyperLogLog | `u64` | no |
+| DDSketch | `Option<f64>` | no |
+| CountMin/Count top-k | `KeyedHashes` | yes, unavoidably |
+| UnivMon | `UnivMonInput` | yes, unavoidably |
+
+`UnivMonInput` hashes only the layers a key actually reaches. Layer depth
+is geometric, so that is nearly always one or two.
+
+The shipped plans are `CmOctoPlan`, `CountOctoPlan`, `CmTopKOctoPlan`,
+`CountTopKOctoPlan`, `HllOctoPlan`, `DdOctoPlan` and `UnivMonOctoPlan`.
+Each takes the same dimensions its worker did, plus an optional shared
+`OctoThreshold`:
+
+```rust
+let plan = CmOctoPlan::new(4, 4096);
+let result = run_octo(&inputs, &config, plan, || CmOctoAggregator::new(4, 4096));
+```
+
 ### OctoRuntime (Streaming)
 
 ```rust
-fn new<F, PF>(config: &OctoConfig, worker_factory: F, parent_factory: PF) -> Self
+fn new<PF>(config: &OctoConfig, plan: L, parent_factory: PF) -> Self
 fn insert(&mut self, input: DataInput<'_>)
 fn insert_batch(&mut self, inputs: &[DataInput<'_>])
 fn flush(&mut self)
@@ -372,10 +417,10 @@ and `L2hhWorkerSketch` each expose `flush` directly.
 ### run_octo (Batch)
 
 ```rust
-pub fn run_octo<W, P>(
+pub fn run_octo<L, P>(
     inputs: &[DataInput<'_>],
     config: &OctoConfig,
-    worker_factory: impl Fn(usize) -> W,
+    plan: L,
     parent_factory: impl FnOnce() -> P,
 ) -> OctoResult<P>
 ```
@@ -399,19 +444,14 @@ heap, which is Algorithm 2.
 ### Sharing a threshold across the fleet
 
 ```rust
-let tau = OctoThreshold::new(31);
+let plan = CmOctoPlan::with_threshold(4, 4096, OctoThreshold::new(31));
 let config = OctoConfig {
     num_workers: 8,
-    threshold: tau.clone(),
+    threshold: plan.threshold().clone(),
     adaptive: Some(OctoAdaptiveThreshold::default()),
     ..OctoConfig::default()
 };
-let result = run_octo(
-    &inputs,
-    &config,
-    { let tau = tau.clone(); move |_| CmOctoWorker::with_threshold(4, 4096, tau.clone()) },
-    || CmOctoAggregator::new(4, 4096),
-);
+let result = run_octo(&inputs, &config, plan, || CmOctoAggregator::new(4, 4096));
 ```
 
 ## Caveats

--- a/docs/api/api_octo.md
+++ b/docs/api/api_octo.md
@@ -6,8 +6,16 @@ Status: `Ready`
 
 Delta-promotion primitives for multi-threaded sketch updates, based on
 the OctoSketch architecture (NSDI 2024). Child sketches maintain small
-counters and emit compact deltas when a promotion threshold is reached;
-a parent sketch absorbs those deltas at full precision.
+counters and emit compact deltas when a promotion threshold τ is
+reached; a parent sketch absorbs those deltas at full precision.
+
+The paper's three ideas map onto this module as:
+
+| Paper | Here |
+| --- | --- |
+| Idea 1 — change-based updates (§3.2) | `OctoWorker` emits one counter at a time |
+| Idea 2 — adaptive resource allocation (§4.3) | `OctoAdaptiveThreshold` drives a shared `OctoThreshold` |
+| Idea 3 — reconstructed data structures (§3.2) | `CmWorkerSketch` / `CountWorkerSketch` drop key storage and use one-byte counters; only the `*TopK*` aggregators hold a heap |
 
 ### Two Usage Levels
 
@@ -22,31 +30,64 @@ a parent sketch absorbs those deltas at full precision.
 Defined in `src/sketches/octo_delta.rs`.
 
 ```rust
-pub struct CmDelta {
-    pub row: u16,
-    pub col: u16,
-    pub value: u8,
-}
+pub struct CmDelta    { pub row: u32, pub col: u32, pub value: u32 }
+pub struct CountDelta { pub row: u32, pub col: u32, pub value: i32 }
+pub struct HllDelta   { pub pos: u32, pub value: u8 }
+pub struct DdDelta    { pub index: i32, pub value: u64 }
 
-pub struct CountDelta {
-    pub row: u16,
-    pub col: u16,
-    pub value: i8,
-}
-
-pub struct HllDelta {
-    pub pos: u16,
-    pub value: u8,
-}
+pub struct KeyedCmDelta    { pub key: HeapItem, pub delta: CmDelta }
+pub struct KeyedCountDelta { pub key: HeapItem, pub delta: CountDelta }
 ```
+
+Indices are `u32`, so any geometry the sketch itself supports can be
+addressed. The keyed forms carry the flow key the paper's 4-tuple
+message includes, which is what lets an aggregator keep a heavy-hitter
+heap the workers no longer maintain.
 
 ### Promotion Thresholds
 
-| Sketch | Constant | Value | Trigger |
-| --- | --- | --- | --- |
-| CountMin | `CM_PROMASK` | `0x1f` (31) | Emit when counter reaches a multiple of `CM_PROMASK` |
-| Count | `COUNT_PROMASK` | `0x1f` (31) | Emit when `\|counter\| >= COUNT_PROMASK` |
-| HyperLogLog | `HLL_PROMASK` | `0` | Emit on every register improvement |
+τ is a runtime value, not a constant. The constants below are only the
+defaults used when a worker is built without an explicit threshold.
+
+| Sketch | Default | Rule |
+| --- | --- | --- |
+| CountMin | `CM_PROMASK` = 31 | Emit and clear when a counter reaches τ |
+| Count | `COUNT_PROMASK` = 31 | Emit and clear when `\|counter\|` reaches τ |
+| DDSketch | `DD_PROMASK` = 4 | Emit and clear when a bucket reaches τ |
+| UnivMon | `UNIVMON_PROMASK` = 64 | As Count, with τ halved per layer |
+| HyperLogLog | `HLL_PROMASK` = 0 | Emit when `\|2^C' - 2^C\| >= 2^τ`; never cleared |
+
+`DD_PROMASK` is much lower on purpose: a bucket that never reaches τ
+never reaches the aggregator at all, so DDSketch loses its sparse tail
+rather than merely lagging. Size it against your samples-per-bucket, and
+read `DdWorkerSketch::held_back` to bound the rank error it costs.
+
+`HLL_PROMASK = 0` makes the parent's registers bit-identical to a
+single-threaded sketch at any cardinality — stronger than the paper's
+Theorem 4, which only guarantees equality above `2·α_m·m²·2^(τ-2)`. The
+cost is that every register improvement is sent.
+
+### Choosing τ from an accuracy target
+
+```rust
+pub fn threshold_for_error(epsilon: f64, l1: f64, k_prime: usize) -> u32
+```
+
+Equation 4 of the paper, `τ = εL1/k'`. `k_prime` is the number of
+workers one flow may reach: 1 under `OctoPartition::HashByKey`, the
+worker count under `OctoPartition::RoundRobin`.
+
+### Shared, adjustable τ
+
+```rust
+let tau = OctoThreshold::new(31);
+tau.get(); tau.set(64); tau.increase(1); tau.decrease(1);
+```
+
+`OctoThreshold` is an `Arc<AtomicU32>` clamped to `1..=MAX_PROMASK`
+(255, the width of a worker counter). Clone it into every worker and
+into `OctoConfig::threshold` so the aggregator's controller and the
+workers refer to the same value.
 
 ## CountMin Delta API
 
@@ -55,15 +96,15 @@ where `S::Counter = i32`.
 
 ```rust
 fn insert_emit_delta(&mut self, value: &DataInput, emit: &mut impl FnMut(CmDelta))
+fn insert_emit_delta_with_threshold(&mut self, value: &DataInput, threshold: u32, emit: &mut impl FnMut(CmDelta))
+fn insert_emit_keyed_delta_with_threshold(&mut self, value: &DataInput, threshold: u32, emit: &mut impl FnMut(KeyedCmDelta))
 fn apply_delta(&mut self, delta: CmDelta)
 ```
 
-`insert_emit_delta` inserts a key and calls `emit` with one `CmDelta` per
-row when the row counter reaches a multiple of `CM_PROMASK`. The child
-counter keeps running; the delta carries the threshold value.
-
-`apply_delta` increments the parent counter at `(row, col)` by
-`delta.value`.
+`insert_emit_delta` inserts a key and, for each row counter that reaches
+τ, emits a delta carrying that counter's value and clears it — Algorithm
+1 of the paper. What the child still holds plus what the parent received
+always reconstructs a single-threaded pass.
 
 ### CountMin Delta Example
 
@@ -82,67 +123,142 @@ child.insert_emit_delta(&key, &mut |delta: CmDelta| {
 
 ## Count Sketch Delta API
 
-Available on `Count<S, RegularPath, H>` and `Count<S, FastPath, H>`
-where `S::Counter = i32`.
+Same shape as CountMin, on `Count<S, RegularPath, H>` and
+`Count<S, FastPath, H>` where `S::Counter = i32`. Counters are signed, so
+the threshold is applied to `|counter|` (§4.4).
 
 ```rust
 fn insert_emit_delta(&mut self, value: &DataInput, emit: &mut impl FnMut(CountDelta))
+fn insert_emit_delta_with_threshold(&mut self, value: &DataInput, threshold: u32, emit: &mut impl FnMut(CountDelta))
+fn insert_emit_keyed_delta_with_threshold(&mut self, value: &DataInput, threshold: u32, emit: &mut impl FnMut(KeyedCountDelta))
 fn apply_delta(&mut self, delta: CountDelta)
-```
-
-`insert_emit_delta` inserts a key with its per-row sign and calls `emit`
-when `|counter| >= COUNT_PROMASK`. The delta carries the signed counter
-value. After emission, the child counter resets to zero.
-
-`apply_delta` increments the parent counter at `(row, col)` by
-`delta.value` (signed).
-
-### Count Sketch Delta Example
-
-```rust
-use asap_sketchlib::{Count, RegularPath, DataInput, Vector2D};
-use asap_sketchlib::sketches::octo_delta::CountDelta;
-
-let mut child = Count::<Vector2D<i32>, RegularPath>::with_dimensions(3, 4096);
-let mut parent = Count::<Vector2D<i32>, RegularPath>::with_dimensions(3, 4096);
-
-let key = DataInput::U64(99);
-child.insert_emit_delta(&key, &mut |delta: CountDelta| {
-    parent.apply_delta(delta);
-});
 ```
 
 ## HyperLogLog Delta API
 
-Available on all `HyperLogLogImpl<Variant, Registers, H>` variants
-(Classic, ErtlMLE, and any precision level).
+Available on all `HyperLogLogImpl<Variant, Registers, H>` variants.
 
 ```rust
 fn insert_emit_delta(&mut self, obj: &DataInput, emit: &mut impl FnMut(HllDelta))
+fn insert_emit_delta_with_threshold(&mut self, obj: &DataInput, threshold: u8, emit: &mut impl FnMut(HllDelta))
 fn insert_emit_delta_with_hash(&mut self, hashed_val: u64, emit: &mut impl FnMut(HllDelta))
+fn insert_emit_delta_with_hash_and_threshold(&mut self, hashed_val: u64, threshold: u8, emit: &mut impl FnMut(HllDelta))
 fn apply_delta(&mut self, delta: HllDelta)
 ```
-
-`insert_emit_delta` calls `emit` only when a register improves (the new
-leading-zero count exceeds the stored value). Since `HLL_PROMASK = 0`,
-every improvement is emitted immediately.
 
 `apply_delta` applies a max-update: the parent register is set to
 `max(current, delta.value)`.
 
-### HyperLogLog Example
+## DDSketch Delta API
 
 ```rust
-use asap_sketchlib::{HyperLogLog, Classic, DataInput};
-use asap_sketchlib::sketches::octo_delta::HllDelta;
-
-let mut child = HyperLogLog::<Classic>::default();
-let mut parent = HyperLogLog::<Classic>::default();
-
-child.insert_emit_delta(&DataInput::U64(1), &mut |delta: HllDelta| {
-    parent.apply_delta(delta);
-});
+fn bucket_index_for(&self, value: f64) -> Option<i32>
+fn apply_delta(&mut self, delta: DdDelta)
 ```
+
+`bucket_index_for` exposes the logarithmic mapping so a worker can hold
+one-byte counters over the same bucket space; it returns `None` for any
+value `add` would itself drop. `apply_delta` advances `count` exactly and
+advances `sum`/`min`/`max` with the bucket's representative value — the
+same α-bounded estimate a deserialize-and-recompute produces.
+
+## UnivMon Delta API
+
+```rust
+fn bottom_layer_for(&self, key: &DataInput) -> usize
+fn apply_layered_delta(&mut self, delta: &LayeredCountDelta, fidelity: UnivMonDeltaFidelity)
+fn set_total_weight(&mut self, weight: usize)
+fn mark_candidates_incomplete(&mut self)
+fn candidates_complete(&self) -> &[bool]
+```
+
+```rust
+pub struct LayeredCountDelta {
+    pub layer: u32,
+    pub key: HeapItem,
+    pub delta: CountDelta,
+    pub worker_id: u32,
+    pub weight_total: u64,
+}
+```
+
+An insert reaches layers `0..=bottom_layer_for(key)`, which is a pure
+function of the key's hash, so a worker selects exactly the layers a
+single-threaded insert would. `apply_layered_delta` writes the counter,
+re-reads the layer's estimate and updates that layer's heap — Algorithm
+2, per layer.
+
+**Where the speed comes from, and where it stops.** A worker's per-insert
+work is a hash and a few one-byte increments; the L2 accumulator, the
+median estimate and the heavy-hitter heap all move to the aggregator,
+which touches them once per *promotion* rather than once per insert.
+Measured with `cargo run --release --example octo_throughput_probe` on a
+2M-insert Zipf stream (heap 64, 5x1024, 12 layers):
+
+| τ | worker | vs single-threaded | deltas/insert | aggregator | sustainable | gap to ideal |
+| --- | --- | --- | --- | --- | --- | --- |
+| 16 | 16.7 M/s | 65x | 1.435 | 0.42 M/s | 0.29 M/s | 0.0000 |
+| 31 | 18.6 M/s | 72x | 1.000 | 0.43 M/s | 0.43 M/s | 0.0002 |
+| 64 | 18.7 M/s | 73x | 0.441 | 0.44 M/s | 0.99 M/s | 0.0002 |
+| 128 | 21.7 M/s | 84x | 0.244 | 0.46 M/s | 1.90 M/s | 0.0161 |
+| 255 | 22.2 M/s | 86x | 0.168 | 0.50 M/s | 2.96 M/s | 0.0195 |
+
+Single-threaded `UnivMon::insert` runs at 0.26 M/s on the same stream, so
+the worker is 65-86x faster per insert — but one aggregator serves every
+worker, so the pipeline's ceiling is the aggregator's rate divided by
+deltas per insert. That is why τ decides everything and why the
+aggregator drives it (§4.3).
+
+The aggregator's own ceiling is `HHHeap`, not the delta protocol: its
+rate falls off as `1/heap_size` (6.84, 1.88, 0.44, 0.13 Mdelta/s at
+capacities 4, 16, 64, 256) because the heap rebuilds its whole position
+index on every accepted update. Single-threaded UnivMon pays the same
+cost on every insert rather than every promotion, which is most of the
+gap between 0.26 M/s and 22 M/s.
+
+**The threshold is scaled per layer.** Layer L only receives the keys that
+survive L coin flips, so it carries roughly `n / 2^L` of the stream. One
+threshold across the whole pyramid is sized for layer 0 and starves the
+deep layers outright — and those are exactly the layers the recursive
+estimator leans on for cardinality. `univmon_layer_threshold(base, layer)`
+halves τ per layer with a floor of 1; measured on a 60k Zipf stream with
+12 layers, a flat τ=31 emptied layers 10 and 11 and collapsed the
+cardinality estimate from 3387 to 187, while the scaled rule tracks the
+single-core answer to 0.6%.
+
+Three pieces of state a delta stream would otherwise lose are handled
+explicitly:
+
+- **L2 per row.** `CountL2HH` carries `l2[row] += new² − old²` on every
+  counter write, so `CountL2HH::apply_delta` does the same fix-up and a
+  parent fed only deltas reports the same `get_l2` as one fed the stream.
+- **Total weight.** `bucket_size` is what g-sum queries divide by and it
+  cannot be recovered from thresholded counters, so each delta carries the
+  emitting worker's running total. The aggregator keeps the newest report
+  per worker and sums them — no extra messages, and the total trails by
+  only what arrived after each worker's last promotion.
+- **Candidate completeness.** See the caveats below.
+
+The worker mirrors `CountL2HH`'s cell mapping through the shared
+`l2hh_cell_for_row`, not a copy of it: a UnivMon layer slices one
+128-bit hash into per-row columns and takes each row's sign from a
+different high bit, under a per-layer seed, so a hand-written copy would
+be easy to drift.
+
+## Compact Worker Sketches
+
+```rust
+pub struct CmWorkerSketch { /* Vec<u8> */ }
+pub struct CountWorkerSketch { /* Vec<i8> */ }
+pub struct DdWorkerSketch { /* HashMap<i32, u8> */ }
+pub struct L2hhWorkerSketch { /* Vec<i8>, one per UnivMon layer */ }
+```
+
+A worker counter is cleared the moment it reaches τ, so it never exceeds
+one byte. Against the 32-bit counters a full `CountMin` uses that is the
+paper's 4× memory saving, and the workers keep no flow-key storage at
+all. Use these when you drive the protocol yourself; `CmOctoWorker` and
+friends already do.
 
 ---
 
@@ -152,18 +268,54 @@ child.insert_emit_delta(&DataInput::U64(1), &mut |delta: HllDelta| {
 > Enable it with `features = ["octo-runtime"]` in your `Cargo.toml`.
 > This pulls in `core_affinity` and `crossbeam-channel` as dependencies.
 
-For users who want a turnkey multi-threaded pipeline without managing
-threads directly.
-
 ### OctoConfig
 
 ```rust
 pub struct OctoConfig {
-    pub num_workers: usize,      // default: 4
-    pub pin_cores: bool,         // default: true
-    pub queue_capacity: usize,   // default: 65536
+    pub num_workers: usize,                          // default: 4
+    pub pin_cores: bool,                             // default: true
+    pub queue_capacity: usize,                       // default: 65536
+    pub threshold: OctoThreshold,                    // default: CM_PROMASK
+    pub partition: OctoPartition,                    // default: HashByKey
+    pub adaptive: Option<OctoAdaptiveThreshold>,     // default: None
 }
 ```
+
+Build one with `..OctoConfig::default()` so later fields stay additive.
+
+### OctoPartition
+
+```rust
+pub enum OctoPartition { HashByKey, RoundRobin }
+```
+
+`HashByKey` — the default and the paper's setting — sends one flow to one
+worker, so `k'` is 1 and the additive `k'τ` term in the error bounds is
+as small as it can be. `RoundRobin` spreads load perfectly even under a
+skewed key distribution, at the cost of `k' = k`.
+
+Note that either way a *counter* is shared by whatever flows hash into
+it, and each worker may hold back up to τ of its own share, so the
+provable per-counter gap to a single-threaded sketch is `k·τ`. `k'τ`
+bounds only the queried flow's own held-back count.
+
+### OctoAdaptiveThreshold
+
+```rust
+pub struct OctoAdaptiveThreshold {
+    pub target_queue_len: usize,   // Q, default 10
+    pub alpha: f64,                // dead band, default 0.25
+    pub interval: Duration,        // default 100µs
+    pub min_threshold: u32,
+    pub max_threshold: u32,
+}
+```
+
+The aggregator samples total queue occupancy every `interval`, predicts
+the next window with Equation 1 (`Q̂ₜ₊₁ = Qₜ + (Qₜ − Qₜ₋₁)`), and moves τ
+by one per Equation 2: down when the prediction falls below
+`(1−α)·Q`, up when it rises above `(1+α)·Q`, unchanged in between. Set
+`min_threshold` from `threshold_for_error` to hold an accuracy floor.
 
 ### OctoRuntime (Streaming)
 
@@ -192,17 +344,65 @@ pub fn run_octo<W, P>(
 | Sketch | Worker | Aggregator | Delta Type |
 | --- | --- | --- | --- |
 | CountMin | `CmOctoWorker` | `CmOctoAggregator` | `CmDelta` |
+| CountMin + top-k | `CmTopKOctoWorker` | `CmTopKOctoAggregator` | `KeyedCmDelta` |
 | Count | `CountOctoWorker` | `CountOctoAggregator` | `CountDelta` |
+| Count + top-k | `CountTopKOctoWorker` | `CountTopKOctoAggregator` | `KeyedCountDelta` |
+| DDSketch | `DdOctoWorker` | `DdOctoAggregator` | `DdDelta` |
+| UnivMon | `UnivMonOctoWorker` | `UnivMonOctoAggregator` | `LayeredCountDelta` |
 | HyperLogLog | `HllOctoWorker` | `HllOctoAggregator` | `HllDelta` |
+
+The `*TopK*` pairs hold the pipeline's only heavy-hitter heap, in the
+aggregator: each keyed delta updates the parent counter and then the
+heap, which is Algorithm 2.
+
+### Sharing a threshold across the fleet
+
+```rust
+let tau = OctoThreshold::new(31);
+let config = OctoConfig {
+    num_workers: 8,
+    threshold: tau.clone(),
+    adaptive: Some(OctoAdaptiveThreshold::default()),
+    ..OctoConfig::default()
+};
+let result = run_octo(
+    &inputs,
+    &config,
+    { let tau = tau.clone(); move |_| CmOctoWorker::with_threshold(4, 4096, tau.clone()) },
+    || CmOctoAggregator::new(4, 4096),
+);
+```
 
 ## Caveats
 
-- Child counters below the promotion threshold are lost when the child
-  is dropped (slight under-count for CMS/Count; no loss for HLL since
-  every improvement is emitted).
+- Counts below τ are lost when a worker is dropped: at most τ per cell
+  per worker for CMS/Count, at most `held_back()` samples for DDSketch,
+  nothing for HLL at the default threshold.
+- DDSketch loses whole buckets rather than lagging on them. Keep τ small
+  and check `held_back()`.
+- The runtime's `insert` dispatches from the calling thread, so that
+  thread is a serialization point. The paper instead has each worker pull
+  from its own NIC queue.
 - Core pinning silently falls back if the platform has fewer cores than
   `num_workers + 1`.
 - `insert` after `close` panics.
+- A UnivMon layer that thresholds cannot call its candidate set complete,
+  so `candidates_complete()` reads false on exactly those layers. Queries
+  then take the conservative branch of `heavy_threshold` instead of
+  overcounting. Deep layers, whose scaled threshold floors at 1, keep the
+  heap's own verdict. At a base threshold of 1 a single worker reproduces
+  a single-threaded UnivMon exactly - counters, L2, heaps, total weight
+  and g-sum alike.
+- DDSketch is the one integrated sketch where delta promotion does not pay
+  off. A lagging Count-Min counter is still counted, just low; a DDSketch
+  bucket that never reaches τ is absent, and a quantile is a statement
+  about where mass sits. On a skewed 200k stream the measured trade is
+  τ=1 → exact at 200k messages, τ=2 → 7x ideal error, τ=4 → 19x, τ=8 →
+  41x, while periodic merge stays at ideal for 3x the traffic. Prefer
+  merge for DDSketch unless τ can be 1.
+- Not yet wired up: CocoSketch and Elastic sketch. Both replace a whole
+  `(key, counter)` bucket rather than incrementing a cell, so they need a
+  bucket-valued delta rather than the cell-valued ones here.
 
 ## Status
 

--- a/docs/api/api_octo.md
+++ b/docs/api/api_octo.md
@@ -335,10 +335,39 @@ by one per Equation 2: down when the prediction falls below
 fn new<F, PF>(config: &OctoConfig, worker_factory: F, parent_factory: PF) -> Self
 fn insert(&mut self, input: DataInput<'_>)
 fn insert_batch(&mut self, inputs: &[DataInput<'_>])
+fn flush(&mut self)
 fn read_handle(&self) -> OctoReadHandle<P>
 fn close(&self)
 fn finish(self) -> OctoResult<P>
 ```
+
+### Flushing before a query
+
+Between promotions a worker holds every counter still under τ. For
+Count-Min and Count that only leaves the parent low by under τ per cell.
+For DDSketch, or a HyperLogLog running a positive threshold, an
+un-promoted cell is *absent* from the parent rather than lagging — and a
+quantile or a cardinality is exactly a statement about which cells
+exist, so those queries are wrong without bound rather than within α.
+
+`flush` hands over every residual counter and waits for the aggregator to
+apply it, so the parent answers against every input accepted so far. It
+is the point at which a stream is handed over for querying. `finish`
+flushes too, so a completed run always answers against the whole stream —
+a flushed Count-Min parent equals a single-threaded pass cell for cell.
+
+It costs one message per non-empty cell, which is as much as shipping the
+sketch, so call it when a query needs to be right rather than on a timer.
+Inserting afterwards is fine; a flush does not seal the runtime.
+
+`OctoWorker::flush` defaults to doing nothing. The `*TopK*` and UnivMon
+workers keep that default on purpose: every delta they send carries the
+key that produced it, and a worker keeps no key storage, so a residual
+cell cannot be attributed back to a key. Their parents stay low by under
+τ per cell, and their heavy-hitter heaps do not depend on the residue.
+
+At the low level, `CmWorkerSketch`, `CountWorkerSketch`, `DdWorkerSketch`
+and `L2hhWorkerSketch` each expose `flush` directly.
 
 ### run_octo (Batch)
 
@@ -387,16 +416,25 @@ let result = run_octo(
 
 ## Caveats
 
-- Counts below τ are lost when a worker is dropped: at most τ per cell
-  per worker for CMS/Count, at most `held_back()` samples for DDSketch,
-  nothing for HLL at the default threshold.
-- DDSketch loses whole buckets rather than lagging on them. Keep τ small
-  and check `held_back()`.
+- Counts below τ reach the parent only at a flush. `finish` flushes, and
+  `OctoRuntime::flush` does it mid-stream; a worker driven directly at the
+  low level must be flushed by its caller. The keyed workers cannot flush
+  at all — see above.
+- DDSketch loses whole buckets rather than lagging on them, so read it
+  only after a flush. Between flushes, keep τ small and check
+  `held_back()`; measured on a skewed 200k stream, τ=2 costs 7x the
+  ideal quantile error, τ=4 costs 19x and τ=8 costs 41x, while periodic
+  sketch-merge stays at ideal for 3x the traffic.
+- Core pinning is a silent no-op on Apple Silicon: macOS exposes
+  `thread_policy_set(THREAD_AFFINITY_POLICY)` but arm64 rejects it, and
+  `core_affinity::get_core_ids` reports a count without testing whether
+  pinning works. `pin_cores: true` costs nothing there but buys nothing
+  either.
 - The runtime's `insert` dispatches from the calling thread, so that
   thread is a serialization point. The paper instead has each worker pull
   from its own NIC queue.
 - Core pinning silently falls back if the platform has fewer cores than
-  `num_workers + 1`.
+  `num_workers + 1`, and is unavailable outright on Apple Silicon.
 - `insert` after `close` panics.
 - A UnivMon layer that thresholds cannot call its candidate set complete,
   so `candidates_complete()` reads false on exactly those layers. Queries

--- a/docs/api/api_octo.md
+++ b/docs/api/api_octo.md
@@ -229,8 +229,9 @@ deep layers outright — and those are exactly the layers the recursive
 estimator leans on for cardinality. `univmon_layer_threshold(base, layer)`
 halves τ per layer with a floor of 1; measured on a 60k Zipf stream with
 12 layers, a flat τ=31 emptied layers 10 and 11 and collapsed the
-cardinality estimate from 3387 to 187, while the scaled rule tracks the
-single-core answer to 0.6%.
+cardinality estimate from 3387 to 187, while the scaled rule reproduced
+the single-core estimate of 3387. Measured by
+`a_flat_threshold_starves_the_deep_univmon_layers`.
 
 Three pieces of state a delta stream would otherwise lose are handled
 explicitly:
@@ -302,7 +303,7 @@ skewed key distribution, at the cost of `k' = k`.
 
 Note that either way a *counter* is shared by whatever flows hash into
 it, and each worker may hold back up to τ of its own share, so the
-provable per-counter gap to a single-threaded sketch is `k·τ`. `k'τ`
+provable per-counter gap to a single-threaded sketch is `workers · (τ - 1)`. `k'τ`
 bounds only the queried flow's own held-back count.
 
 ### OctoAdaptiveThreshold
@@ -365,8 +366,14 @@ Each takes the same dimensions its worker did, plus an optional shared
 
 ```rust
 let plan = CmOctoPlan::new(4, 4096);
-let result = run_octo(&inputs, &config, plan, || CmOctoAggregator::new(4, 4096));
+let result = run_octo(&inputs, &config, plan.clone(), || plan.aggregator());
 ```
+
+Build the parent from the plan. Worker and parent geometry are two
+independent arguments and a mismatch is silent: every delta names a row
+the parent has, the rows past the worker's stay zero, and Count-Min's
+min-over-rows estimate is zero for every key. Every plan has an
+`aggregator()`.
 
 ### OctoRuntime (Streaming)
 
@@ -383,7 +390,8 @@ fn finish(self) -> OctoResult<P>
 ### Flushing before a query
 
 Between promotions a worker holds every counter still under τ. For
-Count-Min and Count that only leaves the parent low by under τ per cell.
+Count-Min and Count that only leaves the parent low - by up to
+`workers · (τ - 1)` per cell, since each worker holds its own residue.
 For DDSketch, or a HyperLogLog running a positive threshold, an
 un-promoted cell is *absent* from the parent rather than lagging — and a
 quantile or a cardinality is exactly a statement about which cells
@@ -397,13 +405,20 @@ a flushed Count-Min parent equals a single-threaded pass cell for cell.
 
 It costs one message per non-empty cell, which is as much as shipping the
 sketch, so call it when a query needs to be right rather than on a timer.
-Inserting afterwards is fine; a flush does not seal the runtime.
+Inserting afterwards is fine; a flush does not seal the runtime. After
+`close` it returns immediately without draining — `close` has already
+asked every worker to flush, but nothing waits for that to land, so read
+the result through `finish` rather than a live handle.
 
 `OctoWorker::flush` defaults to doing nothing. The `*TopK*` and UnivMon
 workers keep that default on purpose: every delta they send carries the
 key that produced it, and a worker keeps no key storage, so a residual
 cell cannot be attributed back to a key. Their parents stay low by under
-τ per cell, and their heavy-hitter heaps do not depend on the residue.
+`workers · (τ - 1)` per cell, and - the sharper consequence - a key that
+has never promoted is absent from the heap entirely rather than merely
+undercounted. A key promotes the first time an increment it caused takes
+some row to τ on its worker, which is its τ-th occurrence only while its
+cells are collision-free; collisions move it either way.
 
 At the low level, `CmWorkerSketch`, `CountWorkerSketch`, `DdWorkerSketch`
 and `L2hhWorkerSketch` each expose `flush` directly.
@@ -459,16 +474,15 @@ let result = run_octo(&inputs, &config, plan, || CmOctoAggregator::new(4, 4096))
   `held_back()`; measured on a skewed 200k stream, τ=2 costs 7x the
   ideal quantile error, τ=4 costs 19x and τ=8 costs 41x, while periodic
   sketch-merge stays at ideal for 3x the traffic.
-- Core pinning is a silent no-op on Apple Silicon: macOS exposes
-  `thread_policy_set(THREAD_AFFINITY_POLICY)` but arm64 rejects it, and
-  `core_affinity::get_core_ids` reports a count without testing whether
-  pinning works. `pin_cores: true` costs nothing there but buys nothing
-  either.
+- Core pinning silently falls back when the platform has fewer cores than
+  `num_workers + 1`, and is a no-op outright on Apple Silicon: macOS
+  exposes `thread_policy_set(THREAD_AFFINITY_POLICY)` but arm64 rejects
+  it, while `core_affinity::get_core_ids` reports a count without testing
+  whether pinning works. The throughput probe prints which case you are
+  in.
 - The runtime's `insert` dispatches from the calling thread, so that
   thread is a serialization point. The paper instead has each worker pull
   from its own NIC queue.
-- Core pinning silently falls back if the platform has fewer cores than
-  `num_workers + 1`, and is unavailable outright on Apple Silicon.
 - `insert` after `close` panics.
 - A UnivMon layer that thresholds cannot call its candidate set complete,
   so `candidates_complete()` reads false on exactly those layers. Queries

--- a/docs/api/api_octo.md
+++ b/docs/api/api_octo.md
@@ -54,8 +54,8 @@ defaults used when a worker is built without an explicit threshold.
 | CountMin | `CM_PROMASK` = 31 | Emit and clear when a counter reaches τ |
 | Count | `COUNT_PROMASK` = 31 | Emit and clear when `\|counter\|` reaches τ |
 | DDSketch | `DD_PROMASK` = 4 | Emit and clear when a bucket reaches τ |
-| UnivMon | `UNIVMON_PROMASK` = 64 | As Count, with τ halved per layer |
 | HyperLogLog | `HLL_PROMASK` = 0 | Emit when `\|2^C' - 2^C\| >= 2^τ`; never cleared |
+| UnivMon | `UNIVMON_PROMASK` = 64 | As Count, with τ halved per layer |
 
 `DD_PROMASK` is much lower on purpose: a bucket that never reaches τ
 never reaches the aggregator at all, so DDSketch loses its sparse tail
@@ -66,6 +66,15 @@ read `DdWorkerSketch::held_back` to bound the rank error it costs.
 single-threaded sketch at any cardinality — stronger than the paper's
 Theorem 4, which only guarantees equality above `2·α_m·m²·2^(τ-2)`. The
 cost is that every register improvement is sent.
+
+In practice 0 is the only HLL threshold worth using below that
+precondition. A register the worker has held back reads at the parent as
+an *empty* bucket rather than a low one, so the harmonic mean the
+estimator is built on collapses: over 50k distinct keys, τ=4 estimates
+about 3.2k. `HllOctoWorker::with_threshold` panics outright on a τ no
+register gain could ever reach (`>= max_hll_threshold(precision)`),
+because such a worker promotes nothing at all and leaves the parent
+empty rather than merely lagging.
 
 ### Choosing τ from an accuracy target
 
@@ -85,9 +94,12 @@ tau.get(); tau.set(64); tau.increase(1); tau.decrease(1);
 ```
 
 `OctoThreshold` is an `Arc<AtomicU32>` clamped to `1..=MAX_PROMASK`
-(255, the width of a worker counter). Clone it into every worker and
-into `OctoConfig::threshold` so the aggregator's controller and the
-workers refer to the same value.
+(127). The ceiling is a *signed* one-byte worker counter, and it is the
+same for every sketch on purpose: one shared threshold serves workers of
+different kinds, so a τ that meant 200 in one and 127 in another would
+leave the aggregator's controller a band in which raising τ changes
+nothing. Clone it into every worker and into `OctoConfig::threshold` so
+the controller and the workers refer to the same value.
 
 ## CountMin Delta API
 
@@ -197,11 +209,11 @@ Measured with `cargo run --release --example octo_throughput_probe` on a
 
 | τ | worker | vs single-threaded | deltas/insert | aggregator | sustainable | gap to ideal |
 | --- | --- | --- | --- | --- | --- | --- |
-| 16 | 16.7 M/s | 65x | 1.435 | 0.42 M/s | 0.29 M/s | 0.0000 |
-| 31 | 18.6 M/s | 72x | 1.000 | 0.43 M/s | 0.43 M/s | 0.0002 |
-| 64 | 18.7 M/s | 73x | 0.441 | 0.44 M/s | 0.99 M/s | 0.0002 |
-| 128 | 21.7 M/s | 84x | 0.244 | 0.46 M/s | 1.90 M/s | 0.0161 |
-| 255 | 22.2 M/s | 86x | 0.168 | 0.50 M/s | 2.96 M/s | 0.0195 |
+| 16 | 16.5 M/s | 62x | 1.435 | 0.43 M/s | 0.30 M/s | 0.0000 |
+| 31 | 18.4 M/s | 69x | 1.000 | 0.43 M/s | 0.43 M/s | 0.0002 |
+| 64 | 20.2 M/s | 76x | 0.441 | 0.40 M/s | 0.90 M/s | 0.0002 |
+| 96 | 21.1 M/s | 80x | 0.322 | 0.42 M/s | 1.32 M/s | 0.0004 |
+| 127 | 20.6 M/s | 78x | 0.278 | 0.45 M/s | 1.64 M/s | 0.0005 |
 
 Single-threaded `UnivMon::insert` runs at 0.26 M/s on the same stream, so
 the worker is 65-86x faster per insert — but one aggregator serves every

--- a/docs/api/api_octo.md
+++ b/docs/api/api_octo.md
@@ -204,29 +204,23 @@ re-reads the layer's estimate and updates that layer's heap — Algorithm
 work is a hash and a few one-byte increments; the L2 accumulator, the
 median estimate and the heavy-hitter heap all move to the aggregator,
 which touches them once per *promotion* rather than once per insert.
-Measured with `cargo run --release --example octo_throughput_probe` on a
-2M-insert Zipf stream (heap 64, 5x1024, 12 layers):
 
-| τ | worker | vs single-threaded | deltas/insert | aggregator | sustainable | gap to ideal |
-| --- | --- | --- | --- | --- | --- | --- |
-| 16 | 16.5 M/s | 62x | 1.435 | 0.43 M/s | 0.30 M/s | 0.0000 |
-| 31 | 18.4 M/s | 69x | 1.000 | 0.43 M/s | 0.43 M/s | 0.0002 |
-| 64 | 20.2 M/s | 76x | 0.441 | 0.40 M/s | 0.90 M/s | 0.0002 |
-| 96 | 21.1 M/s | 80x | 0.322 | 0.42 M/s | 1.32 M/s | 0.0004 |
-| 127 | 20.6 M/s | 78x | 0.278 | 0.45 M/s | 1.64 M/s | 0.0005 |
+One aggregator serves every worker, so the pipeline's ceiling is the
+aggregator's rate divided by how many deltas each insert produces — which
+makes τ the parameter that decides throughput, and is why §4.3 has the
+aggregator drive it. At a low τ an insert produces several deltas, the
+aggregator does more heap work than a single-threaded `UnivMon::insert`
+would, and the pipeline is slower than one core; the accuracy cost of
+raising τ stays negligible well past the default, so the trade is
+throughput against messages rather than against error.
 
-Single-threaded `UnivMon::insert` runs at 0.26 M/s on the same stream, so
-the worker is 65-86x faster per insert — but one aggregator serves every
-worker, so the pipeline's ceiling is the aggregator's rate divided by
-deltas per insert. That is why τ decides everything and why the
-aggregator drives it (§4.3).
+`cargo run --release --example octo_throughput_probe` measures the three
+stages separately on your hardware and prints the host it ran on.
 
 The aggregator's own ceiling is `HHHeap`, not the delta protocol: its
-rate falls off as `1/heap_size` (6.84, 1.88, 0.44, 0.13 Mdelta/s at
-capacities 4, 16, 64, 256) because the heap rebuilds its whole position
-index on every accepted update. Single-threaded UnivMon pays the same
-cost on every insert rather than every promotion, which is most of the
-gap between 0.26 M/s and 22 M/s.
+rate falls off as `1/heap_size`, because the heap rebuilds its whole
+position index on every accepted update. Single-threaded UnivMon pays the
+same cost on every insert rather than every promotion.
 
 **The threshold is scaled per layer.** Layer L only receives the keys that
 survive L coin flips, so it carries roughly `n / 2^L` of the stream. One

--- a/examples/octo_throughput_probe.rs
+++ b/examples/octo_throughput_probe.rs
@@ -13,8 +13,8 @@
 use std::time::Instant;
 
 use asap_sketchlib::{
-    DataInput, OctoAggregator, OctoThreshold, OctoWorker, UnivMon, UnivMonOctoAggregator,
-    UnivMonOctoWorker, univmon_layer_threshold,
+    DataInput, MAX_PROMASK, OctoAggregator, OctoThreshold, OctoWorker, UNIVMON_PROMASK, UnivMon,
+    UnivMonOctoAggregator, UnivMonOctoWorker, univmon_layer_threshold,
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -65,7 +65,11 @@ fn main() {
         "tau", "worker", "speedup", "deltas/ins", "agg Mdelta/s", "pipeline", "gap"
     );
 
-    for tau in [16u32, 31, 64, 128, 255] {
+    // A geometric sweep of the usable range. Powers of two are the natural
+    // grid because `univmon_layer_threshold` halves tau per layer, so a base of
+    // 2^k walks down to 1 exactly at layer k. 127 is MAX_PROMASK, the widest a
+    // signed one-byte worker counter holds; 64 is UNIVMON_PROMASK.
+    for tau in [1u32, 2, 4, 8, 16, 32, 64, 127] {
         let mut worker =
             UnivMonOctoWorker::with_threshold(0, rows, cols, layers, OctoThreshold::new(tau));
         let mut emitted = 0usize;
@@ -93,9 +97,14 @@ fn main() {
         let gap = ((parent.calc_card() - ideal_card).abs() / ideal_card.abs().max(1.0)
             + (parent.calc_entropy() - ideal_entropy).abs() / ideal_entropy.abs().max(1e-9))
             / 2.0;
+        let note = match tau {
+            UNIVMON_PROMASK => "  <- UnivMon default",
+            MAX_PROMASK => "  <- ceiling",
+            _ => "",
+        };
         println!(
             "{tau:<6} {worker_rate:>9.1} M/s {:>8.0}x {per_insert:>12.3} {aggregator_rate:>14.2} \
-             {:>9.2} M/s {gap:>10.4}",
+             {:>9.2} M/s {gap:>10.4}{note}",
             worker_rate / single_rate,
             aggregator_rate / per_insert,
         );

--- a/examples/octo_throughput_probe.rs
+++ b/examples/octo_throughput_probe.rs
@@ -13,8 +13,8 @@
 use std::time::Instant;
 
 use asap_sketchlib::{
-    DataInput, MAX_PROMASK, OctoAggregator, OctoThreshold, OctoWorker, UNIVMON_PROMASK, UnivMon,
-    UnivMonOctoAggregator, UnivMonOctoWorker, univmon_layer_threshold,
+    DataInput, MAX_PROMASK, OctoAggregator, OctoPlan, OctoThreshold, OctoWorker, UNIVMON_PROMASK,
+    UnivMon, UnivMonOctoAggregator, UnivMonOctoPlan, UnivMonOctoWorker, univmon_layer_threshold,
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -70,20 +70,24 @@ fn main() {
     // 2^k walks down to 1 exactly at layer k. 127 is MAX_PROMASK, the widest a
     // signed one-byte worker counter holds; 64 is UNIVMON_PROMASK.
     for tau in [1u32, 2, 4, 8, 16, 32, 64, 127] {
+        let plan = UnivMonOctoPlan::with_threshold(rows, cols, layers, OctoThreshold::new(tau));
+        // Preparation runs on the dispatching thread in the real pipeline, so
+        // it is measured with the worker rather than folded into it.
+        let payloads: Vec<_> = inputs.iter().map(|i| plan.prepare(i)).collect();
         let mut worker =
             UnivMonOctoWorker::with_threshold(0, rows, cols, layers, OctoThreshold::new(tau));
         let mut emitted = 0usize;
         let started = Instant::now();
-        for input in &inputs {
-            worker.process(input, &mut |_| emitted += 1);
+        for payload in &payloads {
+            worker.process(payload, &mut |_| emitted += 1);
         }
         let worker_rate = n as f64 / started.elapsed().as_secs_f64() / 1e6;
 
         let mut replay =
             UnivMonOctoWorker::with_threshold(0, rows, cols, layers, OctoThreshold::new(tau));
         let mut deltas = Vec::with_capacity(emitted);
-        for input in &inputs {
-            replay.process(input, &mut |d| deltas.push(d));
+        for payload in &payloads {
+            replay.process(payload, &mut |d| deltas.push(d));
         }
         let mut aggregator = UnivMonOctoAggregator::new(heap, rows, cols, layers, tau);
         let started = Instant::now();
@@ -122,11 +126,12 @@ fn main() {
     // update, so the rate falls off as 1/heap_size.
     println!("\naggregator rate vs heap capacity (tau=64):");
     for capacity in [4usize, 16, 64, 256] {
+        let plan = UnivMonOctoPlan::with_threshold(rows, cols, layers, OctoThreshold::new(64));
         let mut worker =
             UnivMonOctoWorker::with_threshold(0, rows, cols, layers, OctoThreshold::new(64));
         let mut deltas = Vec::new();
         for input in &inputs {
-            worker.process(input, &mut |d| deltas.push(d));
+            worker.process(&plan.prepare(input), &mut |d| deltas.push(d));
         }
         let count = deltas.len();
         let mut aggregator = UnivMonOctoAggregator::new(capacity, rows, cols, layers, 64);

--- a/examples/octo_throughput_probe.rs
+++ b/examples/octo_throughput_probe.rs
@@ -49,6 +49,30 @@ fn main() {
     let keys = zipf(n, 4_096, 1.1, 13_001);
     let inputs: Vec<DataInput<'static>> = keys.iter().map(|k| DataInput::U64(*k)).collect();
 
+    // Absolute rates below belong to this host. Record it, or the numbers are
+    // not comparable with anyone else's - or with the same box under load.
+    println!(
+        "host: {} {} | {} logical cores | core pinning: {}",
+        std::env::consts::ARCH,
+        std::env::consts::OS,
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(0),
+        match core_affinity::get_core_ids().and_then(|ids| ids.into_iter().next()) {
+            Some(id) if core_affinity::set_for_current(id) => "available",
+            Some(_) => "REJECTED by this platform (measurements are unpinned)",
+            None => "no core ids reported",
+        }
+    );
+    println!(
+        "profile: {}",
+        if cfg!(debug_assertions) {
+            "debug - rates are meaningless, rebuild with --release"
+        } else {
+            "release"
+        }
+    );
+
     let mut ideal = UnivMon::init_univmon(heap, rows, cols, layers);
     let started = Instant::now();
     for input in &inputs {
@@ -115,9 +139,9 @@ fn main() {
     }
 
     println!(
-        "\nper-layer tau at base 128: {:?}",
+        "\nper-layer tau at base {MAX_PROMASK}: {:?}",
         (0..layers)
-            .map(|l| univmon_layer_threshold(128, l))
+            .map(|l| univmon_layer_threshold(MAX_PROMASK, l))
             .collect::<Vec<_>>()
     );
 

--- a/examples/octo_throughput_probe.rs
+++ b/examples/octo_throughput_probe.rs
@@ -58,11 +58,18 @@ fn main() {
         std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(0),
-        match core_affinity::get_core_ids().and_then(|ids| ids.into_iter().next()) {
-            Some(id) if core_affinity::set_for_current(id) => "available",
-            Some(_) => "REJECTED by this platform (measurements are unpinned)",
-            None => "no core ids reported",
-        }
+        // Probe from a throwaway thread: `set_for_current` pins whoever calls
+        // it, and pinning the thread about to run the measurements would be a
+        // side effect of reporting.
+        std::thread::spawn(|| {
+            match core_affinity::get_core_ids().and_then(|ids| ids.into_iter().next()) {
+                Some(id) if core_affinity::set_for_current(id) => "available",
+                Some(_) => "REJECTED by this platform (measurements are unpinned)",
+                None => "no core ids reported",
+            }
+        })
+        .join()
+        .unwrap_or("could not probe")
     );
     println!(
         "profile: {}",

--- a/examples/octo_throughput_probe.rs
+++ b/examples/octo_throughput_probe.rs
@@ -1,0 +1,133 @@
+//! Release-only throughput probe for the OctoSketch pipeline on UnivMon.
+//!
+//! Measures the three stages separately so the bottleneck is visible:
+//! a single-threaded `UnivMon::insert`, an Octo worker's per-insert work, and
+//! the aggregator's per-delta work. The sustainable pipeline rate is the
+//! aggregator's rate divided by how many deltas each insert produces, because
+//! one aggregator serves every worker.
+//!
+//! ```text
+//! cargo run --release --example octo_throughput_probe
+//! ```
+
+use std::time::Instant;
+
+use asap_sketchlib::{
+    DataInput, OctoAggregator, OctoThreshold, OctoWorker, UnivMon, UnivMonOctoAggregator,
+    UnivMonOctoWorker, univmon_layer_threshold,
+};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+/// `n` Zipf(exponent) draws over `[0, domain)`; skew is what puts the hot keys
+/// in the heavy-hitter heap, which is where the per-insert cost lives.
+fn zipf(n: usize, domain: usize, exponent: f64, seed: u64) -> Vec<u64> {
+    let mut cdf: Vec<f64> = (0..domain)
+        .map(|i| 1.0 / (i as f64 + 1.0).powf(exponent))
+        .collect();
+    for i in 1..cdf.len() {
+        cdf[i] += cdf[i - 1];
+    }
+    let total = cdf[domain - 1];
+    for x in cdf.iter_mut() {
+        *x /= total;
+    }
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let u: f64 = rng.random();
+            match cdf.binary_search_by(|p| p.partial_cmp(&u).unwrap()) {
+                Ok(i) | Err(i) => (i as u64).min(domain as u64 - 1),
+            }
+        })
+        .collect()
+}
+
+fn main() {
+    let (heap, rows, cols, layers) = (64usize, 5usize, 1_024usize, 12usize);
+    let n = 2_000_000usize;
+    let keys = zipf(n, 4_096, 1.1, 13_001);
+    let inputs: Vec<DataInput<'static>> = keys.iter().map(|k| DataInput::U64(*k)).collect();
+
+    let mut ideal = UnivMon::init_univmon(heap, rows, cols, layers);
+    let started = Instant::now();
+    for input in &inputs {
+        ideal.insert(input, 1);
+    }
+    let single_rate = n as f64 / started.elapsed().as_secs_f64() / 1e6;
+    let (ideal_card, ideal_entropy) = (ideal.calc_card(), ideal.calc_entropy());
+    println!(
+        "single-threaded UnivMon: {single_rate:.2} Mops/s  \
+         (heap={heap} rows={rows} cols={cols} layers={layers}, n={n} Zipf 1.1 over 4096)"
+    );
+    println!(
+        "{:<6} {:>12} {:>9} {:>12} {:>14} {:>12} {:>10}",
+        "tau", "worker", "speedup", "deltas/ins", "agg Mdelta/s", "pipeline", "gap"
+    );
+
+    for tau in [16u32, 31, 64, 128, 255] {
+        let mut worker =
+            UnivMonOctoWorker::with_threshold(0, rows, cols, layers, OctoThreshold::new(tau));
+        let mut emitted = 0usize;
+        let started = Instant::now();
+        for input in &inputs {
+            worker.process(input, &mut |_| emitted += 1);
+        }
+        let worker_rate = n as f64 / started.elapsed().as_secs_f64() / 1e6;
+
+        let mut replay =
+            UnivMonOctoWorker::with_threshold(0, rows, cols, layers, OctoThreshold::new(tau));
+        let mut deltas = Vec::with_capacity(emitted);
+        for input in &inputs {
+            replay.process(input, &mut |d| deltas.push(d));
+        }
+        let mut aggregator = UnivMonOctoAggregator::new(heap, rows, cols, layers, tau);
+        let started = Instant::now();
+        for delta in deltas {
+            aggregator.apply(delta);
+        }
+        let aggregator_rate = emitted as f64 / started.elapsed().as_secs_f64() / 1e6;
+
+        let per_insert = emitted as f64 / n as f64;
+        let parent = &aggregator.sketch;
+        let gap = ((parent.calc_card() - ideal_card).abs() / ideal_card.abs().max(1.0)
+            + (parent.calc_entropy() - ideal_entropy).abs() / ideal_entropy.abs().max(1e-9))
+            / 2.0;
+        println!(
+            "{tau:<6} {worker_rate:>9.1} M/s {:>8.0}x {per_insert:>12.3} {aggregator_rate:>14.2} \
+             {:>9.2} M/s {gap:>10.4}",
+            worker_rate / single_rate,
+            aggregator_rate / per_insert,
+        );
+    }
+
+    println!(
+        "\nper-layer tau at base 128: {:?}",
+        (0..layers)
+            .map(|l| univmon_layer_threshold(128, l))
+            .collect::<Vec<_>>()
+    );
+
+    // The aggregator is the pipeline's ceiling, and the heap sets the
+    // aggregator: HHHeap rebuilds its whole position index on every accepted
+    // update, so the rate falls off as 1/heap_size.
+    println!("\naggregator rate vs heap capacity (tau=64):");
+    for capacity in [4usize, 16, 64, 256] {
+        let mut worker =
+            UnivMonOctoWorker::with_threshold(0, rows, cols, layers, OctoThreshold::new(64));
+        let mut deltas = Vec::new();
+        for input in &inputs {
+            worker.process(input, &mut |d| deltas.push(d));
+        }
+        let count = deltas.len();
+        let mut aggregator = UnivMonOctoAggregator::new(capacity, rows, cols, layers, 64);
+        let started = Instant::now();
+        for delta in deltas {
+            aggregator.apply(delta);
+        }
+        println!(
+            "  heap={capacity:<4} {:.2} Mdelta/s",
+            count as f64 / started.elapsed().as_secs_f64() / 1e6
+        );
+    }
+}

--- a/src/common/input.rs
+++ b/src/common/input.rs
@@ -321,6 +321,13 @@ impl L2HH {
         }
     }
 
+    /// Applies a counter delta promoted by an OctoSketch worker.
+    pub fn apply_delta(&mut self, delta: crate::octo_delta::CountDelta) {
+        match self {
+            L2HH::COUNT(count_l2hh) => count_l2hh.apply_delta(delta),
+        }
+    }
+
     /// Merges another counter of the same kind into this one.
     pub fn merge(&mut self, other: &L2HH) {
         match (self, other) {

--- a/src/sketch_framework/mod.rs
+++ b/src/sketch_framework/mod.rs
@@ -57,8 +57,8 @@ pub use eh_univ_optimized::{EHMapBucket, EHUnivMonBucket, EHUnivOptimized, EHUni
 
 pub mod octo;
 pub use octo::{
-    CmOctoWorker, CountOctoAggregator, CountOctoWorker, HllOctoAggregator, HllOctoWorker,
-    OctoAggregator, OctoWorker,
+    CmOctoAggregator, CmOctoWorker, CountOctoAggregator, CountOctoWorker, HllOctoAggregator,
+    HllOctoWorker, OctoAggregator, OctoWorker,
 };
 #[cfg(feature = "octo-runtime")]
 pub use octo::{OctoConfig, OctoReadHandle, OctoResult, OctoRuntime, run_octo};

--- a/src/sketch_framework/mod.rs
+++ b/src/sketch_framework/mod.rs
@@ -37,7 +37,7 @@ pub mod hydra;
 pub use hydra::Hydra;
 
 pub mod univmon;
-pub use univmon::UnivMon;
+pub use univmon::{UnivMon, UnivMonDeltaFidelity, bottom_layer_for_hash};
 
 pub mod univmon_q;
 pub use univmon_q::{UnivMonQ, UnivMonQConfig, UnivMonQError, UnivMonQPoint, UnivMonQQuery};
@@ -57,11 +57,17 @@ pub use eh_univ_optimized::{EHMapBucket, EHUnivMonBucket, EHUnivOptimized, EHUni
 
 pub mod octo;
 pub use octo::{
-    CmOctoAggregator, CmOctoWorker, CountOctoAggregator, CountOctoWorker, HllOctoAggregator,
-    HllOctoWorker, OctoAggregator, OctoWorker,
+    CmOctoAggregator, CmOctoWorker, CmTopKOctoAggregator, CmTopKOctoWorker, CmWorkerSketch,
+    CountOctoAggregator, CountOctoWorker, CountTopKOctoAggregator, CountTopKOctoWorker,
+    CountWorkerSketch, DEFAULT_OCTO_TOP_K, DdOctoAggregator, DdOctoWorker, DdWorkerSketch,
+    HllOctoAggregator, HllOctoWorker, L2hhWorkerSketch, OctoAggregator, OctoWorker,
+    UnivMonOctoAggregator, UnivMonOctoWorker, threshold_for_error, univmon_layer_threshold,
 };
 #[cfg(feature = "octo-runtime")]
-pub use octo::{OctoConfig, OctoReadHandle, OctoResult, OctoRuntime, run_octo};
+pub use octo::{
+    OctoAdaptiveThreshold, OctoConfig, OctoPartition, OctoReadHandle, OctoResult, OctoRuntime,
+    run_octo,
+};
 
 pub mod tumbling;
 pub use tumbling::{

--- a/src/sketch_framework/mod.rs
+++ b/src/sketch_framework/mod.rs
@@ -57,12 +57,13 @@ pub use eh_univ_optimized::{EHMapBucket, EHUnivMonBucket, EHUnivOptimized, EHUni
 
 pub mod octo;
 pub use octo::{
-    CmOctoAggregator, CmOctoWorker, CmTopKOctoAggregator, CmTopKOctoWorker, CmWorkerSketch,
-    CountOctoAggregator, CountOctoWorker, CountTopKOctoAggregator, CountTopKOctoWorker,
-    CountWorkerSketch, DEFAULT_OCTO_TOP_K, DdOctoAggregator, DdOctoWorker, DdWorkerSketch,
-    HllOctoAggregator, HllOctoWorker, L2hhWorkerSketch, OctoAggregator, OctoWorker,
-    UnivMonOctoAggregator, UnivMonOctoWorker, max_hll_threshold, threshold_for_error,
-    univmon_layer_threshold,
+    CmOctoAggregator, CmOctoPlan, CmOctoWorker, CmTopKOctoAggregator, CmTopKOctoPlan,
+    CmTopKOctoWorker, CmWorkerSketch, CountOctoAggregator, CountOctoPlan, CountOctoWorker,
+    CountTopKOctoAggregator, CountTopKOctoPlan, CountTopKOctoWorker, CountWorkerSketch,
+    DEFAULT_OCTO_TOP_K, DdOctoAggregator, DdOctoPlan, DdOctoWorker, DdWorkerSketch,
+    HllOctoAggregator, HllOctoPlan, HllOctoWorker, KeyedHashes, L2hhWorkerSketch, OctoAggregator,
+    OctoPlan, OctoWorker, RowHashes, UnivMonInput, UnivMonOctoAggregator, UnivMonOctoPlan,
+    UnivMonOctoWorker, max_hll_threshold, threshold_for_error, univmon_layer_threshold,
 };
 #[cfg(feature = "octo-runtime")]
 pub use octo::{

--- a/src/sketch_framework/mod.rs
+++ b/src/sketch_framework/mod.rs
@@ -61,7 +61,8 @@ pub use octo::{
     CountOctoAggregator, CountOctoWorker, CountTopKOctoAggregator, CountTopKOctoWorker,
     CountWorkerSketch, DEFAULT_OCTO_TOP_K, DdOctoAggregator, DdOctoWorker, DdWorkerSketch,
     HllOctoAggregator, HllOctoWorker, L2hhWorkerSketch, OctoAggregator, OctoWorker,
-    UnivMonOctoAggregator, UnivMonOctoWorker, threshold_for_error, univmon_layer_threshold,
+    UnivMonOctoAggregator, UnivMonOctoWorker, max_hll_threshold, threshold_for_error,
+    univmon_layer_threshold,
 };
 #[cfg(feature = "octo-runtime")]
 pub use octo::{

--- a/src/sketch_framework/octo.rs
+++ b/src/sketch_framework/octo.rs
@@ -75,6 +75,25 @@ pub trait OctoWorker: Send {
     fn process<F>(&mut self, input: &DataInput, emit: &mut F)
     where
         F: FnMut(Self::Delta);
+
+    /// Promote everything still held back, so the aggregator can be queried
+    /// against the whole stream so far.
+    ///
+    /// A worker holds any counter that has not reached τ. For Count-Min and
+    /// Count that only makes the parent low by under τ per cell, but for a
+    /// bucket histogram or a max-register sketch an un-promoted cell is
+    /// *absent* from the parent rather than merely lagging, which is a
+    /// different kind of wrong. Flushing costs one message per non-empty cell -
+    /// as much as shipping the sketch - so it belongs at the point a stream is
+    /// handed over for querying, not on a timer.
+    ///
+    /// The default does nothing, for workers that hold nothing back.
+    fn flush<F>(&mut self, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        let _ = emit;
+    }
 }
 
 /// Aggregator-side trait: absorbs deltas into a full-precision sketch.
@@ -156,6 +175,23 @@ impl CmWorkerSketch {
                     value: *cell as u32,
                 });
                 *cell = 0;
+            }
+        }
+    }
+
+    /// Promotes and clears every counter still holding a partial count.
+    pub fn flush(&mut self, emit: &mut impl FnMut(CmDelta)) {
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                let cell = &mut self.counters[row * self.cols + col];
+                if *cell != 0 {
+                    emit(CmDelta {
+                        row: row as u32,
+                        col: col as u32,
+                        value: *cell as u32,
+                    });
+                    *cell = 0;
+                }
             }
         }
     }
@@ -247,6 +283,23 @@ impl CountWorkerSketch {
         }
     }
 
+    /// Promotes and clears every counter still holding a partial count.
+    pub fn flush(&mut self, emit: &mut impl FnMut(CountDelta)) {
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                let cell = &mut self.counters[row * self.cols + col];
+                if *cell != 0 {
+                    emit(CountDelta {
+                        row: row as u32,
+                        col: col as u32,
+                        value: *cell as i32,
+                    });
+                    *cell = 0;
+                }
+            }
+        }
+    }
+
     /// As `insert_emit_delta`, but each delta carries the flow key.
     #[inline(always)]
     pub fn insert_emit_keyed_delta(
@@ -315,6 +368,23 @@ impl L2hhWorkerSketch {
     /// Counters still held back from the aggregator, one per cell.
     pub fn residual(&self) -> &[i8] {
         &self.counters
+    }
+
+    /// Promotes and clears every counter still holding a partial count.
+    pub fn flush(&mut self, emit: &mut impl FnMut(CountDelta)) {
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                let cell = &mut self.counters[row * self.cols + col];
+                if *cell != 0 {
+                    emit(CountDelta {
+                        row: row as u32,
+                        col: col as u32,
+                        value: *cell as i32,
+                    });
+                    *cell = 0;
+                }
+            }
+        }
     }
 
     /// Inserts a key, emitting and clearing every counter whose magnitude
@@ -463,7 +533,15 @@ pub struct OctoResult<P> {
 #[cfg(feature = "octo-runtime")]
 enum WorkerMsg {
     Data(DataInput<'static>),
+    /// Promote everything held back, then acknowledge.
+    Flush(Sender<()>),
     End,
+}
+
+#[cfg(feature = "octo-runtime")]
+enum AggregatorMsg {
+    /// Apply everything already queued, then acknowledge.
+    Drain(Sender<()>),
 }
 
 #[cfg(feature = "octo-runtime")]
@@ -517,6 +595,7 @@ impl<P> OctoReadHandle<P> {
 #[cfg(feature = "octo-runtime")]
 struct OctoCore<P> {
     worker_input_txs: Vec<Sender<WorkerMsg>>,
+    control_tx: Sender<AggregatorMsg>,
     next_worker: AtomicUsize,
     partition: OctoPartition,
     worker_handles: Vec<thread::JoinHandle<()>>,
@@ -601,6 +680,7 @@ where
 
         let adaptive = config.adaptive.clone();
         let threshold = config.threshold.clone();
+        let (control_tx, control_rx) = bounded::<AggregatorMsg>(1);
         let aggregator_handle = thread::spawn(move || {
             if pin_cores {
                 let _ = core_affinity::set_for_current(core_affinity::CoreId { id: num_workers });
@@ -633,6 +713,13 @@ where
                     controller.maybe_adjust(&delta_rxs, &threshold);
                 }
                 if !made_progress {
+                    // Only answer a drain request once every queue is empty.
+                    // The caller has already collected each worker's flush
+                    // acknowledgement, so no worker is still producing and
+                    // "empty" means "applied".
+                    if let Ok(AggregatorMsg::Drain(ack)) = control_rx.try_recv() {
+                        let _ = ack.send(());
+                    }
                     std::hint::spin_loop();
                 }
             }
@@ -656,7 +743,24 @@ where
                                 .send(delta)
                                 .expect("aggregator receiver dropped while workers still running");
                         }),
-                        WorkerMsg::End => break,
+                        WorkerMsg::Flush(ack) => {
+                            worker.flush(&mut |delta| {
+                                delta_tx_worker.send(delta).expect(
+                                    "aggregator receiver dropped while workers still running",
+                                );
+                            });
+                            let _ = ack.send(());
+                        }
+                        WorkerMsg::End => {
+                            // Hand over whatever is still held back, so a
+                            // finished run answers against the whole stream.
+                            worker.flush(&mut |delta| {
+                                delta_tx_worker.send(delta).expect(
+                                    "aggregator receiver dropped while workers still running",
+                                );
+                            });
+                            break;
+                        }
                     }
                 }
             }));
@@ -664,6 +768,7 @@ where
 
         Self {
             worker_input_txs,
+            control_tx,
             next_worker: AtomicUsize::new(0),
             partition: config.partition,
             worker_handles,
@@ -792,6 +897,44 @@ where
             .expect("worker receiver dropped while runtime is active");
     }
 
+    /// Promotes everything the workers still hold and waits for the aggregator
+    /// to apply it, so the parent answers against every input accepted so far.
+    ///
+    /// This is the point at which a stream is handed over for querying. Between
+    /// flushes a worker holds any counter below τ, which for Count-Min and
+    /// Count only makes the parent low by under τ per cell, but for DDSketch or
+    /// a thresholded HyperLogLog means whole cells are missing - and a quantile
+    /// or a cardinality is exactly a statement about which cells exist. It
+    /// costs one message per non-empty cell, the same as shipping the sketch,
+    /// so call it when a query needs to be right rather than on a timer.
+    ///
+    /// Inserting afterwards is fine; the runtime is not sealed.
+    pub fn flush(&mut self) {
+        let core = self.core.as_ref().expect("runtime core missing");
+        if core.closed.load(Ordering::Acquire) {
+            return;
+        }
+
+        // Phase one: every worker hands over its residue. Taking &mut self
+        // means no insert can race this, so once each has acknowledged, the
+        // delta queues hold everything and nothing more is coming.
+        let (ack_tx, ack_rx) = bounded::<()>(core.worker_input_txs.len());
+        for tx in &core.worker_input_txs {
+            tx.send(WorkerMsg::Flush(ack_tx.clone()))
+                .expect("worker receiver dropped while runtime is active");
+        }
+        for _ in 0..core.worker_input_txs.len() {
+            ack_rx.recv().expect("worker dropped during flush");
+        }
+
+        // Phase two: the aggregator applies what is queued.
+        let (drain_tx, drain_rx) = bounded::<()>(1);
+        core.control_tx
+            .send(AggregatorMsg::Drain(drain_tx))
+            .expect("aggregator dropped during flush");
+        drain_rx.recv().expect("aggregator dropped during flush");
+    }
+
     /// Inserts a batch, one element at a time.
     pub fn insert_batch(&mut self, inputs: &[DataInput<'_>]) {
         for input in inputs {
@@ -853,6 +996,13 @@ impl OctoWorker for CmOctoWorker {
     {
         self.sketch
             .insert_emit_delta(input, self.threshold.get(), emit);
+    }
+
+    fn flush<F>(&mut self, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        self.sketch.flush(emit);
     }
 }
 
@@ -919,6 +1069,13 @@ impl OctoWorker for CmTopKOctoWorker {
         self.sketch
             .insert_emit_keyed_delta(input, self.threshold.get(), emit);
     }
+
+    // No flush: every delta carries the key that produced it, and a worker
+    // keeps no key storage - that is the point of Idea 3. A residual cell
+    // cannot be attributed back to a key, so it stays where it is. The parent's
+    // counters are low by under tau per cell, which is the same bound the
+    // unkeyed workers carry between flushes, and the heavy-hitter heap does not
+    // depend on the residue.
 }
 
 /// Count-Min parent that also maintains the only heavy-hitter heap in the
@@ -988,6 +1145,13 @@ impl OctoWorker for CountOctoWorker {
         self.sketch
             .insert_emit_delta(input, self.threshold.get(), emit);
     }
+
+    fn flush<F>(&mut self, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        self.sketch.flush(emit);
+    }
 }
 
 /// OctoSketch parent wrapping a full-precision `Count`.
@@ -1048,6 +1212,13 @@ impl OctoWorker for CountTopKOctoWorker {
         self.sketch
             .insert_emit_keyed_delta(input, self.threshold.get(), emit);
     }
+
+    // No flush: every delta carries the key that produced it, and a worker
+    // keeps no key storage - that is the point of Idea 3. A residual cell
+    // cannot be attributed back to a key, so it stays where it is. The parent's
+    // counters are low by under tau per cell, which is the same bound the
+    // unkeyed workers carry between flushes, and the heavy-hitter heap does not
+    // depend on the residue.
 }
 
 /// Count-sketch parent holding the pipeline's only heavy-hitter heap.
@@ -1119,6 +1290,22 @@ impl DdWorkerSketch {
         self.counters.values().map(|&c| c as u64).sum()
     }
 
+    /// Promotes and clears every bucket still holding a partial count.
+    ///
+    /// Until this runs, a bucket under the threshold is missing from the parent
+    /// entirely - so `count`, `min`, `max`, `sum` and the extreme quantiles are
+    /// wrong without bound, not within alpha. Flush before reading those.
+    pub fn flush(&mut self, emit: &mut impl FnMut(DdDelta)) {
+        for (index, count) in self.counters.drain() {
+            if count != 0 {
+                emit(DdDelta {
+                    index,
+                    value: count as u64,
+                });
+            }
+        }
+    }
+
     /// Adds a sample, promoting and clearing the bucket that reaches `threshold`.
     ///
     /// Values the parent sketch would itself drop - non-positive, non-finite or
@@ -1174,6 +1361,13 @@ impl OctoWorker for DdOctoWorker {
         };
         self.sketch
             .add_emit_delta(value, self.threshold.get(), emit);
+    }
+
+    fn flush<F>(&mut self, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        self.sketch.flush(emit);
     }
 }
 
@@ -1269,6 +1463,24 @@ impl OctoWorker for HllOctoWorker {
     {
         self.child
             .insert_emit_delta_with_threshold(input, self.threshold, emit);
+    }
+
+    /// Ships every non-empty register. At the default threshold of 0 nothing is
+    /// ever held back and this is redundant, but a worker running a positive
+    /// threshold has registers the parent has not seen, and a missing register
+    /// reads there as an empty bucket rather than a low one.
+    fn flush<F>(&mut self, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        for (pos, value) in self.child.registers_as_slice().iter().enumerate() {
+            if *value != 0 {
+                emit(HllDelta {
+                    pos: pos as u32,
+                    value: *value,
+                });
+            }
+        }
     }
 }
 
@@ -2010,45 +2222,81 @@ mod runtime_tests {
         assert_eq!(runtime.finish().parent.loads, vec![4, 3, 3]);
     }
 
+    /// Reports the threshold each worker is actually reading.
+    struct ThresholdReporter {
+        threshold: OctoThreshold,
+    }
+
+    impl OctoWorker for ThresholdReporter {
+        type Delta = u32;
+
+        fn process<F>(&mut self, _input: &DataInput, emit: &mut F)
+        where
+            F: FnMut(Self::Delta),
+        {
+            emit(self.threshold.get());
+        }
+    }
+
+    struct ThresholdCollector {
+        seen: Vec<u32>,
+    }
+
+    impl OctoAggregator for ThresholdCollector {
+        type Delta = u32;
+
+        fn apply(&mut self, delta: Self::Delta) {
+            self.seen.push(delta);
+        }
+    }
+
     #[test]
     fn a_shared_threshold_reaches_every_worker() {
-        let (rows, cols) = (2usize, 256usize);
-        let threshold = OctoThreshold::new(4);
+        let workers = 4usize;
+        let threshold = OctoThreshold::new(37);
         let cfg = OctoConfig {
             threshold: threshold.clone(),
-            ..config(2)
+            ..config(workers)
         };
-        let inputs: Vec<DataInput<'_>> = (0..400u64).map(|i| DataInput::U64(i % 8)).collect();
+        let inputs: Vec<DataInput<'_>> = (0..2_000u64).map(DataInput::U64).collect();
 
-        let low = run_octo(
+        let result = run_octo(
             &inputs,
             &cfg,
             {
                 let threshold = threshold.clone();
-                move |_| CmOctoWorker::with_threshold(rows, cols, threshold.clone())
+                move |_| ThresholdReporter {
+                    threshold: threshold.clone(),
+                }
             },
-            || CmOctoAggregator::new(rows, cols),
+            || ThresholdCollector { seen: Vec::new() },
         );
 
-        let high_threshold = OctoThreshold::new(64);
-        let high_cfg = OctoConfig {
-            threshold: high_threshold.clone(),
-            ..config(2)
-        };
-        let high = run_octo(
-            &inputs,
-            &high_cfg,
-            {
-                let threshold = high_threshold.clone();
-                move |_| CmOctoWorker::with_threshold(rows, cols, threshold.clone())
-            },
-            || CmOctoAggregator::new(rows, cols),
-        );
-
-        let probe = DataInput::U64(3);
+        assert_eq!(result.parent.seen.len(), inputs.len());
         assert!(
-            low.parent.sketch.estimate(&probe) > high.parent.sketch.estimate(&probe),
-            "a lower threshold must promote more of the count"
+            result.parent.seen.iter().all(|t| *t == 37),
+            "every worker must read the threshold the config was built with"
+        );
+    }
+
+    #[test]
+    fn the_threshold_still_decides_how_much_is_promoted() {
+        // Post-flush the parent is exact whatever tau was, so the threshold's
+        // effect shows up in traffic rather than in the final answer.
+        let (rows, cols) = (2usize, 256usize);
+        let stream: Vec<u64> = (0..4_000u64).map(|i| i % 8).collect();
+        let mut volumes = Vec::new();
+        for tau in [4u32, 64] {
+            let mut worker = CmWorkerSketch::new(rows, cols);
+            let mut promoted = 0usize;
+            for key in &stream {
+                worker.insert_emit_delta(&DataInput::U64(*key), tau, &mut |_| promoted += 1);
+            }
+            volumes.push((tau, promoted));
+        }
+        assert!(
+            volumes[0].1 > volumes[1].1,
+            "a lower threshold must send more: {volumes:?}"
         );
     }
 
@@ -2079,7 +2327,7 @@ mod runtime_tests {
             alpha: 0.25,
             interval: Duration::ZERO,
             min_threshold: 1,
-            max_threshold: 200,
+            max_threshold: MAX_PROMASK,
         };
         let threshold = OctoThreshold::new(31);
         adjust_against_queue_len(&settings, &threshold, 500, 8);
@@ -2097,7 +2345,7 @@ mod runtime_tests {
             alpha: 0.25,
             interval: Duration::ZERO,
             min_threshold: 4,
-            max_threshold: 200,
+            max_threshold: MAX_PROMASK,
         };
         let threshold = OctoThreshold::new(31);
         adjust_against_queue_len(&settings, &threshold, 0, 64);
@@ -2412,6 +2660,130 @@ mod runtime_tests {
                 streamed.parent.sketch.estimate(&key),
                 "key {key_val}"
             );
+        }
+    }
+
+    #[test]
+    fn finishing_a_ddsketch_run_answers_against_the_whole_stream() {
+        // Without the flush on End, a stream of near-distinct values leaves no
+        // bucket at the threshold, the parent holds nothing, and every quantile
+        // query returns None.
+        let alpha = 0.01;
+        let inputs: Vec<DataInput<'_>> = (1..=20_000u64)
+            .map(|i| DataInput::F64(1.0 + i as f64 * 0.37))
+            .collect();
+        let mut exact: Vec<f64> = inputs
+            .iter()
+            .map(|i| match i {
+                DataInput::F64(v) => *v,
+                _ => unreachable!(),
+            })
+            .collect();
+        exact.sort_by(f64::total_cmp);
+
+        let result = run_octo(
+            &inputs,
+            &config(4),
+            |_| DdOctoWorker::new(alpha),
+            || DdOctoAggregator::new(alpha),
+        );
+        let parent = &result.parent.sketch;
+
+        assert_eq!(
+            parent.get_count(),
+            inputs.len() as u64,
+            "every sample must have reached the parent"
+        );
+        for q in [0.0, 0.1, 0.5, 0.9, 1.0] {
+            let truth = exact[((exact.len() - 1) as f64 * q) as usize];
+            let got = parent
+                .get_value_at_quantile(q)
+                .expect("a flushed parent answers every quantile");
+            let relative = (got - truth).abs() / truth;
+            assert!(
+                relative <= 2.0 * alpha,
+                "q={q}: got {got}, truth {truth}, relative {relative:.4}"
+            );
+        }
+        let (min, max) = (parent.min().unwrap(), parent.max().unwrap());
+        assert!(min <= exact[0] * (1.0 + alpha) && max >= exact[exact.len() - 1] * (1.0 - alpha));
+    }
+
+    #[test]
+    fn a_mid_stream_flush_makes_the_live_parent_answerable() {
+        let alpha = 0.01;
+        let values: Vec<f64> = (1..=20_000u64).map(|i| 1.0 + i as f64 * 0.37).collect();
+        let mut runtime = OctoRuntime::new(
+            &config(4),
+            |_| DdOctoWorker::new(alpha),
+            || DdOctoAggregator::new(alpha),
+        );
+        let reader = runtime.read_handle();
+
+        let half = values.len() / 2;
+        for value in &values[..half] {
+            runtime.insert(DataInput::F64(*value));
+        }
+
+        runtime.flush();
+        let counted = reader.with_parent(|p| p.sketch.get_count());
+        assert_eq!(
+            counted, half as u64,
+            "a flush must land every input accepted so far"
+        );
+        let median = reader.with_parent(|p| p.sketch.get_value_at_quantile(0.5));
+        assert!(median.is_some(), "a flushed parent answers mid-stream");
+
+        // The runtime is not sealed by a flush.
+        for value in &values[half..] {
+            runtime.insert(DataInput::F64(*value));
+        }
+        assert_eq!(
+            runtime.finish().parent.sketch.get_count(),
+            values.len() as u64
+        );
+    }
+
+    #[test]
+    fn flushing_twice_is_harmless() {
+        let alpha = 0.01;
+        let mut runtime = OctoRuntime::new(
+            &config(2),
+            |_| DdOctoWorker::new(alpha),
+            || DdOctoAggregator::new(alpha),
+        );
+        for i in 1..=5_000u64 {
+            runtime.insert(DataInput::F64(i as f64));
+        }
+        runtime.flush();
+        runtime.flush();
+        assert_eq!(runtime.finish().parent.sketch.get_count(), 5_000);
+    }
+
+    #[test]
+    fn a_flushed_count_min_parent_matches_a_single_pass_exactly() {
+        // Flush is not DDSketch-only: it makes every unkeyed sketch exact at
+        // the point of query, where before the parent was low by under tau.
+        let (rows, cols) = (3usize, 1024usize);
+        let inputs: Vec<DataInput<'_>> = (0..40_000u64).map(|i| DataInput::U64(i % 512)).collect();
+        let got = run_octo(
+            &inputs,
+            &config(4),
+            |_| CmOctoWorker::new(rows, cols),
+            || CmOctoAggregator::new(rows, cols),
+        );
+        let mut reference = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
+        for input in &inputs {
+            reference.insert(input);
+        }
+        for row in 0..rows {
+            for col in 0..cols {
+                assert_eq!(
+                    got.parent.sketch.as_storage().query_one_counter(row, col),
+                    reference.as_storage().query_one_counter(row, col),
+                    "cell ({row},{col})"
+                );
+            }
         }
     }
 

--- a/src/sketch_framework/octo.rs
+++ b/src/sketch_framework/octo.rs
@@ -20,8 +20,6 @@
 //! - <https://www.usenix.org/conference/nsdi24/presentation/zhang-yinda>
 
 #[cfg(feature = "octo-runtime")]
-use std::marker::PhantomData;
-#[cfg(feature = "octo-runtime")]
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(feature = "octo-runtime")]
 use std::sync::{Arc, RwLock, Weak};
@@ -49,6 +47,7 @@ use crate::{
     RegularPath, UnivMon, Vector2D, hash64_seeded, hash128_seeded, heap_item_to_sketch_input,
     input_to_owned,
 };
+use smallvec::SmallVec;
 
 #[cfg(feature = "octo-runtime")]
 /// Legacy queue capacity default retained for config compatibility.
@@ -63,7 +62,10 @@ const LOWER_32_MASK: u64 = (1u64 << 32) - 1;
 // Traits
 // ---------------------------------------------------------------------------
 
-/// Worker-side trait: processes inputs and emits deltas.
+/// Per-row hashes for a worker sketch, inline for any realistic row count.
+pub type RowHashes = SmallVec<[u64; 8]>;
+
+/// Worker-side trait: processes prepared inputs and emits deltas.
 pub trait OctoWorker: Send {
     /// Delta type emitted by the worker.
     ///
@@ -71,8 +73,17 @@ pub trait OctoWorker: Send {
     /// than `Copy`.
     type Delta: Send + 'static;
 
-    /// Process one input and emit zero or more deltas.
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    /// What actually crosses to the worker thread.
+    ///
+    /// A `DataInput` can borrow, and a worker runs on another thread, so the
+    /// borrow has to end before the hand-off. [`OctoPlan::prepare`] turns the
+    /// input into this on the calling thread: hashes for a worker that only
+    /// hashes, an owned key for one that must store it. The caller is then free
+    /// to drop the key immediately - it never has to outlive the runtime.
+    type Payload: Send + 'static;
+
+    /// Process one prepared input and emit zero or more deltas.
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta);
 
@@ -94,6 +105,24 @@ pub trait OctoWorker: Send {
     {
         let _ = emit;
     }
+}
+
+/// Builds a fleet of workers and prepares inputs for them.
+///
+/// One object holds the geometry, because both jobs need it: `worker` needs the
+/// dimensions to allocate counters, and `prepare` needs them to know how many
+/// hashes to compute. `prepare` runs on the calling thread, which is what lets
+/// the borrow in a `DataInput` end at the call rather than having to outlive
+/// the runtime.
+pub trait OctoPlan: Send + 'static {
+    /// Worker type this plan builds.
+    type Worker: OctoWorker;
+
+    /// Builds worker `worker_id`. Called once per worker at startup.
+    fn worker(&self, worker_id: usize) -> Self::Worker;
+
+    /// Converts one input into the worker's transport form.
+    fn prepare(&self, input: &DataInput<'_>) -> <Self::Worker as OctoWorker>::Payload;
 }
 
 /// Aggregator-side trait: absorbs deltas into a full-precision sketch.
@@ -153,6 +182,11 @@ impl CmWorkerSketch {
         &self.counters
     }
 
+    /// Per-row hashes this geometry needs for `value`.
+    pub fn hashes(rows: usize, value: &DataInput) -> RowHashes {
+        (0..rows.max(1)).map(|r| hash64_seeded(r, value)).collect()
+    }
+
     /// Inserts a key, emitting and clearing every counter that reaches
     /// `threshold` (Algorithm 1).
     #[inline(always)]
@@ -162,9 +196,20 @@ impl CmWorkerSketch {
         threshold: u32,
         emit: &mut impl FnMut(CmDelta),
     ) {
+        self.insert_hashes_emit_delta(&Self::hashes(self.rows, value), threshold, emit);
+    }
+
+    /// As `insert_emit_delta`, from hashes already computed by `hashes`.
+    #[inline(always)]
+    pub fn insert_hashes_emit_delta(
+        &mut self,
+        hashes: &[u64],
+        threshold: u32,
+        emit: &mut impl FnMut(CmDelta),
+    ) {
+        debug_assert_eq!(hashes.len(), self.rows, "one hash per row");
         let threshold = threshold.clamp(1, MAX_PROMASK) as u8;
-        for r in 0..self.rows {
-            let hashed = hash64_seeded(r, value);
+        for (r, hashed) in hashes.iter().copied().enumerate() {
             let col = ((hashed & LOWER_32_MASK) as usize) % self.cols;
             let cell = &mut self.counters[r * self.cols + col];
             *cell += 1;
@@ -196,18 +241,17 @@ impl CmWorkerSketch {
         }
     }
 
-    /// As `insert_emit_delta`, but each delta carries the flow key so the
-    /// aggregator can maintain the heavy-hitter heap.
+    /// As `insert_hashes_emit_delta`, but each delta carries the flow key so
+    /// the aggregator can maintain the heavy-hitter heap.
     #[inline(always)]
-    pub fn insert_emit_keyed_delta(
+    pub fn insert_hashes_emit_keyed_delta(
         &mut self,
-        value: &DataInput,
+        hashes: &[u64],
+        key: &HeapItem,
         threshold: u32,
         emit: &mut impl FnMut(KeyedCmDelta),
     ) {
-        let mut key: Option<HeapItem> = None;
-        self.insert_emit_delta(value, threshold, &mut |delta| {
-            let key = key.get_or_insert_with(|| input_to_owned(value));
+        self.insert_hashes_emit_delta(hashes, threshold, &mut |delta| {
             emit(KeyedCmDelta {
                 key: key.clone(),
                 delta,
@@ -265,9 +309,21 @@ impl CountWorkerSketch {
         threshold: u32,
         emit: &mut impl FnMut(CountDelta),
     ) {
+        self.insert_hashes_emit_delta(&CmWorkerSketch::hashes(self.rows, value), threshold, emit);
+    }
+
+    /// As `insert_emit_delta`, from hashes already computed by
+    /// `CmWorkerSketch::hashes` - the two share a per-row hashing scheme.
+    #[inline(always)]
+    pub fn insert_hashes_emit_delta(
+        &mut self,
+        hashes: &[u64],
+        threshold: u32,
+        emit: &mut impl FnMut(CountDelta),
+    ) {
+        debug_assert_eq!(hashes.len(), self.rows, "one hash per row");
         let threshold = threshold.clamp(1, MAX_PROMASK) as i8;
-        for r in 0..self.rows {
-            let hashed = hash64_seeded(r, value);
+        for (r, hashed) in hashes.iter().copied().enumerate() {
             let col = ((hashed & LOWER_32_MASK) as usize) % self.cols;
             let sign: i8 = if ((hashed >> 63) & 1) == 1 { 1 } else { -1 };
             let cell = &mut self.counters[r * self.cols + col];
@@ -300,17 +356,16 @@ impl CountWorkerSketch {
         }
     }
 
-    /// As `insert_emit_delta`, but each delta carries the flow key.
+    /// As `insert_hashes_emit_delta`, but each delta carries the flow key.
     #[inline(always)]
-    pub fn insert_emit_keyed_delta(
+    pub fn insert_hashes_emit_keyed_delta(
         &mut self,
-        value: &DataInput,
+        hashes: &[u64],
+        key: &HeapItem,
         threshold: u32,
         emit: &mut impl FnMut(KeyedCountDelta),
     ) {
-        let mut key: Option<HeapItem> = None;
-        self.insert_emit_delta(value, threshold, &mut |delta| {
-            let key = key.get_or_insert_with(|| input_to_owned(value));
+        self.insert_hashes_emit_delta(hashes, threshold, &mut |delta| {
             emit(KeyedCountDelta {
                 key: key.clone(),
                 delta,
@@ -396,8 +451,23 @@ impl L2hhWorkerSketch {
         threshold: u32,
         emit: &mut impl FnMut(CountDelta),
     ) {
+        self.insert_hash_emit_delta(hash128_seeded(self.seed_idx, value), threshold, emit);
+    }
+
+    /// Seed this layer hashes under.
+    pub fn seed_idx(&self) -> usize {
+        self.seed_idx
+    }
+
+    /// As `insert_emit_delta`, from a hash already computed under `seed_idx`.
+    #[inline(always)]
+    pub fn insert_hash_emit_delta(
+        &mut self,
+        hashed: u128,
+        threshold: u32,
+        emit: &mut impl FnMut(CountDelta),
+    ) {
         let threshold = threshold.clamp(1, MAX_PROMASK) as u8;
-        let hashed = hash128_seeded(self.seed_idx, value);
         for row in 0..self.rows {
             let (col, sign) = l2hh_cell_for_row(hashed, row, self.cols, self.mask_bits);
             let cell = &mut self.counters[row * self.cols + col];
@@ -531,8 +601,8 @@ pub struct OctoResult<P> {
 }
 
 #[cfg(feature = "octo-runtime")]
-enum WorkerMsg {
-    Data(DataInput<'static>),
+enum WorkerMsg<T> {
+    Data(T),
     /// Promote everything held back, then acknowledge.
     Flush(Sender<()>),
     End,
@@ -545,23 +615,18 @@ enum AggregatorMsg {
 }
 
 #[cfg(feature = "octo-runtime")]
-/// Extends a `DataInput` lifetime to `'static` for cross-thread transport in
-/// streaming mode. Caller must ensure all borrowed data outlives worker processing.
-#[inline(always)]
-unsafe fn assume_input_static(input: DataInput<'_>) -> DataInput<'static> {
-    // SAFETY: enforced by caller contract described above.
-    unsafe { std::mem::transmute::<DataInput<'_>, DataInput<'static>>(input) }
-}
-
-#[cfg(feature = "octo-runtime")]
 /// Streaming Octo runtime that accepts incremental inserts and finalizes into a parent sketch.
-pub struct OctoRuntime<W, P>
+///
+/// Nothing borrowed crosses a thread: [`OctoPlan::prepare`] turns each input
+/// into the worker's payload on the calling thread, so a borrowed key is
+/// finished with by the time `insert` returns.
+pub struct OctoRuntime<L, P>
 where
-    W: OctoWorker + 'static,
-    P: OctoAggregator<Delta = W::Delta> + Send + Sync + 'static,
+    L: OctoPlan,
+    P: OctoAggregator<Delta = <L::Worker as OctoWorker>::Delta> + Send + Sync + 'static,
 {
-    core: Option<OctoCore<P>>,
-    _worker_marker: PhantomData<W>,
+    core: Option<OctoCore<<L::Worker as OctoWorker>::Payload, P>>,
+    plan: L,
 }
 
 #[cfg(feature = "octo-runtime")]
@@ -593,8 +658,8 @@ impl<P> OctoReadHandle<P> {
 }
 
 #[cfg(feature = "octo-runtime")]
-struct OctoCore<P> {
-    worker_input_txs: Vec<Sender<WorkerMsg>>,
+struct OctoCore<T, P> {
+    worker_input_txs: Vec<Sender<WorkerMsg<T>>>,
     control_tx: Sender<AggregatorMsg>,
     next_worker: AtomicUsize,
     partition: OctoPartition,
@@ -605,7 +670,7 @@ struct OctoCore<P> {
 }
 
 #[cfg(feature = "octo-runtime")]
-impl<P> OctoCore<P> {
+impl<T, P> OctoCore<T, P> {
     fn read_handle(&self) -> OctoReadHandle<P> {
         OctoReadHandle {
             parent: Arc::downgrade(&self.parent),
@@ -631,7 +696,7 @@ impl<P> OctoCore<P> {
 }
 
 #[cfg(feature = "octo-runtime")]
-impl<P> OctoCore<P> {
+impl<T, P> OctoCore<T, P> {
     fn into_parent(mut self) -> P {
         self.close();
 
@@ -654,13 +719,14 @@ impl<P> OctoCore<P> {
 }
 
 #[cfg(feature = "octo-runtime")]
-impl<P> OctoCore<P>
+impl<T, P> OctoCore<T, P>
 where
+    T: Send + 'static,
     P: Send + Sync + 'static,
 {
     fn start<W>(workers: Vec<W>, parent: P, config: &OctoConfig) -> Self
     where
-        W: OctoWorker + 'static,
+        W: OctoWorker<Payload = T> + 'static,
         P: OctoAggregator<Delta = W::Delta>,
     {
         let num_workers = config.num_workers.max(1);
@@ -730,7 +796,7 @@ where
         for (worker_id, (mut worker, delta_tx_worker)) in
             workers.into_iter().zip(delta_txs).enumerate()
         {
-            let (worker_tx, worker_rx) = bounded::<WorkerMsg>(queue_capacity);
+            let (worker_tx, worker_rx) = bounded::<WorkerMsg<T>>(queue_capacity);
             worker_input_txs.push(worker_tx);
             worker_handles.push(thread::spawn(move || {
                 if pin_cores {
@@ -738,7 +804,7 @@ where
                 }
                 while let Ok(msg) = worker_rx.recv() {
                     match msg {
-                        WorkerMsg::Data(input) => worker.process(&input, &mut |delta| {
+                        WorkerMsg::Data(payload) => worker.process(&payload, &mut |delta| {
                             delta_tx_worker
                                 .send(delta)
                                 .expect("aggregator receiver dropped while workers still running");
@@ -847,26 +913,30 @@ impl ThresholdController {
 }
 
 #[cfg(feature = "octo-runtime")]
-impl<W, P> OctoRuntime<W, P>
+impl<L, P> OctoRuntime<L, P>
 where
-    W: OctoWorker + 'static,
-    P: OctoAggregator<Delta = W::Delta> + Send + Sync + 'static,
+    L: OctoPlan,
+    P: OctoAggregator<Delta = <L::Worker as OctoWorker>::Delta> + Send + Sync + 'static,
 {
     /// Starts the worker and aggregator threads described by `config`.
-    pub fn new<F, PF>(config: &OctoConfig, worker_factory: F, parent_factory: PF) -> Self
+    pub fn new<PF>(config: &OctoConfig, plan: L, parent_factory: PF) -> Self
     where
-        F: Fn(usize) -> W,
         PF: FnOnce() -> P,
     {
         let num_workers = config.num_workers.max(1);
-        let workers: Vec<W> = (0..num_workers).map(worker_factory).collect();
+        let workers: Vec<L::Worker> = (0..num_workers).map(|id| plan.worker(id)).collect();
         let parent = parent_factory();
         let core = OctoCore::start(workers, parent, config);
 
         Self {
             core: Some(core),
-            _worker_marker: PhantomData,
+            plan,
         }
+    }
+
+    /// Borrows the plan the runtime was built with.
+    pub fn plan(&self) -> &L {
+        &self.plan
     }
 
     /// Returns a handle for reading the parent while the runtime is live.
@@ -883,6 +953,10 @@ where
     }
 
     /// Routes one input to a worker according to the configured partition.
+    ///
+    /// The input is hashed for partitioning and converted to the worker's
+    /// payload here, on the calling thread, so `input` may borrow from storage
+    /// that is dropped as soon as this returns.
     pub fn insert(&mut self, input: DataInput<'_>) {
         let core = self.core.as_ref().expect("runtime core missing");
         if core.closed.load(Ordering::Acquire) {
@@ -890,10 +964,9 @@ where
         }
 
         let worker_id = core.worker_for(&input);
-        // SAFETY: caller explicitly guarantees borrowed data lives long enough.
-        let static_input = unsafe { assume_input_static(input) };
+        let payload = self.plan.prepare(&input);
         core.worker_input_txs[worker_id]
-            .send(WorkerMsg::Data(static_input))
+            .send(WorkerMsg::Data(payload))
             .expect("worker receiver dropped while runtime is active");
     }
 
@@ -955,6 +1028,34 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// Prepared inputs
+// ---------------------------------------------------------------------------
+
+/// Per-row hashes plus the key, for a worker whose deltas carry the key.
+///
+/// The key is owned: a worker that must store it has to copy it, and copying
+/// once at the hand-off is what lets the caller drop the original immediately.
+#[derive(Clone, Debug)]
+pub struct KeyedHashes {
+    /// Per-row hashes, as `CmWorkerSketch::hashes` computes them.
+    pub hashes: RowHashes,
+    /// The flow key.
+    pub key: HeapItem,
+}
+
+/// A prepared UnivMon insert.
+#[derive(Clone, Debug)]
+pub struct UnivMonInput {
+    /// Deepest layer this key reaches; it touches `0..=bottom`.
+    pub bottom: usize,
+    /// One 128-bit hash per touched layer, under that layer's seed. Layer depth
+    /// is geometric, so this is nearly always one or two entries.
+    pub layer_hashes: SmallVec<[u128; 4]>,
+    /// The flow key.
+    pub key: HeapItem,
+}
+
+// ---------------------------------------------------------------------------
 // Concrete worker/parent implementations
 // ---------------------------------------------------------------------------
 
@@ -988,14 +1089,15 @@ impl CmOctoWorker {
 
 impl OctoWorker for CmOctoWorker {
     type Delta = CmDelta;
+    type Payload = RowHashes;
 
     #[inline(always)]
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta),
     {
         self.sketch
-            .insert_emit_delta(input, self.threshold.get(), emit);
+            .insert_hashes_emit_delta(payload, self.threshold.get(), emit);
     }
 
     fn flush<F>(&mut self, emit: &mut F)
@@ -1060,14 +1162,19 @@ impl CmTopKOctoWorker {
 
 impl OctoWorker for CmTopKOctoWorker {
     type Delta = KeyedCmDelta;
+    type Payload = KeyedHashes;
 
     #[inline(always)]
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta),
     {
-        self.sketch
-            .insert_emit_keyed_delta(input, self.threshold.get(), emit);
+        self.sketch.insert_hashes_emit_keyed_delta(
+            &payload.hashes,
+            &payload.key,
+            self.threshold.get(),
+            emit,
+        );
     }
 
     // No flush: every delta carries the key that produced it, and a worker
@@ -1136,14 +1243,15 @@ impl CountOctoWorker {
 
 impl OctoWorker for CountOctoWorker {
     type Delta = CountDelta;
+    type Payload = RowHashes;
 
     #[inline(always)]
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta),
     {
         self.sketch
-            .insert_emit_delta(input, self.threshold.get(), emit);
+            .insert_hashes_emit_delta(payload, self.threshold.get(), emit);
     }
 
     fn flush<F>(&mut self, emit: &mut F)
@@ -1203,14 +1311,19 @@ impl CountTopKOctoWorker {
 
 impl OctoWorker for CountTopKOctoWorker {
     type Delta = KeyedCountDelta;
+    type Payload = KeyedHashes;
 
     #[inline(always)]
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta),
     {
-        self.sketch
-            .insert_emit_keyed_delta(input, self.threshold.get(), emit);
+        self.sketch.insert_hashes_emit_keyed_delta(
+            &payload.hashes,
+            &payload.key,
+            self.threshold.get(),
+            emit,
+        );
     }
 
     // No flush: every delta carries the key that produced it, and a worker
@@ -1350,17 +1463,20 @@ impl DdOctoWorker {
 
 impl OctoWorker for DdOctoWorker {
     type Delta = DdDelta;
+    /// `None` for an input DDSketch cannot index; the conversion happens at
+    /// preparation so a non-numeric key never crosses a thread.
+    type Payload = Option<f64>;
 
     #[inline(always)]
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta),
     {
-        let Ok(value) = data_input_to_f64(input) else {
+        let Some(value) = payload else {
             return;
         };
         self.sketch
-            .add_emit_delta(value, self.threshold.get(), emit);
+            .add_emit_delta(*value, self.threshold.get(), emit);
     }
 
     fn flush<F>(&mut self, emit: &mut F)
@@ -1455,14 +1571,16 @@ impl Default for HllOctoWorker {
 
 impl OctoWorker for HllOctoWorker {
     type Delta = HllDelta;
+    /// The single canonical-seed hash; HLL never needs the key itself.
+    type Payload = u64;
 
     #[inline(always)]
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta),
     {
         self.child
-            .insert_emit_delta_with_threshold(input, self.threshold, emit);
+            .insert_emit_delta_with_hash_and_threshold(*payload, self.threshold, emit);
     }
 
     /// Ships every non-empty register. At the default threshold of 0 nothing is
@@ -1585,22 +1703,27 @@ impl UnivMonOctoWorker {
 
 impl OctoWorker for UnivMonOctoWorker {
     type Delta = LayeredCountDelta;
+    type Payload = UnivMonInput;
 
     #[inline(always)]
-    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    fn process<F>(&mut self, payload: &Self::Payload, emit: &mut F)
     where
         F: FnMut(Self::Delta),
     {
         self.weight_total += 1;
-        let bottom =
-            bottom_layer_for_hash(hash64_seeded(BOTTOM_LAYER_FINDER, input), self.layers.len());
         let threshold = self.threshold.get();
         let (worker_id, weight_total) = (self.worker_id, self.weight_total);
-        let mut key: Option<HeapItem> = None;
-        for layer in 0..=bottom {
+        let bottom = payload.bottom.min(self.layers.len() - 1);
+        for (layer, hashed) in payload
+            .layer_hashes
+            .iter()
+            .copied()
+            .enumerate()
+            .take(bottom + 1)
+        {
             let layer_threshold = univmon_layer_threshold(threshold, layer);
-            self.layers[layer].insert_emit_delta(input, layer_threshold, &mut |delta| {
-                let key = key.get_or_insert_with(|| input_to_owned(input));
+            let key = &payload.key;
+            self.layers[layer].insert_hash_emit_delta(hashed, layer_threshold, &mut |delta| {
                 emit(LayeredCountDelta {
                     layer: layer as u32,
                     key: key.clone(),
@@ -1727,6 +1850,270 @@ impl OctoAggregator for UnivMonOctoAggregator {
 }
 
 // ---------------------------------------------------------------------------
+// Plans: geometry plus the preparation that strips the borrow
+// ---------------------------------------------------------------------------
+
+/// Builds `CmOctoWorker`s and prepares their per-row hashes.
+#[derive(Clone, Debug)]
+pub struct CmOctoPlan {
+    rows: usize,
+    cols: usize,
+    threshold: OctoThreshold,
+}
+
+/// Builds `CountOctoWorker`s and prepares their per-row hashes.
+#[derive(Clone, Debug)]
+pub struct CountOctoPlan {
+    rows: usize,
+    cols: usize,
+    threshold: OctoThreshold,
+}
+
+/// Builds `CmTopKOctoWorker`s; payloads carry the key as well as the hashes.
+#[derive(Clone, Debug)]
+pub struct CmTopKOctoPlan {
+    rows: usize,
+    cols: usize,
+    threshold: OctoThreshold,
+}
+
+/// Builds `CountTopKOctoWorker`s; payloads carry the key as well as the hashes.
+#[derive(Clone, Debug)]
+pub struct CountTopKOctoPlan {
+    rows: usize,
+    cols: usize,
+    threshold: OctoThreshold,
+}
+
+/// Builds `HllOctoWorker`s; payloads are the single canonical-seed hash.
+#[derive(Clone, Debug)]
+pub struct HllOctoPlan {
+    threshold: u8,
+}
+
+/// Builds `DdOctoWorker`s; payloads are the numeric value.
+#[derive(Clone, Debug)]
+pub struct DdOctoPlan {
+    alpha: f64,
+    threshold: OctoThreshold,
+}
+
+/// Builds `UnivMonOctoWorker`s; payloads carry one hash per touched layer plus
+/// the key, since the aggregator's heaps need it.
+#[derive(Clone, Debug)]
+pub struct UnivMonOctoPlan {
+    rows: usize,
+    cols: usize,
+    layers: usize,
+    threshold: OctoThreshold,
+}
+
+macro_rules! counter_plan {
+    ($plan:ident, $worker:ident, $default:expr) => {
+        impl $plan {
+            /// Creates a plan at the sketch's default threshold.
+            pub fn new(rows: usize, cols: usize) -> Self {
+                Self::with_threshold(rows, cols, OctoThreshold::new($default))
+            }
+
+            /// Creates a plan whose workers share `threshold`.
+            pub fn with_threshold(rows: usize, cols: usize, threshold: OctoThreshold) -> Self {
+                Self {
+                    rows,
+                    cols,
+                    threshold,
+                }
+            }
+
+            /// The threshold this plan's workers read. Clone it into
+            /// `OctoConfig::threshold` so the controller drives the same value.
+            pub fn threshold(&self) -> &OctoThreshold {
+                &self.threshold
+            }
+        }
+    };
+}
+
+counter_plan!(CmOctoPlan, CmOctoWorker, CM_PROMASK);
+counter_plan!(CountOctoPlan, CountOctoWorker, COUNT_PROMASK);
+counter_plan!(CmTopKOctoPlan, CmTopKOctoWorker, CM_PROMASK);
+counter_plan!(CountTopKOctoPlan, CountTopKOctoWorker, COUNT_PROMASK);
+
+impl OctoPlan for CmOctoPlan {
+    type Worker = CmOctoWorker;
+
+    fn worker(&self, _worker_id: usize) -> Self::Worker {
+        CmOctoWorker::with_threshold(self.rows, self.cols, self.threshold.clone())
+    }
+
+    fn prepare(&self, input: &DataInput<'_>) -> RowHashes {
+        CmWorkerSketch::hashes(self.rows, input)
+    }
+}
+
+impl OctoPlan for CountOctoPlan {
+    type Worker = CountOctoWorker;
+
+    fn worker(&self, _worker_id: usize) -> Self::Worker {
+        CountOctoWorker::with_threshold(self.rows, self.cols, self.threshold.clone())
+    }
+
+    fn prepare(&self, input: &DataInput<'_>) -> RowHashes {
+        CmWorkerSketch::hashes(self.rows, input)
+    }
+}
+
+impl OctoPlan for CmTopKOctoPlan {
+    type Worker = CmTopKOctoWorker;
+
+    fn worker(&self, _worker_id: usize) -> Self::Worker {
+        CmTopKOctoWorker::with_threshold(self.rows, self.cols, self.threshold.clone())
+    }
+
+    fn prepare(&self, input: &DataInput<'_>) -> KeyedHashes {
+        KeyedHashes {
+            hashes: CmWorkerSketch::hashes(self.rows, input),
+            key: input_to_owned(input),
+        }
+    }
+}
+
+impl OctoPlan for CountTopKOctoPlan {
+    type Worker = CountTopKOctoWorker;
+
+    fn worker(&self, _worker_id: usize) -> Self::Worker {
+        CountTopKOctoWorker::with_threshold(self.rows, self.cols, self.threshold.clone())
+    }
+
+    fn prepare(&self, input: &DataInput<'_>) -> KeyedHashes {
+        KeyedHashes {
+            hashes: CmWorkerSketch::hashes(self.rows, input),
+            key: input_to_owned(input),
+        }
+    }
+}
+
+impl HllOctoPlan {
+    /// Creates a plan at the default threshold, which promotes every register
+    /// improvement and leaves the parent exact.
+    pub fn new() -> Self {
+        Self::with_threshold(HLL_PROMASK)
+    }
+
+    /// Creates a plan at a custom threshold exponent.
+    pub fn with_threshold(threshold: u8) -> Self {
+        // Fail here rather than at the first worker, where it would surface on
+        // a background thread.
+        let _ = HllOctoWorker::with_threshold(threshold);
+        Self { threshold }
+    }
+}
+
+impl Default for HllOctoPlan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OctoPlan for HllOctoPlan {
+    type Worker = HllOctoWorker;
+
+    fn worker(&self, _worker_id: usize) -> Self::Worker {
+        HllOctoWorker::with_threshold(self.threshold)
+    }
+
+    fn prepare(&self, input: &DataInput<'_>) -> u64 {
+        HyperLogLog::<Classic>::canonical_hash(input)
+    }
+}
+
+impl DdOctoPlan {
+    /// Creates a plan at the DDSketch default threshold.
+    pub fn new(alpha: f64) -> Self {
+        Self::with_threshold(alpha, OctoThreshold::new(DD_PROMASK))
+    }
+
+    /// Creates a plan whose workers share `threshold`.
+    pub fn with_threshold(alpha: f64, threshold: OctoThreshold) -> Self {
+        Self { alpha, threshold }
+    }
+
+    /// Relative accuracy of the bucket space.
+    pub fn alpha(&self) -> f64 {
+        self.alpha
+    }
+
+    /// The threshold this plan's workers read.
+    pub fn threshold(&self) -> &OctoThreshold {
+        &self.threshold
+    }
+}
+
+impl OctoPlan for DdOctoPlan {
+    type Worker = DdOctoWorker;
+
+    fn worker(&self, _worker_id: usize) -> Self::Worker {
+        DdOctoWorker::with_threshold(self.alpha, self.threshold.clone())
+    }
+
+    fn prepare(&self, input: &DataInput<'_>) -> Option<f64> {
+        data_input_to_f64(input).ok()
+    }
+}
+
+impl UnivMonOctoPlan {
+    /// Creates a plan at the UnivMon default threshold.
+    pub fn new(rows: usize, cols: usize, layers: usize) -> Self {
+        Self::with_threshold(rows, cols, layers, OctoThreshold::new(UNIVMON_PROMASK))
+    }
+
+    /// Creates a plan whose workers share `threshold`.
+    pub fn with_threshold(
+        rows: usize,
+        cols: usize,
+        layers: usize,
+        threshold: OctoThreshold,
+    ) -> Self {
+        Self {
+            rows,
+            cols,
+            layers: layers.max(1),
+            threshold,
+        }
+    }
+
+    /// The threshold this plan's workers read.
+    pub fn threshold(&self) -> &OctoThreshold {
+        &self.threshold
+    }
+}
+
+impl OctoPlan for UnivMonOctoPlan {
+    type Worker = UnivMonOctoWorker;
+
+    fn worker(&self, worker_id: usize) -> Self::Worker {
+        UnivMonOctoWorker::with_threshold(
+            worker_id,
+            self.rows,
+            self.cols,
+            self.layers,
+            self.threshold.clone(),
+        )
+    }
+
+    fn prepare(&self, input: &DataInput<'_>) -> UnivMonInput {
+        // Only the layers this key actually reaches get hashed. Layer depth is
+        // geometric, so that is nearly always one or two.
+        let bottom = bottom_layer_for_hash(hash64_seeded(BOTTOM_LAYER_FINDER, input), self.layers);
+        UnivMonInput {
+            bottom,
+            layer_hashes: (0..=bottom).map(|l| hash128_seeded(l, input)).collect(),
+            key: input_to_owned(input),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Core execution engine
 // ---------------------------------------------------------------------------
 
@@ -1737,17 +2124,17 @@ impl OctoAggregator for UnivMonOctoAggregator {
 /// 2. Each worker maintains a compact child sketch, emitting deltas on its own channel.
 /// 3. The aggregator applies deltas to the parent and, if configured, adjusts τ.
 /// 4. Returns the fully-merged parent sketch.
-pub fn run_octo<W, P>(
+pub fn run_octo<L, P>(
     inputs: &[DataInput<'_>],
     config: &OctoConfig,
-    worker_factory: impl Fn(usize) -> W,
+    plan: L,
     parent_factory: impl FnOnce() -> P,
 ) -> OctoResult<P>
 where
-    W: OctoWorker + 'static,
-    P: OctoAggregator<Delta = W::Delta> + Send + Sync + 'static,
+    L: OctoPlan,
+    P: OctoAggregator<Delta = <L::Worker as OctoWorker>::Delta> + Send + Sync + 'static,
 {
-    let mut runtime = OctoRuntime::new(config, worker_factory, parent_factory);
+    let mut runtime = OctoRuntime::new(config, plan, parent_factory);
     for input in inputs {
         runtime.insert(input.clone());
     }
@@ -1823,7 +2210,12 @@ mod worker_tests {
         let key = DataInput::Str("flow-a");
         let mut keyed: Vec<KeyedCmDelta> = Vec::new();
         for _ in 0..CM_PROMASK {
-            worker.insert_emit_keyed_delta(&key, CM_PROMASK, &mut |d| keyed.push(d));
+            worker.insert_hashes_emit_keyed_delta(
+                &CmWorkerSketch::hashes(2, &key),
+                &input_to_owned(&key),
+                CM_PROMASK,
+                &mut |d| keyed.push(d),
+            );
         }
         assert!(!keyed.is_empty());
         for d in &keyed {
@@ -2136,12 +2528,9 @@ mod runtime_tests {
             reference.insert(input);
         }
 
-        let result = run_octo(
-            &inputs,
-            &config(4),
-            |_| CmOctoWorker::new(rows, cols),
-            || CmOctoAggregator::new(rows, cols),
-        );
+        let result = run_octo(&inputs, &config(4), CmOctoPlan::new(rows, cols), || {
+            CmOctoAggregator::new(rows, cols)
+        });
 
         // A counter is shared by whatever flows hash into it, and each worker
         // may hold back up to tau of its own share, so the provable ceiling is
@@ -2170,7 +2559,7 @@ mod runtime_tests {
         let result = run_octo(
             &inputs,
             &config(4),
-            |_| HllOctoWorker::new(),
+            HllOctoPlan::new(),
             HllOctoAggregator::new,
         );
         assert_eq!(
@@ -2186,13 +2575,9 @@ mod runtime_tests {
             partition: OctoPartition::HashByKey,
             ..config(workers)
         };
-        let mut runtime = OctoRuntime::new(
-            &cfg,
-            |worker_id| WorkerIdEmitter { worker_id },
-            || WorkerLoadAggregator {
-                loads: vec![0; workers],
-            },
-        );
+        let mut runtime = OctoRuntime::new(&cfg, WorkerIdPlan, || WorkerLoadAggregator {
+            loads: vec![0; workers],
+        });
         // One key, many inserts: a hash partition must pile them all on one worker.
         for _ in 0..1_000 {
             runtime.insert(DataInput::U64(4_242));
@@ -2209,13 +2594,9 @@ mod runtime_tests {
             partition: OctoPartition::RoundRobin,
             ..config(workers)
         };
-        let mut runtime = OctoRuntime::new(
-            &cfg,
-            |worker_id| WorkerIdEmitter { worker_id },
-            || WorkerLoadAggregator {
-                loads: vec![0; workers],
-            },
-        );
+        let mut runtime = OctoRuntime::new(&cfg, WorkerIdPlan, || WorkerLoadAggregator {
+            loads: vec![0; workers],
+        });
         for i in 0..10u64 {
             runtime.insert(DataInput::U64(i));
         }
@@ -2229,13 +2610,31 @@ mod runtime_tests {
 
     impl OctoWorker for ThresholdReporter {
         type Delta = u32;
+        type Payload = ();
 
-        fn process<F>(&mut self, _input: &DataInput, emit: &mut F)
+        fn process<F>(&mut self, _payload: &(), emit: &mut F)
         where
             F: FnMut(Self::Delta),
         {
             emit(self.threshold.get());
         }
+    }
+
+    #[derive(Clone)]
+    struct ThresholdReporterPlan {
+        threshold: OctoThreshold,
+    }
+
+    impl OctoPlan for ThresholdReporterPlan {
+        type Worker = ThresholdReporter;
+
+        fn worker(&self, _worker_id: usize) -> Self::Worker {
+            ThresholdReporter {
+                threshold: self.threshold.clone(),
+            }
+        }
+
+        fn prepare(&self, _input: &DataInput<'_>) {}
     }
 
     struct ThresholdCollector {
@@ -2263,11 +2662,8 @@ mod runtime_tests {
         let result = run_octo(
             &inputs,
             &cfg,
-            {
-                let threshold = threshold.clone();
-                move |_| ThresholdReporter {
-                    threshold: threshold.clone(),
-                }
+            ThresholdReporterPlan {
+                threshold: threshold.clone(),
             },
             || ThresholdCollector { seen: Vec::new() },
         );
@@ -2423,10 +2819,7 @@ mod runtime_tests {
         let result = run_octo(
             &inputs,
             &cfg,
-            {
-                let threshold = threshold.clone();
-                move |_| CmOctoWorker::with_threshold(rows, cols, threshold.clone())
-            },
+            CmOctoPlan::with_threshold(rows, cols, threshold.clone()),
             || CmOctoAggregator::new(rows, cols),
         );
 
@@ -2465,12 +2858,9 @@ mod runtime_tests {
             inputs.push(DataInput::U64(i));
         }
 
-        let result = run_octo(
-            &inputs,
-            &config(4),
-            |_| CmTopKOctoWorker::new(rows, cols),
-            || CmTopKOctoAggregator::new(rows, cols, top_k),
-        );
+        let result = run_octo(&inputs, &config(4), CmTopKOctoPlan::new(rows, cols), || {
+            CmTopKOctoAggregator::new(rows, cols, top_k)
+        });
 
         let heap = result.parent.sketch.heap();
         assert!(!heap.is_empty(), "the aggregator must have built a heap");
@@ -2503,7 +2893,7 @@ mod runtime_tests {
         let result = run_octo(
             &inputs,
             &config(4),
-            |_| CountTopKOctoWorker::new(rows, cols),
+            CountTopKOctoPlan::new(rows, cols),
             || CountTopKOctoAggregator::new(rows, cols, top_k),
         );
         for hot in 0..3u64 {
@@ -2534,12 +2924,9 @@ mod runtime_tests {
             .collect();
         exact.sort_by(f64::total_cmp);
 
-        let result = run_octo(
-            &inputs,
-            &config(4),
-            |_| DdOctoWorker::new(alpha),
-            || DdOctoAggregator::new(alpha),
-        );
+        let result = run_octo(&inputs, &config(4), DdOctoPlan::new(alpha), || {
+            DdOctoAggregator::new(alpha)
+        });
 
         // Four workers each hold back their own partial buckets, so the rank
         // slack is what the whole fleet has yet to promote.
@@ -2587,18 +2974,7 @@ mod runtime_tests {
         let result = run_octo(
             &inputs,
             &cfg,
-            {
-                let threshold = threshold.clone();
-                move |worker_id| {
-                    UnivMonOctoWorker::with_threshold(
-                        worker_id,
-                        rows,
-                        cols,
-                        layers,
-                        threshold.clone(),
-                    )
-                }
-            },
+            UnivMonOctoPlan::with_threshold(rows, cols, layers, threshold.clone()),
             || UnivMonOctoAggregator::new(heap, rows, cols, layers, tau),
         );
         let univmon = &result.parent.sketch;
@@ -2636,18 +3012,13 @@ mod runtime_tests {
         let inputs: Vec<DataInput<'_>> = (0..30_000u64).map(|i| DataInput::U64(i % 1024)).collect();
         let cfg = config(4);
 
-        let batch = run_octo(
-            &inputs,
-            &cfg,
-            |_| CmOctoWorker::new(rows, cols),
-            || CmOctoAggregator::new(rows, cols),
-        );
+        let batch = run_octo(&inputs, &cfg, CmOctoPlan::new(rows, cols), || {
+            CmOctoAggregator::new(rows, cols)
+        });
 
-        let mut runtime = OctoRuntime::new(
-            &cfg,
-            move |_| CmOctoWorker::new(rows, cols),
-            move || CmOctoAggregator::new(rows, cols),
-        );
+        let mut runtime = OctoRuntime::new(&cfg, CmOctoPlan::new(rows, cols), move || {
+            CmOctoAggregator::new(rows, cols)
+        });
         for input in &inputs {
             runtime.insert(input.clone());
         }
@@ -2681,12 +3052,9 @@ mod runtime_tests {
             .collect();
         exact.sort_by(f64::total_cmp);
 
-        let result = run_octo(
-            &inputs,
-            &config(4),
-            |_| DdOctoWorker::new(alpha),
-            || DdOctoAggregator::new(alpha),
-        );
+        let result = run_octo(&inputs, &config(4), DdOctoPlan::new(alpha), || {
+            DdOctoAggregator::new(alpha)
+        });
         let parent = &result.parent.sketch;
 
         assert_eq!(
@@ -2713,11 +3081,9 @@ mod runtime_tests {
     fn a_mid_stream_flush_makes_the_live_parent_answerable() {
         let alpha = 0.01;
         let values: Vec<f64> = (1..=20_000u64).map(|i| 1.0 + i as f64 * 0.37).collect();
-        let mut runtime = OctoRuntime::new(
-            &config(4),
-            |_| DdOctoWorker::new(alpha),
-            || DdOctoAggregator::new(alpha),
-        );
+        let mut runtime = OctoRuntime::new(&config(4), DdOctoPlan::new(alpha), || {
+            DdOctoAggregator::new(alpha)
+        });
         let reader = runtime.read_handle();
 
         let half = values.len() / 2;
@@ -2747,11 +3113,9 @@ mod runtime_tests {
     #[test]
     fn flushing_twice_is_harmless() {
         let alpha = 0.01;
-        let mut runtime = OctoRuntime::new(
-            &config(2),
-            |_| DdOctoWorker::new(alpha),
-            || DdOctoAggregator::new(alpha),
-        );
+        let mut runtime = OctoRuntime::new(&config(2), DdOctoPlan::new(alpha), || {
+            DdOctoAggregator::new(alpha)
+        });
         for i in 1..=5_000u64 {
             runtime.insert(DataInput::F64(i as f64));
         }
@@ -2766,12 +3130,9 @@ mod runtime_tests {
         // the point of query, where before the parent was low by under tau.
         let (rows, cols) = (3usize, 1024usize);
         let inputs: Vec<DataInput<'_>> = (0..40_000u64).map(|i| DataInput::U64(i % 512)).collect();
-        let got = run_octo(
-            &inputs,
-            &config(4),
-            |_| CmOctoWorker::new(rows, cols),
-            || CmOctoAggregator::new(rows, cols),
-        );
+        let got = run_octo(&inputs, &config(4), CmOctoPlan::new(rows, cols), || {
+            CmOctoAggregator::new(rows, cols)
+        });
         let mut reference = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
         for input in &inputs {
             reference.insert(input);
@@ -2789,8 +3150,7 @@ mod runtime_tests {
 
     #[test]
     fn octo_runtime_close_is_idempotent() {
-        let runtime =
-            OctoRuntime::new(&config(2), |_| HllOctoWorker::new(), HllOctoAggregator::new);
+        let runtime = OctoRuntime::new(&config(2), HllOctoPlan::new(), HllOctoAggregator::new);
         runtime.close();
         runtime.close();
         assert_eq!(runtime.finish().parent.sketch.estimate(), 0);
@@ -2799,27 +3159,22 @@ mod runtime_tests {
     #[test]
     #[should_panic(expected = "cannot insert after runtime has been closed")]
     fn octo_runtime_insert_after_close_panics() {
-        let mut runtime =
-            OctoRuntime::new(&config(2), |_| HllOctoWorker::new(), HllOctoAggregator::new);
+        let mut runtime = OctoRuntime::new(&config(2), HllOctoPlan::new(), HllOctoAggregator::new);
         runtime.close();
         runtime.insert(DataInput::U64(1));
     }
 
     #[test]
     fn octo_runtime_empty_stream_finishes() {
-        let runtime =
-            OctoRuntime::new(&config(4), |_| HllOctoWorker::new(), HllOctoAggregator::new);
+        let runtime = OctoRuntime::new(&config(4), HllOctoPlan::new(), HllOctoAggregator::new);
         assert_eq!(runtime.finish().parent.sketch.estimate(), 0);
     }
 
     #[test]
     fn octo_runtime_live_read_handle_tracks_the_aggregator() {
         let n = 64u64;
-        let mut runtime = OctoRuntime::new(
-            &config(2),
-            |_| CountingWorker,
-            || CountingAggregator { total: 0 },
-        );
+        let mut runtime =
+            OctoRuntime::new(&config(2), CountingPlan, || CountingAggregator { total: 0 });
         let reader = runtime.read_handle();
         assert_eq!(reader.with_parent(|p| p.total), 0, "nothing inserted yet");
 
@@ -2856,11 +3211,8 @@ mod runtime_tests {
     #[test]
     fn octo_runtime_close_preserves_queued_items() {
         let n = 257u64;
-        let mut runtime = OctoRuntime::new(
-            &config(4),
-            |_| CountingWorker,
-            || CountingAggregator { total: 0 },
-        );
+        let mut runtime =
+            OctoRuntime::new(&config(4), CountingPlan, || CountingAggregator { total: 0 });
         for i in 0..n {
             runtime.insert(DataInput::U64(i + 42));
         }
@@ -2872,13 +3224,26 @@ mod runtime_tests {
 
     impl OctoWorker for CountingWorker {
         type Delta = u64;
+        type Payload = ();
 
-        fn process<F>(&mut self, _input: &DataInput, emit: &mut F)
+        fn process<F>(&mut self, _payload: &(), emit: &mut F)
         where
             F: FnMut(Self::Delta),
         {
             emit(1);
         }
+    }
+
+    struct CountingPlan;
+
+    impl OctoPlan for CountingPlan {
+        type Worker = CountingWorker;
+
+        fn worker(&self, _worker_id: usize) -> Self::Worker {
+            CountingWorker
+        }
+
+        fn prepare(&self, _input: &DataInput<'_>) {}
     }
 
     struct CountingAggregator {
@@ -2899,13 +3264,26 @@ mod runtime_tests {
 
     impl OctoWorker for WorkerIdEmitter {
         type Delta = usize;
+        type Payload = ();
 
-        fn process<F>(&mut self, _input: &DataInput, emit: &mut F)
+        fn process<F>(&mut self, _payload: &(), emit: &mut F)
         where
             F: FnMut(Self::Delta),
         {
             emit(self.worker_id);
         }
+    }
+
+    struct WorkerIdPlan;
+
+    impl OctoPlan for WorkerIdPlan {
+        type Worker = WorkerIdEmitter;
+
+        fn worker(&self, worker_id: usize) -> Self::Worker {
+            WorkerIdEmitter { worker_id }
+        }
+
+        fn prepare(&self, _input: &DataInput<'_>) {}
     }
 
     struct WorkerLoadAggregator {
@@ -2994,12 +3372,13 @@ mod univmon_tests {
             reference.insert(input, 1);
         }
 
+        let preparer = UnivMonOctoPlan::with_threshold(ROWS, COLS, LAYERS, OctoThreshold::new(1));
         let mut worker =
             UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, OctoThreshold::new(1));
         let mut aggregator = UnivMonOctoAggregator::new(HEAP, ROWS, COLS, LAYERS, 1);
         for input in &inputs {
             let mut promoted = Vec::new();
-            worker.process(input, &mut |d| promoted.push(d));
+            worker.process(&preparer.prepare(input), &mut |d| promoted.push(d));
             for delta in promoted {
                 aggregator.apply(delta);
             }
@@ -3046,12 +3425,14 @@ mod univmon_tests {
             reference.insert(input, 1);
         }
 
+        let preparer =
+            UnivMonOctoPlan::with_threshold(ROWS, COLS, LAYERS, OctoThreshold::new(threshold));
         let mut worker =
             UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, OctoThreshold::new(threshold));
         let mut aggregator = UnivMonOctoAggregator::new(HEAP, ROWS, COLS, LAYERS, threshold);
         for input in &inputs {
             let mut promoted = Vec::new();
-            worker.process(input, &mut |d| promoted.push(d));
+            worker.process(&preparer.prepare(input), &mut |d| promoted.push(d));
             for delta in promoted {
                 aggregator.apply(delta);
             }
@@ -3081,12 +3462,14 @@ mod univmon_tests {
     fn completeness_is_withdrawn_exactly_where_the_layer_thresholds() {
         let base = 8u32;
         let inputs = stream(5_000);
+        let preparer =
+            UnivMonOctoPlan::with_threshold(ROWS, COLS, LAYERS, OctoThreshold::new(base));
         let mut worker =
             UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, OctoThreshold::new(base));
         let mut aggregator = UnivMonOctoAggregator::new(HEAP, ROWS, COLS, LAYERS, base);
         for input in &inputs {
             let mut promoted = Vec::new();
-            worker.process(input, &mut |d| promoted.push(d));
+            worker.process(&preparer.prepare(input), &mut |d| promoted.push(d));
             for delta in promoted {
                 aggregator.apply(delta);
             }
@@ -3119,15 +3502,20 @@ mod univmon_tests {
         assert!(thresholding > 0 && exact > 0, "{thresholding} / {exact}");
     }
 
+    fn plan(threshold: &OctoThreshold) -> UnivMonOctoPlan {
+        UnivMonOctoPlan::with_threshold(ROWS, COLS, LAYERS, threshold.clone())
+    }
+
     /// Drives one worker/aggregator pair over `inputs`.
     fn drive(
+        plan: &UnivMonOctoPlan,
         worker: &mut UnivMonOctoWorker,
         aggregator: &mut UnivMonOctoAggregator,
         inputs: &[DataInput<'_>],
     ) {
         for input in inputs {
             let mut promoted = Vec::new();
-            worker.process(input, &mut |d| promoted.push(d));
+            worker.process(&plan.prepare(input), &mut |d| promoted.push(d));
             for delta in promoted {
                 aggregator.apply(delta);
             }
@@ -3145,15 +3533,16 @@ mod univmon_tests {
             UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, threshold.clone());
         let mut aggregator =
             UnivMonOctoAggregator::with_threshold(HEAP, ROWS, COLS, LAYERS, threshold.clone());
+        let pl = plan(&threshold);
         let inputs = stream(4_000);
-        drive(&mut worker, &mut aggregator, &inputs);
+        drive(&pl, &mut worker, &mut aggregator, &inputs);
         assert!(
             aggregator.sketch.candidates_complete().iter().any(|c| *c),
             "at tau = 1 the aggregator sees every insert, so some layer should still be complete"
         );
 
         threshold.set(64);
-        drive(&mut worker, &mut aggregator, &inputs);
+        drive(&pl, &mut worker, &mut aggregator, &inputs);
         for (layer, complete) in aggregator.sketch.candidates_complete().iter().enumerate() {
             if univmon_layer_threshold(64, layer) > 1 {
                 assert!(
@@ -3173,11 +3562,12 @@ mod univmon_tests {
         let mut first = UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, threshold.clone());
         let mut second =
             UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, threshold.clone());
+        let pl = plan(&threshold);
         let mut aggregator =
             UnivMonOctoAggregator::with_threshold(HEAP, ROWS, COLS, LAYERS, threshold);
         let inputs = stream(200);
-        drive(&mut first, &mut aggregator, &inputs);
-        drive(&mut second, &mut aggregator, &inputs);
+        drive(&pl, &mut first, &mut aggregator, &inputs);
+        drive(&pl, &mut second, &mut aggregator, &inputs);
     }
 
     #[test]
@@ -3204,9 +3594,10 @@ mod univmon_tests {
         // And no key storage: a worker's footprint must not grow with the
         // number of distinct keys it has seen, however long the strings are.
         let before = worker.counter_bytes();
+        let preparer = UnivMonOctoPlan::new(ROWS, COLS, LAYERS);
         let keys: Vec<String> = (0..5_000).map(|i| format!("flow-{i:040}")).collect();
         for key in &keys {
-            worker.process(&DataInput::Str(key), &mut |_| {});
+            worker.process(&preparer.prepare(&DataInput::Str(key)), &mut |_| {});
         }
         assert_eq!(
             worker.counter_bytes(),

--- a/src/sketch_framework/octo.rs
+++ b/src/sketch_framework/octo.rs
@@ -229,9 +229,7 @@ impl CountWorkerSketch {
         threshold: u32,
         emit: &mut impl FnMut(CountDelta),
     ) {
-        // A signed one-byte counter reaches -128 before +127, so the usable
-        // magnitude is i8::MAX.
-        let threshold = threshold.clamp(1, i8::MAX as u32) as i8;
+        let threshold = threshold.clamp(1, MAX_PROMASK) as i8;
         for r in 0..self.rows {
             let hashed = hash64_seeded(r, value);
             let col = ((hashed & LOWER_32_MASK) as usize) % self.cols;
@@ -290,12 +288,22 @@ impl L2hhWorkerSketch {
     pub fn new(rows: usize, cols: usize, seed_idx: usize) -> Self {
         let rows = rows.max(1);
         let cols = cols.max(1);
+        let mask_bits = cols_mask_bits(cols);
+        // Every row slices its column out of the same 128-bit hash, so the
+        // rows collectively have 128 bits to spend. Past that the shift is
+        // undefined: debug builds panic and release builds wrap, aliasing a
+        // deep row onto a shallow one's column bits.
+        assert!(
+            rows * mask_bits as usize <= 128,
+            "{rows} rows x {mask_bits} column bits exceeds the 128-bit hash budget; \
+             reduce rows or columns"
+        );
         Self {
             counters: vec![0i8; rows * cols],
             rows,
             cols,
             seed_idx,
-            mask_bits: cols_mask_bits(cols),
+            mask_bits,
         }
     }
 
@@ -318,7 +326,7 @@ impl L2hhWorkerSketch {
         threshold: u32,
         emit: &mut impl FnMut(CountDelta),
     ) {
-        let threshold = threshold.clamp(1, i8::MAX as u32) as u8;
+        let threshold = threshold.clamp(1, MAX_PROMASK) as u8;
         let hashed = hash128_seeded(self.seed_idx, value);
         for row in 0..self.rows {
             let (col, sign) = l2hh_cell_for_row(hashed, row, self.cols, self.mask_bits);
@@ -682,10 +690,20 @@ impl ThresholdController {
     const POLLS_BETWEEN_CLOCK_READS: u32 = 256;
 
     fn new(settings: &OctoAdaptiveThreshold) -> Self {
+        let mut settings = settings.clone();
+        // `OctoAdaptiveThreshold` has public fields, and `clamp` panics on an
+        // inverted range. Normalising here keeps a misconfigured band from
+        // killing the aggregator thread and surfacing as an unrelated
+        // "worker receiver dropped" panic on the caller's thread.
+        settings.min_threshold = settings.min_threshold.clamp(1, MAX_PROMASK);
+        settings.max_threshold = settings
+            .max_threshold
+            .clamp(settings.min_threshold, MAX_PROMASK);
+        let next_check = Instant::now() + settings.interval;
         Self {
-            settings: settings.clone(),
+            settings,
             previous_queue_len: 0.0,
-            next_check: Instant::now() + settings.interval,
+            next_check,
             polls_since_check: 0,
         }
     }
@@ -1195,6 +1213,16 @@ pub struct HllOctoWorker {
     threshold: u8,
 }
 
+/// Largest HLL threshold exponent that can still fire at precision `p`.
+///
+/// A register holds a leading-zero count of at most `64 - p + 1`, so the gain
+/// `2^C' - 2^C` never reaches `2^(64 - p)`. A threshold at or above that
+/// silently promotes nothing at all, leaving the parent empty.
+#[inline(always)]
+pub const fn max_hll_threshold(precision: u8) -> u8 {
+    64 - precision
+}
+
 impl HllOctoWorker {
     /// Creates a HyperLogLog-backed Octo worker at the default threshold,
     /// which promotes every register improvement.
@@ -1204,11 +1232,24 @@ impl HllOctoWorker {
 
     /// Creates a worker that promotes a register only once the improvement in
     /// `2^register` reaches `2^threshold`.
+    ///
+    /// # Panics
+    ///
+    /// If `threshold` is large enough that no register improvement can ever
+    /// reach it. Such a worker promotes nothing at all and leaves the parent
+    /// empty, which is worse than any accuracy trade the caller was after, so
+    /// it is refused rather than silently accepted. Useful values are small -
+    /// the paper finds 2 sufficient, and 0 makes the parent exact.
     pub fn with_threshold(threshold: u8) -> Self {
-        Self {
-            child: HyperLogLog::default(),
-            threshold,
-        }
+        let child = HyperLogLog::<Classic>::default();
+        let precision = child.registers_as_slice().len().ilog2() as u8;
+        let ceiling = max_hll_threshold(precision);
+        assert!(
+            threshold < ceiling,
+            "HLL threshold {threshold} can never fire at precision {precision}; \
+             the largest register gain is below 2^{ceiling}"
+        );
+        Self { child, threshold }
     }
 }
 
@@ -1368,6 +1409,9 @@ impl OctoWorker for UnivMonOctoWorker {
 pub struct UnivMonOctoAggregator {
     /// Parent UnivMon updated by worker deltas.
     pub sketch: UnivMon,
+    threshold: OctoThreshold,
+    /// τ the per-layer fidelity was last computed from.
+    fidelity_threshold: u32,
     fidelity: Vec<UnivMonDeltaFidelity>,
     worker_weights: Vec<u64>,
     total_weight: u64,
@@ -1385,30 +1429,57 @@ impl UnivMonOctoAggregator {
         layer_size: usize,
         threshold: u32,
     ) -> Self {
-        let mut sketch = UnivMon::init_univmon(heap_size, sketch_row, sketch_col, layer_size);
-        // Each layer runs its own scaled threshold, so completeness is decided
-        // per layer: one that promotes every insert can still keep the heap's
-        // own verdict, while one that thresholds has provably missed keys and
-        // must give the flag up before any delta arrives.
-        let fidelity: Vec<UnivMonDeltaFidelity> = (0..layer_size)
-            .map(|layer| {
-                if univmon_layer_threshold(threshold, layer) <= 1 {
-                    UnivMonDeltaFidelity::EveryInsert
-                } else {
-                    UnivMonDeltaFidelity::PromotedOnly
-                }
-            })
-            .collect();
-        for (layer, mode) in fidelity.iter().enumerate() {
-            if *mode == UnivMonDeltaFidelity::PromotedOnly {
-                sketch.mark_layer_candidates_incomplete(layer);
-            }
-        }
-        Self {
-            sketch,
-            fidelity,
+        Self::with_threshold(
+            heap_size,
+            sketch_row,
+            sketch_col,
+            layer_size,
+            OctoThreshold::new(threshold),
+        )
+    }
+
+    /// Creates an aggregator that reads the same live threshold its workers do.
+    ///
+    /// Completeness has to track τ rather than a snapshot of it: with the
+    /// adaptive controller running, a layer that started at τ = 1 can be
+    /// raised above it mid-stream, and a stale `EveryInsert` verdict would let
+    /// `heavy_threshold` take its permissive branch and overcount.
+    pub fn with_threshold(
+        heap_size: usize,
+        sketch_row: usize,
+        sketch_col: usize,
+        layer_size: usize,
+        threshold: OctoThreshold,
+    ) -> Self {
+        let mut this = Self {
+            sketch: UnivMon::init_univmon(heap_size, sketch_row, sketch_col, layer_size),
+            fidelity_threshold: u32::MAX,
+            fidelity: vec![UnivMonDeltaFidelity::EveryInsert; layer_size],
+            threshold,
             worker_weights: Vec::new(),
             total_weight: 0,
+        };
+        this.refresh_fidelity();
+        this
+    }
+
+    /// Recomputes per-layer fidelity from the current τ, withdrawing
+    /// completeness wherever a layer now thresholds. Withdrawal is one-way: a
+    /// layer that has ever thresholded stays partial for the rest of the run.
+    fn refresh_fidelity(&mut self) {
+        let threshold = self.threshold.get();
+        if threshold == self.fidelity_threshold {
+            return;
+        }
+        self.fidelity_threshold = threshold;
+        for layer in 0..self.fidelity.len() {
+            if univmon_layer_threshold(threshold, layer) > 1 {
+                self.fidelity[layer] = UnivMonDeltaFidelity::PromotedOnly;
+                // A layer that receives traffic but never promotes any of it
+                // sends nothing, so the flag has to come down before a delta
+                // arrives rather than when one does.
+                self.sketch.mark_layer_candidates_incomplete(layer);
+            }
         }
     }
 }
@@ -1418,16 +1489,25 @@ impl OctoAggregator for UnivMonOctoAggregator {
 
     #[inline(always)]
     fn apply(&mut self, delta: LayeredCountDelta) {
+        self.refresh_fidelity();
+
         let worker = delta.worker_id as usize;
         if worker >= self.worker_weights.len() {
             self.worker_weights.resize(worker + 1, 0);
         }
-        // A worker's running total only grows, so the newest report wins and
-        // the fleet total is the sum of the newest report from each.
-        if delta.weight_total > self.worker_weights[worker] {
-            self.total_weight += delta.weight_total - self.worker_weights[worker];
-            self.worker_weights[worker] = delta.weight_total;
-        }
+        // A single worker's running total only grows, so a report that moves
+        // backwards means two workers were built with the same id and their
+        // totals are being folded into one slot - which would silently turn
+        // the fleet total into a maximum instead of a sum.
+        assert!(
+            delta.weight_total >= self.worker_weights[worker],
+            "worker id {worker} reported a total of {} after {}; worker ids must be distinct",
+            delta.weight_total,
+            self.worker_weights[worker]
+        );
+        self.total_weight += delta.weight_total - self.worker_weights[worker];
+        self.worker_weights[worker] = delta.weight_total;
+
         let fidelity = self.fidelity[delta.layer as usize];
         self.sketch.apply_layered_delta(&delta, fidelity);
         self.sketch.set_total_weight(self.total_weight as usize);
@@ -1632,11 +1712,143 @@ mod worker_tests {
     }
 
     #[test]
+    #[should_panic(expected = "exceeds the 128-bit hash budget")]
+    fn a_univmon_worker_refuses_a_geometry_that_outruns_the_hash() {
+        // 13 rows x 11 column bits = 143 > 128. Debug builds used to panic on
+        // the shift; release builds wrapped it and aliased row 12 onto row 1.
+        L2hhWorkerSketch::new(13, 2048, 0);
+    }
+
+    #[test]
+    fn the_widest_accepted_univmon_geometry_still_addresses_distinct_rows() {
+        // 11 rows x 11 bits = 121, just inside the budget.
+        let mut worker = L2hhWorkerSketch::new(11, 2048, 0);
+        let mut cells: Vec<(u32, u32)> = Vec::new();
+        worker.insert_emit_delta(&DataInput::U64(7), 1, &mut |d| cells.push((d.row, d.col)));
+        assert_eq!(cells.len(), 11, "every row promotes at threshold 1");
+        let rows: std::collections::HashSet<u32> = cells.iter().map(|(r, _)| *r).collect();
+        assert_eq!(rows.len(), 11, "each row must land on its own index");
+    }
+
+    #[test]
+    fn every_worker_reads_one_threshold_the_same_way() {
+        // The signed one-byte workers used to clamp to i8::MAX while the shared
+        // threshold and the full sketches clamped to 255, so a tau in 128..=255
+        // meant two different things in the same pipeline.
+        let tau = 200u32;
+        let key = DataInput::U64(9);
+
+        let mut compact = CountWorkerSketch::new(1, 64);
+        let mut compact_values: Vec<i32> = Vec::new();
+        let mut full = Count::<Vector2D<i32>, RegularPath>::with_dimensions(1, 64);
+        let mut full_values: Vec<i32> = Vec::new();
+        for _ in 0..400 {
+            compact.insert_emit_delta(&key, tau, &mut |d| compact_values.push(d.value));
+            full.insert_emit_delta_with_threshold(&key, tau, &mut |d| full_values.push(d.value));
+        }
+
+        assert!(!compact_values.is_empty(), "tau must be reachable at all");
+        assert_eq!(
+            compact_values, full_values,
+            "the compact worker and the full sketch must promote identically"
+        );
+        for value in &compact_values {
+            assert_eq!(value.unsigned_abs(), MAX_PROMASK);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "can never fire at precision")]
+    fn an_hll_worker_refuses_a_threshold_no_register_can_reach() {
+        // A register tops out at 64 - PRECISION + 1, so the gain 2^C' - 2^C
+        // never reaches 2^(64 - PRECISION). Such a worker promoted nothing at
+        // all and left the parent estimating zero.
+        HllOctoWorker::with_threshold(max_hll_threshold(14));
+    }
+
+    #[test]
+    fn any_hll_threshold_above_zero_costs_cardinality_accuracy() {
+        // HLL merges by max, so a register the worker has not promoted reads at
+        // the parent as an *empty* bucket rather than a low one, and the
+        // harmonic mean the estimator is built on collapses. Theorem 4 says the
+        // same thing from the other side: it only promises equality once
+        // Z > 2*alpha_m*m^2*2^(tau-2), which at m = 16384 is around 3.9e8 for
+        // tau = 2 - far above the 50k here. Zero is the only threshold that
+        // keeps the estimate.
+        let truth = 50_000u64;
+        let mut sweep: Vec<(u8, usize, usize)> = Vec::new();
+        for threshold in [0u8, 1, 2, 4] {
+            let mut child = HyperLogLog::<Classic>::default();
+            let mut parent = HyperLogLog::<Classic>::default();
+            let mut promoted = 0usize;
+            for i in 0..truth {
+                child.insert_emit_delta_with_threshold(&DataInput::U64(i), threshold, &mut |d| {
+                    promoted += 1;
+                    parent.apply_delta(d);
+                });
+            }
+            sweep.push((threshold, promoted, parent.estimate()));
+        }
+
+        let mut reference = HyperLogLog::<Classic>::default();
+        for i in 0..truth {
+            reference.insert(&DataInput::U64(i));
+        }
+        assert_eq!(
+            sweep[0].2,
+            reference.estimate(),
+            "threshold 0 must leave the parent exactly ideal"
+        );
+
+        for pair in sweep.windows(2) {
+            let (lo_tau, lo_msgs, lo_est) = pair[0];
+            let (hi_tau, hi_msgs, hi_est) = pair[1];
+            assert!(
+                hi_msgs < lo_msgs,
+                "tau {hi_tau} should send fewer messages than {lo_tau}: {hi_msgs} vs {lo_msgs}"
+            );
+            assert!(
+                hi_est <= lo_est,
+                "tau {hi_tau} should not estimate higher than {lo_tau}: {hi_est} vs {lo_est}"
+            );
+        }
+        assert!(
+            (sweep[3].2 as f64) < truth as f64 * 0.5,
+            "a threshold of 4 loses most of the cardinality: {:?}",
+            sweep[3]
+        );
+        assert_eq!(max_hll_threshold(14), 50);
+    }
+
+    #[test]
+    fn a_ddsketch_delta_from_a_finer_mapping_is_dropped_not_allocated() {
+        // The worker's index space is bounded by its own alpha; a delta from a
+        // much finer sketch names an index this store cannot hold, and growing
+        // the dense array across that gap would allocate gigabytes.
+        let mut parent = DDSketch::new(0.01);
+        parent.add(&50.0);
+        let before = parent.store_counts().len();
+        parent.apply_delta(DdDelta {
+            index: i32::MAX / 2,
+            value: 4,
+        });
+        parent.apply_delta(DdDelta {
+            index: i32::MIN / 2,
+            value: 4,
+        });
+        assert_eq!(parent.store_counts().len(), before, "store must not grow");
+        assert_eq!(parent.get_count(), 1, "out-of-range deltas are dropped");
+    }
+
+    #[test]
     fn threshold_for_error_follows_equation_four() {
         // tau = eps * L1 / k'
-        assert_eq!(threshold_for_error(0.001, 1_000_000.0, 4), 250);
-        assert_eq!(threshold_for_error(0.001, 1_000_000.0, 1), MAX_PROMASK);
+        assert_eq!(threshold_for_error(0.0004, 1_000_000.0, 4), 100);
+        assert_eq!(threshold_for_error(0.0001, 1_000_000.0, 1), 100);
         assert_eq!(threshold_for_error(1e-9, 1_000.0, 1), 1, "never below one");
+        // An accuracy target loose enough to want a threshold wider than a
+        // one-byte worker counter gets the widest one that fits.
+        assert_eq!(threshold_for_error(0.001, 1_000_000.0, 1), MAX_PROMASK);
     }
 
     #[test]
@@ -1648,7 +1860,11 @@ mod worker_tests {
         clone.decrease(34);
         assert_eq!(shared.get(), 1, "the floor is one");
         clone.set(u32::MAX);
-        assert_eq!(shared.get(), MAX_PROMASK, "the ceiling is one byte");
+        assert_eq!(
+            shared.get(),
+            MAX_PROMASK,
+            "the ceiling is a signed one-byte worker counter"
+        );
     }
 
     #[test]
@@ -1715,14 +1931,17 @@ mod runtime_tests {
             || CmOctoAggregator::new(rows, cols),
         );
 
-        // Hash partitioning puts each key on one worker, so at most one worker
-        // holds back up to tau of any key: k' = 1.
+        // A counter is shared by whatever flows hash into it, and each worker
+        // may hold back up to tau of its own share, so the provable ceiling is
+        // k*tau whatever the partition. Hash partitioning bounds the *queried
+        // flow's own* held-back count at tau, not the counter's.
+        let ceiling = 4 * CM_PROMASK as i32;
         for key_val in 0u64..1024 {
             let key = DataInput::U64(key_val);
             let deficit = reference.estimate(&key) - result.parent.sketch.estimate(&key);
             assert!(
-                (0..CM_PROMASK as i32).contains(&deficit),
-                "key {key_val}: deficit {deficit} outside [0, tau)"
+                (0..ceiling).contains(&deficit),
+                "key {key_val}: deficit {deficit} outside [0, k*tau)"
             );
         }
     }
@@ -1890,6 +2109,27 @@ mod runtime_tests {
     }
 
     #[test]
+    fn an_inverted_control_band_is_normalised_rather_than_fatal() {
+        // OctoAdaptiveThreshold's fields are public and clamp panics on an
+        // inverted range. That panic used to land on the aggregator thread and
+        // surface on the caller's as an unrelated "worker receiver dropped".
+        let settings = OctoAdaptiveThreshold {
+            target_queue_len: 10,
+            alpha: 0.25,
+            interval: Duration::ZERO,
+            min_threshold: 32,
+            max_threshold: 8,
+        };
+        let threshold = OctoThreshold::new(31);
+        adjust_against_queue_len(&settings, &threshold, 500, 8);
+        assert_eq!(
+            threshold.get(),
+            32,
+            "an inverted band collapses onto its floor instead of panicking"
+        );
+    }
+
+    #[test]
     fn the_controller_holds_tau_inside_the_dead_band() {
         let settings = OctoAdaptiveThreshold {
             target_queue_len: 10,
@@ -1942,14 +2182,25 @@ mod runtime_tests {
             || CmOctoAggregator::new(rows, cols),
         );
 
+        // Whether tau moves, and how far, depends on live queue occupancy, so
+        // this asserts only what holds regardless of scheduling. That the rule
+        // itself raises, lowers and holds tau is pinned deterministically by
+        // the_controller_* tests above.
         let settled = threshold.get();
         assert!(
             (settings.min_threshold..=settings.max_threshold).contains(&settled),
             "tau {settled} left the configured band"
         );
-        assert_ne!(settled, 60, "the controller should have moved tau at all");
-        // Whatever tau settled at, the parent is still a usable sketch.
-        assert!(result.parent.sketch.estimate(&DataInput::U64(0)) > 0);
+        let mut reference = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
+        for input in &inputs {
+            reference.insert(input);
+        }
+        let key = DataInput::U64(0);
+        let deficit = reference.estimate(&key) - result.parent.sketch.estimate(&key);
+        assert!(
+            deficit >= 0 && deficit <= (cfg.num_workers as i32) * MAX_PROMASK as i32,
+            "a controller run must still leave the parent within k*tau: deficit {deficit}"
+        );
     }
 
     #[test]
@@ -2190,24 +2441,44 @@ mod runtime_tests {
     }
 
     #[test]
-    fn octo_runtime_live_read_handle_observes_progress() {
+    fn octo_runtime_live_read_handle_tracks_the_aggregator() {
+        let n = 64u64;
         let mut runtime = OctoRuntime::new(
             &config(2),
             |_| CountingWorker,
             || CountingAggregator { total: 0 },
         );
         let reader = runtime.read_handle();
+        assert_eq!(reader.with_parent(|p| p.total), 0, "nothing inserted yet");
 
-        for i in 0..64u64 {
+        for i in 0..n {
             runtime.insert(DataInput::U64(i));
         }
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let observed = reader.with_parent(|p| p.total);
-        assert!(observed <= 64);
 
-        let result = runtime.finish();
-        assert_eq!(result.parent.total, 64);
-        assert!(result.parent.total >= observed);
+        // Poll rather than sleep-and-hope: the point is that the handle reaches
+        // the live total without the runtime being finished. A handle wired to
+        // a constant would never get here.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut last = 0u64;
+        loop {
+            let observed = reader.with_parent(|p| p.total);
+            assert!(
+                observed >= last,
+                "live total went backwards: {last} -> {observed}"
+            );
+            assert!(observed <= n, "live total {observed} exceeded the stream");
+            last = observed;
+            if observed == n {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "read handle stalled at {observed}/{n}"
+            );
+            std::hint::spin_loop();
+        }
+
+        assert_eq!(runtime.finish().parent.total, n);
     }
 
     #[test]
@@ -2449,22 +2720,92 @@ mod univmon_tests {
             }
         }
 
+        let (mut thresholding, mut exact) = (0usize, 0usize);
         for (layer, complete) in aggregator.sketch.candidates_complete().iter().enumerate() {
             if univmon_layer_threshold(base, layer) > 1 {
                 // The aggregator provably never saw the keys that stayed under
                 // this layer's threshold.
+                thresholding += 1;
                 assert!(
                     !complete,
                     "layer {layer} thresholds at {} yet claims completeness",
                     univmon_layer_threshold(base, layer)
                 );
+            } else {
+                // A layer at threshold 1 promotes every insert, so its verdict
+                // must come from the heap rather than from the withdrawal - and
+                // this stream is small enough that the heap holds everything.
+                exact += 1;
+                assert!(
+                    complete,
+                    "layer {layer} promotes every insert yet lost completeness"
+                );
             }
         }
-        // The rule has to actually bite somewhere, or the test proves nothing.
+        // Both halves of "exactly where" have to be exercised, or the test
+        // passes on an aggregator that simply withdraws everything.
+        assert!(thresholding > 0 && exact > 0, "{thresholding} / {exact}");
+    }
+
+    /// Drives one worker/aggregator pair over `inputs`.
+    fn drive(
+        worker: &mut UnivMonOctoWorker,
+        aggregator: &mut UnivMonOctoAggregator,
+        inputs: &[DataInput<'_>],
+    ) {
+        for input in inputs {
+            let mut promoted = Vec::new();
+            worker.process(input, &mut |d| promoted.push(d));
+            for delta in promoted {
+                aggregator.apply(delta);
+            }
+        }
+    }
+
+    #[test]
+    fn raising_tau_mid_run_withdraws_completeness_that_was_already_granted() {
+        // With the adaptive controller live, a layer that started at tau = 1
+        // can be pushed above it. A fidelity verdict frozen at construction
+        // would leave that layer claiming a complete candidate set, sending
+        // heavy_threshold down its permissive branch.
+        let threshold = OctoThreshold::new(1);
+        let mut worker =
+            UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, threshold.clone());
+        let mut aggregator =
+            UnivMonOctoAggregator::with_threshold(HEAP, ROWS, COLS, LAYERS, threshold.clone());
+        let inputs = stream(4_000);
+        drive(&mut worker, &mut aggregator, &inputs);
         assert!(
-            (0..LAYERS).any(|layer| univmon_layer_threshold(base, layer) > 1),
-            "pick a base threshold that thresholds at least one layer"
+            aggregator.sketch.candidates_complete().iter().any(|c| *c),
+            "at tau = 1 the aggregator sees every insert, so some layer should still be complete"
         );
+
+        threshold.set(64);
+        drive(&mut worker, &mut aggregator, &inputs);
+        for (layer, complete) in aggregator.sketch.candidates_complete().iter().enumerate() {
+            if univmon_layer_threshold(64, layer) > 1 {
+                assert!(
+                    !complete,
+                    "layer {layer} kept a completeness verdict from before tau rose"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "worker ids must be distinct")]
+    fn workers_sharing_an_id_are_refused_rather_than_summed_wrongly() {
+        // Two workers in one slot would make the fleet total a maximum instead
+        // of a sum, and calc_l1 would report about N/k.
+        let threshold = OctoThreshold::new(1);
+        let mut first = UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, threshold.clone());
+        let mut second =
+            UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, threshold.clone());
+        let mut aggregator =
+            UnivMonOctoAggregator::with_threshold(HEAP, ROWS, COLS, LAYERS, threshold);
+        let inputs = stream(200);
+        drive(&mut first, &mut aggregator, &inputs);
+        drive(&mut second, &mut aggregator, &inputs);
     }
 
     #[test]
@@ -2480,10 +2821,25 @@ mod univmon_tests {
 
     #[test]
     fn the_worker_holds_one_byte_per_counter_and_no_keys() {
-        let worker = UnivMonOctoWorker::new(0, ROWS, COLS, LAYERS);
+        let mut worker = UnivMonOctoWorker::new(0, ROWS, COLS, LAYERS);
+        // One byte per cell against the i64 counters a UnivMon layer holds.
         assert_eq!(worker.counter_bytes(), ROWS * COLS * LAYERS);
-        // A UnivMon layer stores i64 counters plus a heap of owned keys.
-        let parent_counter_bytes = ROWS * COLS * LAYERS * std::mem::size_of::<i64>();
-        assert_eq!(worker.counter_bytes() * 8, parent_counter_bytes);
+        assert_eq!(
+            worker.counter_bytes(),
+            ROWS * COLS * LAYERS * std::mem::size_of::<i64>() / 8
+        );
+
+        // And no key storage: a worker's footprint must not grow with the
+        // number of distinct keys it has seen, however long the strings are.
+        let before = worker.counter_bytes();
+        let keys: Vec<String> = (0..5_000).map(|i| format!("flow-{i:040}")).collect();
+        for key in &keys {
+            worker.process(&DataInput::Str(key), &mut |_| {});
+        }
+        assert_eq!(
+            worker.counter_bytes(),
+            before,
+            "a worker that kept keys would grow here"
+        );
     }
 }

--- a/src/sketch_framework/octo.rs
+++ b/src/sketch_framework/octo.rs
@@ -993,6 +993,11 @@ where
     /// so call it when a query needs to be right rather than on a timer.
     ///
     /// Inserting afterwards is fine; the runtime is not sealed.
+    ///
+    /// After `close` this returns immediately without draining anything.
+    /// `close` has already asked every worker to flush, but nothing here waits
+    /// for that to land, so read the result through `finish` rather than
+    /// through a live handle.
     pub fn flush(&mut self) {
         let core = self.core.as_ref().expect("runtime core missing");
         if core.closed.load(Ordering::Acquire) {
@@ -1197,12 +1202,17 @@ impl OctoWorker for CmTopKOctoWorker {
     // cannot be attributed back to a key and has to stay where it is.
     //
     // The consequence is not just a low counter. The aggregator only ever
-    // learns a key exists from a delta, so under HashByKey a key is invisible
-    // to it until that key occurs tau times on its worker. Below that the
-    // heap does not contain it at all, and its estimate is zero - see
-    // `a_key_below_the_threshold_never_reaches_the_topk_aggregator`. Size tau
-    // well under the frequency you care about, or use the unkeyed pair and
-    // track keys yourself.
+    // learns a key exists from a delta, so a key that has never promoted is
+    // absent from the heap entirely and estimates zero.
+    //
+    // A key promotes the first time an increment *it* caused takes some row's
+    // counter to tau on its worker. Under HashByKey and collision-free cells
+    // that is exactly its tau-th occurrence, but collisions move it either
+    // way: another key sharing the cell can carry it over early, or can cross
+    // first and clear the cell, discarding the partial count - so a key with
+    // far more than tau occurrences can still be missing. Size tau well under
+    // the frequency you care about, or use the unkeyed pair and track keys
+    // yourself. See `a_key_below_the_threshold_never_reaches_the_topk_aggregator`.
 }
 
 /// Count-Min parent that also maintains the only heavy-hitter heap in the
@@ -1950,6 +1960,66 @@ macro_rules! counter_plan {
     };
 }
 
+impl CmOctoPlan {
+    /// Builds the parent this plan's workers feed.
+    ///
+    /// Worker and parent geometry are two independent arguments to `run_octo`,
+    /// and a mismatch is silent: deltas name rows the parent has, the rows
+    /// beyond them stay zero, and Count-Min's min-over-rows estimate is zero
+    /// for every key. Building the parent from the plan removes the chance.
+    pub fn aggregator(&self) -> CmOctoAggregator {
+        CmOctoAggregator::new(self.rows, self.cols)
+    }
+}
+
+impl CountOctoPlan {
+    /// Builds the parent this plan's workers feed. See `CmOctoPlan::aggregator`.
+    pub fn aggregator(&self) -> CountOctoAggregator {
+        CountOctoAggregator::new(self.rows, self.cols)
+    }
+}
+
+impl CmTopKOctoPlan {
+    /// Builds the parent this plan's workers feed, tracking `top_k` keys.
+    pub fn aggregator(&self, top_k: usize) -> CmTopKOctoAggregator {
+        CmTopKOctoAggregator::new(self.rows, self.cols, top_k)
+    }
+}
+
+impl CountTopKOctoPlan {
+    /// Builds the parent this plan's workers feed, tracking `top_k` keys.
+    pub fn aggregator(&self, top_k: usize) -> CountTopKOctoAggregator {
+        CountTopKOctoAggregator::new(self.rows, self.cols, top_k)
+    }
+}
+
+impl DdOctoPlan {
+    /// Builds the parent this plan's workers feed, over the same bucket space.
+    pub fn aggregator(&self) -> DdOctoAggregator {
+        DdOctoAggregator::new(self.alpha)
+    }
+}
+
+impl HllOctoPlan {
+    /// Builds the parent this plan's workers feed.
+    pub fn aggregator(&self) -> HllOctoAggregator {
+        HllOctoAggregator::new()
+    }
+}
+
+impl UnivMonOctoPlan {
+    /// Builds the parent this plan's workers feed, sharing their threshold.
+    pub fn aggregator(&self, heap_size: usize) -> UnivMonOctoAggregator {
+        UnivMonOctoAggregator::with_threshold(
+            heap_size,
+            self.rows,
+            self.cols,
+            self.layers,
+            self.threshold.clone(),
+        )
+    }
+}
+
 counter_plan!(CmOctoPlan, CmOctoWorker, CM_PROMASK);
 counter_plan!(CountOctoPlan, CountOctoWorker, COUNT_PROMASK);
 counter_plan!(CmTopKOctoPlan, CmTopKOctoWorker, CM_PROMASK);
@@ -2462,6 +2532,14 @@ mod worker_tests {
 
     #[test]
     #[should_panic(expected = "one hash per row")]
+    fn a_count_worker_refuses_hashes_built_for_a_different_geometry() {
+        let mut worker = CountWorkerSketch::new(4, 16);
+        let hashes = CmWorkerSketch::hashes(2, &DataInput::U64(1));
+        worker.insert_hashes_emit_delta(&hashes, COUNT_PROMASK, &mut |_| {});
+    }
+
+    #[test]
+    #[should_panic(expected = "one hash per row")]
     fn a_worker_refuses_hashes_built_for_a_different_geometry() {
         // The hashes are a public entry point, so a plan/worker mismatch has to
         // fail loudly. Silently using the rows it was given would leave the rest
@@ -2906,25 +2984,70 @@ mod runtime_tests {
     }
 
     #[test]
+    fn a_parent_wider_than_its_workers_estimates_zero() {
+        // Worker and parent geometry are separate arguments and a mismatch is
+        // silent: every delta names a row the parent has, the rows past the
+        // worker's never receive one, and min-over-rows is zero for every key.
+        // `CmOctoPlan::aggregator` is the way not to hit this; this pins the
+        // hazard so a future check has to update the test rather than pass
+        // quietly.
+        let inputs: Vec<DataInput<'_>> = (0..40_000u64).map(|i| DataInput::U64(i % 64)).collect();
+        let plan = CmOctoPlan::new(3, 1024);
+
+        let mismatched = run_octo(&inputs, &config(4), plan.clone(), || {
+            CmOctoAggregator::new(5, 1024)
+        });
+        assert_eq!(
+            mismatched.parent.sketch.estimate(&DataInput::U64(0)),
+            0,
+            "a wider parent has rows no worker ever writes"
+        );
+
+        let matched = run_octo(&inputs, &config(4), plan.clone(), || plan.aggregator());
+        assert!(
+            matched.parent.sketch.estimate(&DataInput::U64(0)) >= 600,
+            "building the parent from the plan keeps the geometries together"
+        );
+    }
+
+    #[test]
     fn a_key_below_the_threshold_never_reaches_the_topk_aggregator() {
         // The keyed workers keep no key storage and so cannot flush, and the
-        // aggregator only learns a key exists from a delta. Under HashByKey a
-        // key lands on one worker, so it becomes visible exactly when it occurs
-        // tau times. This is the boundary, in both directions.
+        // aggregator only learns a key exists from a delta. A key promotes the
+        // first time an increment it caused takes some row to tau on its
+        // worker - which is exactly its tau-th occurrence only while its cells
+        // are collision-free, so the geometry is checked here rather than
+        // assumed.
         let (rows, cols, top_k) = (3usize, 1024usize, 32usize);
         let tau = CM_PROMASK;
+        let keys: Vec<u64> = (0..20).collect();
+
+        let mut occupied: std::collections::HashSet<(usize, usize, usize)> =
+            std::collections::HashSet::new();
+        for key in &keys {
+            let input = DataInput::U64(*key);
+            let worker = (hash64_seeded(0, &input) % 4) as usize;
+            for (row, hashed) in CmWorkerSketch::hashes(rows, &input).iter().enumerate() {
+                let col = ((hashed & LOWER_32_MASK) as usize) % cols;
+                assert!(
+                    occupied.insert((worker, row, col)),
+                    "key {key} shares a cell with another; the tau-th-occurrence \
+                     boundary only holds for collision-free cells"
+                );
+            }
+        }
+
         let run = |occurrences: u32| {
             let mut inputs: Vec<DataInput<'_>> = Vec::new();
-            for key in 0..20u64 {
+            for key in &keys {
                 for _ in 0..occurrences {
-                    inputs.push(DataInput::U64(key));
+                    inputs.push(DataInput::U64(*key));
                 }
             }
-            run_octo(&inputs, &config(4), CmTopKOctoPlan::new(rows, cols), || {
-                CmTopKOctoAggregator::new(rows, cols, top_k)
-            })
-            .parent
-            .sketch
+            let plan = CmTopKOctoPlan::new(rows, cols);
+            run_octo(&inputs, &config(4), plan.clone(), || plan.aggregator(top_k))
+                .parent
+                .sketch
         };
 
         let below = run(tau - 1);
@@ -2942,10 +3065,75 @@ mod runtime_tests {
         let at = run(tau);
         assert_eq!(
             at.heap().len(),
-            20,
+            keys.len(),
             "one more occurrence per key makes every one of them a candidate"
         );
         assert!(at.estimate(&DataInput::U64(0)) >= tau as i32);
+    }
+
+    #[test]
+    fn zz_probe_starvation() {
+        // Interleaved order, tight columns: can a key need MORE than tau?
+        let tau = CM_PROMASK;
+        for &(rows, cols, nkeys) in &[(3usize, 16usize, 20u64), (3, 8, 20), (1, 32, 20), (3, 4, 8)]
+        {
+            for off in [0u64, 1000, 7777] {
+                let mut inputs: Vec<DataInput<'_>> = Vec::new();
+                for _ in 0..tau {
+                    for key in off..off + nkeys {
+                        inputs.push(DataInput::U64(key));
+                    }
+                }
+                let sk = run_octo(&inputs, &config(1), CmTopKOctoPlan::new(rows, cols), || {
+                    CmTopKOctoAggregator::new(rows, cols, 1024)
+                })
+                .parent
+                .sketch;
+                println!(
+                    "interleaved rows={rows} cols={cols} keys={nkeys} off={off}: heap={} (want {nkeys})",
+                    sk.heap().len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn zz_probe_collision_fragility() {
+        let tau = CM_PROMASK;
+        for &(rows, cols, nkeys, workers) in &[
+            (3usize, 1024usize, 20u64, 4usize),
+            (3, 1024, 20, 1),
+            (3, 256, 20, 4),
+            (3, 128, 20, 4),
+            (3, 64, 20, 4),
+            (3, 1024, 60, 4),
+            (3, 1024, 100, 4),
+            (3, 1024, 200, 4),
+        ] {
+            let run = |occ: u32, off: u64| {
+                let mut inputs: Vec<DataInput<'_>> = Vec::new();
+                for key in off..off + nkeys {
+                    for _ in 0..occ {
+                        inputs.push(DataInput::U64(key));
+                    }
+                }
+                run_octo(
+                    &inputs,
+                    &config(workers),
+                    CmTopKOctoPlan::new(rows, cols),
+                    || CmTopKOctoAggregator::new(rows, cols, 1024),
+                )
+                .parent
+                .sketch
+            };
+            for off in [0u64, 1000, 7777, 123456] {
+                let b = run(tau - 1, off).heap().len();
+                let a = run(tau, off).heap().len();
+                println!(
+                    "rows={rows} cols={cols} keys={nkeys} workers={workers} off={off}: below={b} at={a} (want 0/{nkeys})"
+                );
+            }
+        }
     }
 
     #[test]
@@ -3020,6 +3208,30 @@ mod runtime_tests {
                 "q={q}: {got} outside [{lo}, {hi}] at rank slack {rank_slack:.3}"
             );
         }
+    }
+
+    #[test]
+    fn run_octo_univmon_reaches_the_deepest_layer() {
+        use crate::L2HH;
+        // The structural half of `a_flat_threshold_starves_the_deep_univmon_layers`,
+        // checked against the shipped pipeline rather than the replica that
+        // test needs in order to run the flat counterfactual at all.
+        let (heap, rows, cols, layers) = (64usize, 5usize, 1_024usize, 12usize);
+        let inputs: Vec<DataInput<'_>> =
+            (0..60_000u64).map(|i| DataInput::U64(i % 4_096)).collect();
+        let plan = UnivMonOctoPlan::new(rows, cols, layers);
+        let result = run_octo(&inputs, &config(1), plan.clone(), || plan.aggregator(heap));
+
+        let deepest = layers - 1;
+        let L2HH::COUNT(inner) = &result.parent.sketch.l2_sketch_layers[deepest];
+        let nonzero = (0..inner.rows())
+            .flat_map(|r| (0..inner.cols()).map(move |c| (r, c)))
+            .filter(|(r, c)| inner.as_storage().query_one_counter(*r, *c) != 0)
+            .count();
+        assert!(
+            nonzero > 0,
+            "the scaled per-layer threshold must let the deepest layer through"
+        );
     }
 
     #[test]

--- a/src/sketch_framework/octo.rs
+++ b/src/sketch_framework/octo.rs
@@ -1,9 +1,20 @@
 //! OctoSketch multi-threaded sketch framework.
 //!
 //! Implements the parent-child delta-promotion architecture from OctoSketch (NSDI 2024).
-//! Worker threads maintain lightweight child sketches with small counters and emit
-//! compact delta entries via an MPSC channel when counters overflow a promotion
-//! threshold. An aggregator thread applies deltas to a full-precision parent sketch.
+//! Worker threads maintain lightweight child sketches with one-byte counters and emit
+//! compact delta entries via per-worker channels when a counter reaches the promotion
+//! threshold τ. An aggregator thread applies deltas to a full-precision parent sketch
+//! and adjusts τ to keep its receive rate matched to the workers' send rate.
+//!
+//! The three ideas of §3.2 map onto this module as follows:
+//!
+//! - Idea 1, change-based updates: [`OctoWorker`] emits one counter at a time
+//!   instead of shipping whole sketches.
+//! - Idea 2, adaptive resource allocation: [`OctoAdaptiveThreshold`] drives the
+//!   shared [`OctoThreshold`] from the aggregator's queue occupancy.
+//! - Idea 3, reconstructed data structures: [`CmWorkerSketch`] and
+//!   [`CountWorkerSketch`] drop flow-key storage and use one-byte counters,
+//!   while the `*TopK*` aggregators hold the only heavy-hitter heap.
 //!
 //! Reference:
 //! - <https://www.usenix.org/conference/nsdi24/presentation/zhang-yinda>
@@ -16,18 +27,37 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock, Weak};
 #[cfg(feature = "octo-runtime")]
 use std::thread;
+#[cfg(feature = "octo-runtime")]
+use std::time::{Duration, Instant};
 
 #[cfg(feature = "octo-runtime")]
 use crossbeam_channel::{Receiver, Sender, TryRecvError, bounded};
 
+use std::collections::HashMap;
+
+use crate::common::input::data_input_to_f64;
+use crate::common::structures::matrix_storage::cols_mask_bits;
+use crate::octo_delta::{
+    DD_PROMASK, DdDelta, KeyedCmDelta, KeyedCountDelta, MAX_PROMASK, OctoThreshold, UNIVMON_PROMASK,
+};
+use crate::sketch_framework::univmon::{UnivMonDeltaFidelity, bottom_layer_for_hash};
+use crate::sketches::countminsketch_topk::CMSHeap;
+use crate::sketches::countsketch_topk::{CSHeap, l2hh_cell_for_row};
 use crate::{
-    Classic, CmDelta, Count, CountDelta, CountMin, DataInput, HllDelta, HyperLogLog, RegularPath,
-    Vector2D,
+    BOTTOM_LAYER_FINDER, CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin,
+    DDSketch, DataInput, HLL_PROMASK, HeapItem, HllDelta, HyperLogLog, LayeredCountDelta,
+    RegularPath, UnivMon, Vector2D, hash64_seeded, hash128_seeded, heap_item_to_sketch_input,
+    input_to_owned,
 };
 
 #[cfg(feature = "octo-runtime")]
 /// Legacy queue capacity default retained for config compatibility.
 const DEFAULT_QUEUE_CAPACITY: usize = 65536;
+
+/// Default heavy-hitter heap capacity for the `*TopK*` aggregators.
+pub const DEFAULT_OCTO_TOP_K: usize = 128;
+
+const LOWER_32_MASK: u64 = (1u64 << 32) - 1;
 
 // ---------------------------------------------------------------------------
 // Traits
@@ -36,7 +66,10 @@ const DEFAULT_QUEUE_CAPACITY: usize = 65536;
 /// Worker-side trait: processes inputs and emits deltas.
 pub trait OctoWorker: Send {
     /// Delta type emitted by the worker.
-    type Delta: Copy + Send + 'static;
+    ///
+    /// Deltas that carry a flow key own it, so this is `Send + 'static` rather
+    /// than `Copy`.
+    type Delta: Send + 'static;
 
     /// Process one input and emit zero or more deltas.
     fn process<F>(&mut self, input: &DataInput, emit: &mut F)
@@ -47,10 +80,260 @@ pub trait OctoWorker: Send {
 /// Aggregator-side trait: absorbs deltas into a full-precision sketch.
 pub trait OctoAggregator: Send {
     /// Delta type consumed by the aggregator.
-    type Delta: Copy + Send + 'static;
+    type Delta: Send + 'static;
 
     /// Apply a single delta to the parent sketch.
     fn apply(&mut self, delta: Self::Delta);
+}
+
+// ---------------------------------------------------------------------------
+// Compact worker sketches (§4.1, §3.2 Idea 3)
+// ---------------------------------------------------------------------------
+
+/// Count-Min worker sketch: one-byte counters, no flow-key storage.
+///
+/// A worker counter is cleared the moment it reaches τ, so it never exceeds
+/// `MAX_PROMASK` and `⌈log τ⌉` bits suffice. Against the 32-bit counters a
+/// full `CountMin` uses, this is the 4x memory saving of §4.1.
+#[derive(Clone, Debug)]
+pub struct CmWorkerSketch {
+    counters: Vec<u8>,
+    rows: usize,
+    cols: usize,
+}
+
+impl CmWorkerSketch {
+    /// Creates a `rows` x `cols` worker sketch with all counters cleared.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        let rows = rows.max(1);
+        let cols = cols.max(1);
+        Self {
+            counters: vec![0u8; rows * cols],
+            rows,
+            cols,
+        }
+    }
+
+    /// Number of rows.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Number of columns per row.
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    /// Bytes held by the counter array.
+    pub fn counter_bytes(&self) -> usize {
+        self.counters.len()
+    }
+
+    /// Counters still held back from the aggregator, one per cell.
+    pub fn residual(&self) -> &[u8] {
+        &self.counters
+    }
+
+    /// Inserts a key, emitting and clearing every counter that reaches
+    /// `threshold` (Algorithm 1).
+    #[inline(always)]
+    pub fn insert_emit_delta(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(CmDelta),
+    ) {
+        let threshold = threshold.clamp(1, MAX_PROMASK) as u8;
+        for r in 0..self.rows {
+            let hashed = hash64_seeded(r, value);
+            let col = ((hashed & LOWER_32_MASK) as usize) % self.cols;
+            let cell = &mut self.counters[r * self.cols + col];
+            *cell += 1;
+            if *cell >= threshold {
+                emit(CmDelta {
+                    row: r as u32,
+                    col: col as u32,
+                    value: *cell as u32,
+                });
+                *cell = 0;
+            }
+        }
+    }
+
+    /// As `insert_emit_delta`, but each delta carries the flow key so the
+    /// aggregator can maintain the heavy-hitter heap.
+    #[inline(always)]
+    pub fn insert_emit_keyed_delta(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(KeyedCmDelta),
+    ) {
+        let mut key: Option<HeapItem> = None;
+        self.insert_emit_delta(value, threshold, &mut |delta| {
+            let key = key.get_or_insert_with(|| input_to_owned(value));
+            emit(KeyedCmDelta {
+                key: key.clone(),
+                delta,
+            })
+        });
+    }
+}
+
+/// Count-sketch worker sketch: one-byte signed counters, no flow-key storage.
+#[derive(Clone, Debug)]
+pub struct CountWorkerSketch {
+    counters: Vec<i8>,
+    rows: usize,
+    cols: usize,
+}
+
+impl CountWorkerSketch {
+    /// Creates a `rows` x `cols` worker sketch with all counters cleared.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        let rows = rows.max(1);
+        let cols = cols.max(1);
+        Self {
+            counters: vec![0i8; rows * cols],
+            rows,
+            cols,
+        }
+    }
+
+    /// Number of rows.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Number of columns per row.
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    /// Bytes held by the counter array.
+    pub fn counter_bytes(&self) -> usize {
+        self.counters.len()
+    }
+
+    /// Counters still held back from the aggregator, one per cell.
+    pub fn residual(&self) -> &[i8] {
+        &self.counters
+    }
+
+    /// Inserts a key, emitting and clearing every counter whose magnitude
+    /// reaches `threshold` (§4.4: signed counters compare on `|counter|`).
+    #[inline(always)]
+    pub fn insert_emit_delta(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(CountDelta),
+    ) {
+        // A signed one-byte counter reaches -128 before +127, so the usable
+        // magnitude is i8::MAX.
+        let threshold = threshold.clamp(1, i8::MAX as u32) as i8;
+        for r in 0..self.rows {
+            let hashed = hash64_seeded(r, value);
+            let col = ((hashed & LOWER_32_MASK) as usize) % self.cols;
+            let sign: i8 = if ((hashed >> 63) & 1) == 1 { 1 } else { -1 };
+            let cell = &mut self.counters[r * self.cols + col];
+            *cell += sign;
+            if cell.unsigned_abs() >= threshold as u8 {
+                emit(CountDelta {
+                    row: r as u32,
+                    col: col as u32,
+                    value: *cell as i32,
+                });
+                *cell = 0;
+            }
+        }
+    }
+
+    /// As `insert_emit_delta`, but each delta carries the flow key.
+    #[inline(always)]
+    pub fn insert_emit_keyed_delta(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(KeyedCountDelta),
+    ) {
+        let mut key: Option<HeapItem> = None;
+        self.insert_emit_delta(value, threshold, &mut |delta| {
+            let key = key.get_or_insert_with(|| input_to_owned(value));
+            emit(KeyedCountDelta {
+                key: key.clone(),
+                delta,
+            })
+        });
+    }
+}
+
+/// UnivMon-layer worker sketch: one-byte signed counters over the cell mapping
+/// `CountL2HH` uses.
+///
+/// A UnivMon layer is not a plain `Count` sketch: it slices one 128-bit hash
+/// into per-row columns and takes each row's sign from a different high bit,
+/// and every layer hashes under its own seed. This worker calls the same
+/// `l2hh_cell_for_row` the parent does, so the two cannot drift apart.
+#[derive(Clone, Debug)]
+pub struct L2hhWorkerSketch {
+    counters: Vec<i8>,
+    rows: usize,
+    cols: usize,
+    seed_idx: usize,
+    mask_bits: u32,
+}
+
+impl L2hhWorkerSketch {
+    /// Creates a worker over the cell space of a `CountL2HH` with these
+    /// dimensions and seed.
+    pub fn new(rows: usize, cols: usize, seed_idx: usize) -> Self {
+        let rows = rows.max(1);
+        let cols = cols.max(1);
+        Self {
+            counters: vec![0i8; rows * cols],
+            rows,
+            cols,
+            seed_idx,
+            mask_bits: cols_mask_bits(cols),
+        }
+    }
+
+    /// Bytes held by the counter array.
+    pub fn counter_bytes(&self) -> usize {
+        self.counters.len()
+    }
+
+    /// Counters still held back from the aggregator, one per cell.
+    pub fn residual(&self) -> &[i8] {
+        &self.counters
+    }
+
+    /// Inserts a key, emitting and clearing every counter whose magnitude
+    /// reaches `threshold`.
+    #[inline(always)]
+    pub fn insert_emit_delta(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(CountDelta),
+    ) {
+        let threshold = threshold.clamp(1, i8::MAX as u32) as u8;
+        let hashed = hash128_seeded(self.seed_idx, value);
+        for row in 0..self.rows {
+            let (col, sign) = l2hh_cell_for_row(hashed, row, self.cols, self.mask_bits);
+            let cell = &mut self.counters[row * self.cols + col];
+            *cell += sign as i8;
+            if cell.unsigned_abs() >= threshold {
+                emit(CountDelta {
+                    row: row as u32,
+                    col: col as u32,
+                    value: *cell as i32,
+                });
+                *cell = 0;
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -58,7 +341,76 @@ pub trait OctoAggregator: Send {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "octo-runtime")]
-/// Configuration for `run_octo`.
+/// How inputs are handed to workers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum OctoPartition {
+    /// Hash the key so one flow always lands on one worker.
+    ///
+    /// This is the paper's setting - each worker owns a slice of the traffic -
+    /// and makes k', the number of workers a flow may pass by, equal to 1. The
+    /// additive term k'τ in the error bounds is then as small as it can be.
+    #[default]
+    HashByKey,
+    /// Hand inputs to workers in turn, regardless of key.
+    ///
+    /// Spreads load perfectly even under a skewed key distribution, at the cost
+    /// of k' = k: every flow reaches every worker, so each one may hold back up
+    /// to τ of that flow's count.
+    RoundRobin,
+}
+
+#[cfg(feature = "octo-runtime")]
+/// Aggregator-driven threshold control (§4.3).
+///
+/// The aggregator watches how much work is queued and nudges the shared τ so
+/// its receive rate tracks the workers' send rate: a short queue means it can
+/// afford more updates, a long one means it is falling behind.
+#[derive(Clone, Debug)]
+pub struct OctoAdaptiveThreshold {
+    /// Target total queue length Q across all worker channels (paper: 10).
+    pub target_queue_len: usize,
+    /// Dead band α around the target (paper: 0.25).
+    pub alpha: f64,
+    /// How often the threshold is re-evaluated (paper: 100µs).
+    pub interval: Duration,
+    /// Floor for τ. Derive it from an accuracy target with `threshold_for_error`.
+    pub min_threshold: u32,
+    /// Ceiling for τ.
+    pub max_threshold: u32,
+}
+
+#[cfg(feature = "octo-runtime")]
+impl Default for OctoAdaptiveThreshold {
+    fn default() -> Self {
+        Self {
+            target_queue_len: 10,
+            alpha: 0.25,
+            interval: Duration::from_micros(100),
+            min_threshold: 1,
+            max_threshold: MAX_PROMASK,
+        }
+    }
+}
+
+/// The threshold that meets an additive error target, from Equation 4: `τ = εL1/k'`.
+///
+/// `k_prime` is the number of workers a single flow may reach: 1 under
+/// [`OctoPartition::HashByKey`], and the worker count under
+/// [`OctoPartition::RoundRobin`].
+pub fn threshold_for_error(epsilon: f64, l1: f64, k_prime: usize) -> u32 {
+    if !(epsilon.is_finite() && l1.is_finite()) || k_prime == 0 {
+        return 1;
+    }
+    let tau = epsilon * l1 / k_prime as f64;
+    if !tau.is_finite() || tau < 1.0 {
+        return 1;
+    }
+    (tau as u32).min(MAX_PROMASK)
+}
+
+#[cfg(feature = "octo-runtime")]
+/// Configuration for `run_octo` and [`OctoRuntime`].
+#[derive(Clone, Debug)]
 pub struct OctoConfig {
     /// Number of worker threads (default: 4).
     pub num_workers: usize,
@@ -68,6 +420,15 @@ pub struct OctoConfig {
     pub pin_cores: bool,
     /// Queue capacity for bounded worker-input and worker-delta channels (default: 65536).
     pub queue_capacity: usize,
+    /// Promotion threshold τ shared by every worker.
+    ///
+    /// Clone it into the worker factory so the workers and the aggregator's
+    /// controller refer to the same value.
+    pub threshold: OctoThreshold,
+    /// How inputs are routed to workers (default: [`OctoPartition::HashByKey`]).
+    pub partition: OctoPartition,
+    /// Threshold control, or `None` to hold τ fixed (default: `None`).
+    pub adaptive: Option<OctoAdaptiveThreshold>,
 }
 
 #[cfg(feature = "octo-runtime")]
@@ -77,6 +438,9 @@ impl Default for OctoConfig {
             num_workers: 4,
             pin_cores: true,
             queue_capacity: DEFAULT_QUEUE_CAPACITY,
+            threshold: OctoThreshold::new(CM_PROMASK),
+            partition: OctoPartition::default(),
+            adaptive: None,
         }
     }
 }
@@ -146,6 +510,7 @@ impl<P> OctoReadHandle<P> {
 struct OctoCore<P> {
     worker_input_txs: Vec<Sender<WorkerMsg>>,
     next_worker: AtomicUsize,
+    partition: OctoPartition,
     worker_handles: Vec<thread::JoinHandle<()>>,
     aggregator_handle: Option<thread::JoinHandle<()>>,
     parent: Arc<RwLock<P>>,
@@ -166,6 +531,14 @@ impl<P> OctoCore<P> {
         }
         for tx in &self.worker_input_txs {
             let _ = tx.send(WorkerMsg::End);
+        }
+    }
+
+    fn worker_for(&self, input: &DataInput<'_>) -> usize {
+        let workers = self.worker_input_txs.len();
+        match self.partition {
+            OctoPartition::RoundRobin => self.next_worker.fetch_add(1, Ordering::AcqRel) % workers,
+            OctoPartition::HashByKey => (hash64_seeded(0, input) % workers as u64) as usize,
         }
     }
 }
@@ -198,19 +571,15 @@ impl<P> OctoCore<P>
 where
     P: Send + Sync + 'static,
 {
-    fn start<W>(
-        workers: Vec<W>,
-        parent: P,
-        num_workers: usize,
-        pin_cores: bool,
-        queue_capacity: usize,
-    ) -> Self
+    fn start<W>(workers: Vec<W>, parent: P, config: &OctoConfig) -> Self
     where
         W: OctoWorker + 'static,
         P: OctoAggregator<Delta = W::Delta>,
     {
+        let num_workers = config.num_workers.max(1);
         assert_eq!(workers.len(), num_workers);
-        let queue_capacity = queue_capacity.max(1);
+        let queue_capacity = config.queue_capacity.max(1);
+        let pin_cores = config.pin_cores;
 
         let parent = Arc::new(RwLock::new(parent));
         let parent_for_aggregator = Arc::clone(&parent);
@@ -222,11 +591,14 @@ where
             delta_rxs.push(Some(rx));
         }
 
+        let adaptive = config.adaptive.clone();
+        let threshold = config.threshold.clone();
         let aggregator_handle = thread::spawn(move || {
             if pin_cores {
                 let _ = core_affinity::set_for_current(core_affinity::CoreId { id: num_workers });
             }
 
+            let mut controller = adaptive.as_ref().map(ThresholdController::new);
             let mut disconnected_workers = 0usize;
             while disconnected_workers < num_workers {
                 let mut made_progress = false;
@@ -248,6 +620,9 @@ where
                             disconnected_workers += 1;
                         }
                     }
+                }
+                if let Some(controller) = controller.as_mut() {
+                    controller.maybe_adjust(&delta_rxs, &threshold);
                 }
                 if !made_progress {
                     std::hint::spin_loop();
@@ -282,6 +657,7 @@ where
         Self {
             worker_input_txs,
             next_worker: AtomicUsize::new(0),
+            partition: config.partition,
             worker_handles,
             aggregator_handle: Some(aggregator_handle),
             parent,
@@ -291,11 +667,69 @@ where
 }
 
 #[cfg(feature = "octo-runtime")]
+/// Applies Equations 1 and 2 of §4.3 on the aggregator thread.
+struct ThresholdController {
+    settings: OctoAdaptiveThreshold,
+    previous_queue_len: f64,
+    next_check: Instant,
+    polls_since_check: u32,
+}
+
+#[cfg(feature = "octo-runtime")]
+impl ThresholdController {
+    /// Reading the clock on every poll would cost more than the control loop
+    /// saves, so the elapsed-time check is itself sampled.
+    const POLLS_BETWEEN_CLOCK_READS: u32 = 256;
+
+    fn new(settings: &OctoAdaptiveThreshold) -> Self {
+        Self {
+            settings: settings.clone(),
+            previous_queue_len: 0.0,
+            next_check: Instant::now() + settings.interval,
+            polls_since_check: 0,
+        }
+    }
+
+    fn maybe_adjust<D>(&mut self, receivers: &[Option<Receiver<D>>], threshold: &OctoThreshold) {
+        self.polls_since_check += 1;
+        if self.polls_since_check < Self::POLLS_BETWEEN_CLOCK_READS {
+            return;
+        }
+        self.polls_since_check = 0;
+
+        let now = Instant::now();
+        if now < self.next_check {
+            return;
+        }
+        self.next_check = now + self.settings.interval;
+
+        let queue_len: usize = receivers.iter().flatten().map(|rx| rx.len()).sum();
+        let queue_len = queue_len as f64;
+        // Equation 1: predict the next window from the last two observations.
+        let predicted = queue_len + (queue_len - self.previous_queue_len);
+        self.previous_queue_len = queue_len;
+
+        // Equation 2: nudge τ by one in whichever direction the prediction misses.
+        let target = self.settings.target_queue_len.max(1) as f64;
+        let tau = threshold.get();
+        let adjusted = if predicted < (1.0 - self.settings.alpha) * target {
+            tau.saturating_sub(1)
+        } else if predicted > (1.0 + self.settings.alpha) * target {
+            tau.saturating_add(1)
+        } else {
+            tau
+        };
+        threshold.set(adjusted.clamp(self.settings.min_threshold, self.settings.max_threshold));
+    }
+}
+
+#[cfg(feature = "octo-runtime")]
 impl<W, P> OctoRuntime<W, P>
 where
     W: OctoWorker + 'static,
     P: OctoAggregator<Delta = W::Delta> + Send + Sync + 'static,
 {
+    /// Starts the worker and aggregator threads described by `config`.
     pub fn new<F, PF>(config: &OctoConfig, worker_factory: F, parent_factory: PF) -> Self
     where
         F: Fn(usize) -> W,
@@ -304,13 +738,7 @@ where
         let num_workers = config.num_workers.max(1);
         let workers: Vec<W> = (0..num_workers).map(worker_factory).collect();
         let parent = parent_factory();
-        let core = OctoCore::start(
-            workers,
-            parent,
-            num_workers,
-            config.pin_cores,
-            config.queue_capacity,
-        );
+        let core = OctoCore::start(workers, parent, config);
 
         Self {
             core: Some(core),
@@ -318,6 +746,7 @@ where
         }
     }
 
+    /// Returns a handle for reading the parent while the runtime is live.
     pub fn read_handle(&self) -> OctoReadHandle<P> {
         self.core
             .as_ref()
@@ -325,18 +754,19 @@ where
             .read_handle()
     }
 
+    /// Signals every worker to stop after draining what is already queued.
     pub fn close(&self) {
         self.core.as_ref().expect("runtime core missing").close();
     }
 
+    /// Routes one input to a worker according to the configured partition.
     pub fn insert(&mut self, input: DataInput<'_>) {
         let core = self.core.as_ref().expect("runtime core missing");
         if core.closed.load(Ordering::Acquire) {
             panic!("cannot insert after runtime has been closed");
         }
 
-        let worker_id =
-            core.next_worker.fetch_add(1, Ordering::AcqRel) % core.worker_input_txs.len();
+        let worker_id = core.worker_for(&input);
         // SAFETY: caller explicitly guarantees borrowed data lives long enough.
         let static_input = unsafe { assume_input_static(input) };
         core.worker_input_txs[worker_id]
@@ -344,12 +774,14 @@ where
             .expect("worker receiver dropped while runtime is active");
     }
 
+    /// Inserts a batch, one element at a time.
     pub fn insert_batch(&mut self, inputs: &[DataInput<'_>]) {
         for input in inputs {
             self.insert(input.clone());
         }
     }
 
+    /// Drains the pipeline and returns the finished parent sketch.
     pub fn finish(mut self) -> OctoResult<P> {
         let parent = self
             .core
@@ -367,17 +799,29 @@ where
 
 // -- CountMin --
 
-/// OctoSketch worker backed by `CountMin`.
+/// OctoSketch worker backed by a compact one-byte Count-Min sketch.
 pub struct CmOctoWorker {
-    sketch: CountMin<Vector2D<i32>, RegularPath>,
+    sketch: CmWorkerSketch,
+    threshold: OctoThreshold,
 }
 
 impl CmOctoWorker {
-    /// Creates a Count-Min-backed Octo worker.
+    /// Creates a worker with a private threshold fixed at `CM_PROMASK`.
     pub fn new(rows: usize, cols: usize) -> Self {
+        Self::with_threshold(rows, cols, OctoThreshold::new(CM_PROMASK))
+    }
+
+    /// Creates a worker sharing `threshold` with its peers and the aggregator.
+    pub fn with_threshold(rows: usize, cols: usize, threshold: OctoThreshold) -> Self {
         Self {
-            sketch: CountMin::with_dimensions(rows, cols),
+            sketch: CmWorkerSketch::new(rows, cols),
+            threshold,
         }
+    }
+
+    /// Borrows the worker's counter array.
+    pub fn sketch(&self) -> &CmWorkerSketch {
+        &self.sketch
     }
 }
 
@@ -389,7 +833,8 @@ impl OctoWorker for CmOctoWorker {
     where
         F: FnMut(Self::Delta),
     {
-        self.sketch.insert_emit_delta(input, emit);
+        self.sketch
+            .insert_emit_delta(input, self.threshold.get(), emit);
     }
 }
 
@@ -397,6 +842,15 @@ impl OctoWorker for CmOctoWorker {
 pub struct CmOctoAggregator {
     /// Parent Count-Min sketch updated by worker deltas.
     pub sketch: CountMin<Vector2D<i32>, RegularPath>,
+}
+
+impl CmOctoAggregator {
+    /// Creates an aggregator with a `rows` x `cols` parent sketch.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            sketch: CountMin::with_dimensions(rows, cols),
+        }
+    }
 }
 
 impl OctoAggregator for CmOctoAggregator {
@@ -408,19 +862,100 @@ impl OctoAggregator for CmOctoAggregator {
     }
 }
 
+// -- CountMin with heavy-hitter tracking (§3.2, Idea 3) --
+
+/// Count-Min worker that ships the flow key alongside each promoted counter.
+pub struct CmTopKOctoWorker {
+    sketch: CmWorkerSketch,
+    threshold: OctoThreshold,
+}
+
+impl CmTopKOctoWorker {
+    /// Creates a worker with a private threshold fixed at `CM_PROMASK`.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self::with_threshold(rows, cols, OctoThreshold::new(CM_PROMASK))
+    }
+
+    /// Creates a worker sharing `threshold` with its peers and the aggregator.
+    pub fn with_threshold(rows: usize, cols: usize, threshold: OctoThreshold) -> Self {
+        Self {
+            sketch: CmWorkerSketch::new(rows, cols),
+            threshold,
+        }
+    }
+
+    /// Borrows the worker's counter array.
+    pub fn sketch(&self) -> &CmWorkerSketch {
+        &self.sketch
+    }
+}
+
+impl OctoWorker for CmTopKOctoWorker {
+    type Delta = KeyedCmDelta;
+
+    #[inline(always)]
+    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        self.sketch
+            .insert_emit_keyed_delta(input, self.threshold.get(), emit);
+    }
+}
+
+/// Count-Min parent that also maintains the only heavy-hitter heap in the
+/// pipeline, rebuilt from the keys the workers ship (Algorithm 2).
+pub struct CmTopKOctoAggregator {
+    /// Parent sketch plus heavy-hitter heap.
+    pub sketch: CMSHeap<Vector2D<i32>, RegularPath>,
+}
+
+impl CmTopKOctoAggregator {
+    /// Creates an aggregator tracking the `top_k` heaviest keys.
+    pub fn new(rows: usize, cols: usize, top_k: usize) -> Self {
+        Self {
+            sketch: CMSHeap::new(rows, cols, top_k),
+        }
+    }
+}
+
+impl OctoAggregator for CmTopKOctoAggregator {
+    type Delta = KeyedCmDelta;
+
+    #[inline(always)]
+    fn apply(&mut self, delta: KeyedCmDelta) {
+        self.sketch.cms_mut().apply_delta(delta.delta);
+        let key = heap_item_to_sketch_input(&delta.key);
+        let estimate = self.sketch.cms().estimate(&key);
+        self.sketch.heap_mut().update(&key, estimate as i64);
+    }
+}
+
 // -- Count Sketch --
 
-/// OctoSketch worker backed by `Count`.
+/// OctoSketch worker backed by a compact one-byte Count sketch.
 pub struct CountOctoWorker {
-    child: Count<Vector2D<i32>, RegularPath>,
+    sketch: CountWorkerSketch,
+    threshold: OctoThreshold,
 }
 
 impl CountOctoWorker {
-    /// Creates a Count-Sketch-backed Octo worker.
+    /// Creates a worker with a private threshold fixed at `COUNT_PROMASK`.
     pub fn new(rows: usize, cols: usize) -> Self {
+        Self::with_threshold(rows, cols, OctoThreshold::new(COUNT_PROMASK))
+    }
+
+    /// Creates a worker sharing `threshold` with its peers and the aggregator.
+    pub fn with_threshold(rows: usize, cols: usize, threshold: OctoThreshold) -> Self {
         Self {
-            child: Count::with_dimensions(rows, cols),
+            sketch: CountWorkerSketch::new(rows, cols),
+            threshold,
         }
+    }
+
+    /// Borrows the worker's counter array.
+    pub fn sketch(&self) -> &CountWorkerSketch {
+        &self.sketch
     }
 }
 
@@ -432,7 +967,8 @@ impl OctoWorker for CountOctoWorker {
     where
         F: FnMut(Self::Delta),
     {
-        self.child.insert_emit_delta(input, emit);
+        self.sketch
+            .insert_emit_delta(input, self.threshold.get(), emit);
     }
 }
 
@@ -440,6 +976,15 @@ impl OctoWorker for CountOctoWorker {
 pub struct CountOctoAggregator {
     /// Parent Count Sketch updated by worker deltas.
     pub sketch: Count<Vector2D<i32>, RegularPath>,
+}
+
+impl CountOctoAggregator {
+    /// Creates an aggregator with a `rows` x `cols` parent sketch.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            sketch: Count::with_dimensions(rows, cols),
+        }
+    }
 }
 
 impl OctoAggregator for CountOctoAggregator {
@@ -451,18 +996,218 @@ impl OctoAggregator for CountOctoAggregator {
     }
 }
 
+// -- Count Sketch with heavy-hitter tracking --
+
+/// Count-sketch worker that ships the flow key alongside each promoted counter.
+pub struct CountTopKOctoWorker {
+    sketch: CountWorkerSketch,
+    threshold: OctoThreshold,
+}
+
+impl CountTopKOctoWorker {
+    /// Creates a worker with a private threshold fixed at `COUNT_PROMASK`.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self::with_threshold(rows, cols, OctoThreshold::new(COUNT_PROMASK))
+    }
+
+    /// Creates a worker sharing `threshold` with its peers and the aggregator.
+    pub fn with_threshold(rows: usize, cols: usize, threshold: OctoThreshold) -> Self {
+        Self {
+            sketch: CountWorkerSketch::new(rows, cols),
+            threshold,
+        }
+    }
+}
+
+impl OctoWorker for CountTopKOctoWorker {
+    type Delta = KeyedCountDelta;
+
+    #[inline(always)]
+    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        self.sketch
+            .insert_emit_keyed_delta(input, self.threshold.get(), emit);
+    }
+}
+
+/// Count-sketch parent holding the pipeline's only heavy-hitter heap.
+pub struct CountTopKOctoAggregator {
+    /// Parent sketch plus heavy-hitter heap.
+    pub sketch: CSHeap<Vector2D<i32>, RegularPath>,
+}
+
+impl CountTopKOctoAggregator {
+    /// Creates an aggregator tracking the `top_k` heaviest keys.
+    pub fn new(rows: usize, cols: usize, top_k: usize) -> Self {
+        Self {
+            sketch: CSHeap::new(rows, cols, top_k),
+        }
+    }
+}
+
+impl OctoAggregator for CountTopKOctoAggregator {
+    type Delta = KeyedCountDelta;
+
+    #[inline(always)]
+    fn apply(&mut self, delta: KeyedCountDelta) {
+        self.sketch.cs_mut().apply_delta(delta.delta);
+        let key = heap_item_to_sketch_input(&delta.key);
+        let estimate = self.sketch.cs().estimate(&key);
+        self.sketch.heap_mut().update(&key, estimate as i64);
+    }
+}
+
+// -- DDSketch --
+
+/// DDSketch worker: one-byte counters over the parent's bucket space.
+///
+/// Appendix C applies OctoSketch to DDSketch the same way as to Count-Min - one
+/// array of counters, promote and clear at τ. Bucket indices are sparse and
+/// signed, so the counters are held in a map rather than a dense row.
+#[derive(Clone, Debug)]
+pub struct DdWorkerSketch {
+    /// An empty sketch kept only for its logarithmic bucket mapping.
+    mapping: DDSketch,
+    counters: HashMap<i32, u8>,
+}
+
+impl DdWorkerSketch {
+    /// Creates a worker over the bucket space of a DDSketch with this `alpha`.
+    pub fn new(alpha: f64) -> Self {
+        Self {
+            mapping: DDSketch::new(alpha),
+            counters: HashMap::new(),
+        }
+    }
+
+    /// Relative accuracy of the bucket space this worker maps into.
+    pub fn alpha(&self) -> f64 {
+        self.mapping.alpha()
+    }
+
+    /// Counts still held back from the aggregator, by bucket index.
+    pub fn residual(&self) -> &HashMap<i32, u8> {
+        &self.counters
+    }
+
+    /// Total sample count still held back from the aggregator.
+    ///
+    /// A quantile read from the parent is off by at most this many ranks, so
+    /// dividing it by the stream length bounds the rank error that promotion
+    /// contributes on top of the sketch's own α.
+    pub fn held_back(&self) -> u64 {
+        self.counters.values().map(|&c| c as u64).sum()
+    }
+
+    /// Adds a sample, promoting and clearing the bucket that reaches `threshold`.
+    ///
+    /// Values the parent sketch would itself drop - non-positive, non-finite or
+    /// outside the indexable range - are dropped here too.
+    pub fn add_emit_delta(&mut self, value: f64, threshold: u32, emit: &mut impl FnMut(DdDelta)) {
+        let Some(index) = self.mapping.bucket_index_for(value) else {
+            return;
+        };
+        let threshold = threshold.clamp(1, MAX_PROMASK) as u8;
+        let counter = self.counters.entry(index).or_insert(0);
+        *counter += 1;
+        if *counter >= threshold {
+            emit(DdDelta {
+                index,
+                value: *counter as u64,
+            });
+            self.counters.remove(&index);
+        }
+    }
+}
+
+/// OctoSketch worker backed by a compact DDSketch bucket store.
+pub struct DdOctoWorker {
+    sketch: DdWorkerSketch,
+    threshold: OctoThreshold,
+}
+
+impl DdOctoWorker {
+    /// Creates a worker with a private threshold fixed at `DD_PROMASK`.
+    pub fn new(alpha: f64) -> Self {
+        Self::with_threshold(alpha, OctoThreshold::new(DD_PROMASK))
+    }
+
+    /// Creates a worker sharing `threshold` with its peers and the aggregator.
+    pub fn with_threshold(alpha: f64, threshold: OctoThreshold) -> Self {
+        Self {
+            sketch: DdWorkerSketch::new(alpha),
+            threshold,
+        }
+    }
+}
+
+impl OctoWorker for DdOctoWorker {
+    type Delta = DdDelta;
+
+    #[inline(always)]
+    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        let Ok(value) = data_input_to_f64(input) else {
+            return;
+        };
+        self.sketch
+            .add_emit_delta(value, self.threshold.get(), emit);
+    }
+}
+
+/// OctoSketch parent wrapping a full-precision `DDSketch`.
+pub struct DdOctoAggregator {
+    /// Parent quantile sketch updated by worker deltas.
+    pub sketch: DDSketch,
+}
+
+impl DdOctoAggregator {
+    /// Creates an aggregator with the given relative accuracy.
+    pub fn new(alpha: f64) -> Self {
+        Self {
+            sketch: DDSketch::new(alpha),
+        }
+    }
+}
+
+impl OctoAggregator for DdOctoAggregator {
+    type Delta = DdDelta;
+
+    #[inline(always)]
+    fn apply(&mut self, delta: DdDelta) {
+        self.sketch.apply_delta(delta);
+    }
+}
+
 // -- HyperLogLog --
 
 /// OctoSketch worker backed by `HyperLogLog`.
+///
+/// Cardinality sketches merge by `max`, so this worker never clears a register;
+/// its threshold is the exponent τ in the paper's `|2^C' - 2^C| >= 2^τ` rule and
+/// is held fixed rather than driven by the aggregator's queue controller.
 pub struct HllOctoWorker {
     child: HyperLogLog<Classic>,
+    threshold: u8,
 }
 
 impl HllOctoWorker {
-    /// Creates a HyperLogLog-backed Octo worker.
+    /// Creates a HyperLogLog-backed Octo worker at the default threshold,
+    /// which promotes every register improvement.
     pub fn new() -> Self {
+        Self::with_threshold(HLL_PROMASK)
+    }
+
+    /// Creates a worker that promotes a register only once the improvement in
+    /// `2^register` reaches `2^threshold`.
+    pub fn with_threshold(threshold: u8) -> Self {
         Self {
             child: HyperLogLog::default(),
+            threshold,
         }
     }
 }
@@ -481,7 +1226,8 @@ impl OctoWorker for HllOctoWorker {
     where
         F: FnMut(Self::Delta),
     {
-        self.child.insert_emit_delta(input, emit);
+        self.child
+            .insert_emit_delta_with_threshold(input, self.threshold, emit);
     }
 }
 
@@ -489,6 +1235,21 @@ impl OctoWorker for HllOctoWorker {
 pub struct HllOctoAggregator {
     /// Parent HyperLogLog sketch updated by worker deltas.
     pub sketch: HyperLogLog<Classic>,
+}
+
+impl HllOctoAggregator {
+    /// Creates an aggregator over a default-precision HyperLogLog.
+    pub fn new() -> Self {
+        Self {
+            sketch: HyperLogLog::default(),
+        }
+    }
+}
+
+impl Default for HllOctoAggregator {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl OctoAggregator for HllOctoAggregator {
@@ -500,6 +1261,179 @@ impl OctoAggregator for HllOctoAggregator {
     }
 }
 
+// -- UnivMon --
+
+/// Promotion threshold for UnivMon layer `layer`, given the pyramid's base τ.
+///
+/// A UnivMon layer only receives the keys that survive `layer` coin flips, so
+/// layer L carries roughly `n / 2^L` of the stream. One threshold across the
+/// whole pyramid would be sized for layer 0 and would starve the deep layers
+/// outright - and those are exactly the layers the recursive estimator leans on
+/// for cardinality. Halving τ per layer keeps each layer's promotion rate in
+/// proportion to the traffic it actually sees, and the floor of 1 makes the
+/// deepest layers exact, where they have too little traffic to threshold at all.
+#[inline(always)]
+pub fn univmon_layer_threshold(base: u32, layer: usize) -> u32 {
+    if layer >= u32::BITS as usize {
+        return 1;
+    }
+    (base >> layer).max(1)
+}
+
+/// OctoSketch worker backed by one compact sketch per UnivMon layer.
+///
+/// An insert reaches layers `0..=bottom_layer_for(key)`, exactly the set a
+/// single-threaded `UnivMon::insert` touches, because the layer selector is a
+/// pure function of the key's hash. The worker keeps no heavy-hitter heap;
+/// that lives only in the aggregator.
+pub struct UnivMonOctoWorker {
+    layers: Vec<L2hhWorkerSketch>,
+    threshold: OctoThreshold,
+    worker_id: u32,
+    weight_total: u64,
+}
+
+impl UnivMonOctoWorker {
+    /// Creates a worker mirroring a `UnivMon` of these dimensions.
+    pub fn new(worker_id: usize, sketch_row: usize, sketch_col: usize, layer_size: usize) -> Self {
+        Self::with_threshold(
+            worker_id,
+            sketch_row,
+            sketch_col,
+            layer_size,
+            OctoThreshold::new(UNIVMON_PROMASK),
+        )
+    }
+
+    /// Creates a worker sharing `threshold` with its peers and the aggregator.
+    pub fn with_threshold(
+        worker_id: usize,
+        sketch_row: usize,
+        sketch_col: usize,
+        layer_size: usize,
+        threshold: OctoThreshold,
+    ) -> Self {
+        let layer_size = layer_size.max(1);
+        Self {
+            layers: (0..layer_size)
+                .map(|layer| L2hhWorkerSketch::new(sketch_row, sketch_col, layer))
+                .collect(),
+            threshold,
+            worker_id: worker_id as u32,
+            weight_total: 0,
+        }
+    }
+
+    /// Bytes held across every layer's counter array.
+    pub fn counter_bytes(&self) -> usize {
+        self.layers.iter().map(|l| l.counter_bytes()).sum()
+    }
+}
+
+impl OctoWorker for UnivMonOctoWorker {
+    type Delta = LayeredCountDelta;
+
+    #[inline(always)]
+    fn process<F>(&mut self, input: &DataInput, emit: &mut F)
+    where
+        F: FnMut(Self::Delta),
+    {
+        self.weight_total += 1;
+        let bottom =
+            bottom_layer_for_hash(hash64_seeded(BOTTOM_LAYER_FINDER, input), self.layers.len());
+        let threshold = self.threshold.get();
+        let (worker_id, weight_total) = (self.worker_id, self.weight_total);
+        let mut key: Option<HeapItem> = None;
+        for layer in 0..=bottom {
+            let layer_threshold = univmon_layer_threshold(threshold, layer);
+            self.layers[layer].insert_emit_delta(input, layer_threshold, &mut |delta| {
+                let key = key.get_or_insert_with(|| input_to_owned(input));
+                emit(LayeredCountDelta {
+                    layer: layer as u32,
+                    key: key.clone(),
+                    delta,
+                    worker_id,
+                    weight_total,
+                })
+            });
+        }
+    }
+}
+
+/// OctoSketch parent wrapping a full-precision `UnivMon`.
+///
+/// It holds the pipeline's only heavy-hitter heaps and restores the total
+/// weight UnivMon's g-sum queries divide by from the running totals its
+/// workers report.
+pub struct UnivMonOctoAggregator {
+    /// Parent UnivMon updated by worker deltas.
+    pub sketch: UnivMon,
+    fidelity: Vec<UnivMonDeltaFidelity>,
+    worker_weights: Vec<u64>,
+    total_weight: u64,
+}
+
+impl UnivMonOctoAggregator {
+    /// Creates an aggregator whose workers promote at `threshold`.
+    ///
+    /// The threshold decides whether candidate sets can ever be called
+    /// complete: only a threshold of 1 delivers every insert to the heaps.
+    pub fn new(
+        heap_size: usize,
+        sketch_row: usize,
+        sketch_col: usize,
+        layer_size: usize,
+        threshold: u32,
+    ) -> Self {
+        let mut sketch = UnivMon::init_univmon(heap_size, sketch_row, sketch_col, layer_size);
+        // Each layer runs its own scaled threshold, so completeness is decided
+        // per layer: one that promotes every insert can still keep the heap's
+        // own verdict, while one that thresholds has provably missed keys and
+        // must give the flag up before any delta arrives.
+        let fidelity: Vec<UnivMonDeltaFidelity> = (0..layer_size)
+            .map(|layer| {
+                if univmon_layer_threshold(threshold, layer) <= 1 {
+                    UnivMonDeltaFidelity::EveryInsert
+                } else {
+                    UnivMonDeltaFidelity::PromotedOnly
+                }
+            })
+            .collect();
+        for (layer, mode) in fidelity.iter().enumerate() {
+            if *mode == UnivMonDeltaFidelity::PromotedOnly {
+                sketch.mark_layer_candidates_incomplete(layer);
+            }
+        }
+        Self {
+            sketch,
+            fidelity,
+            worker_weights: Vec::new(),
+            total_weight: 0,
+        }
+    }
+}
+
+impl OctoAggregator for UnivMonOctoAggregator {
+    type Delta = LayeredCountDelta;
+
+    #[inline(always)]
+    fn apply(&mut self, delta: LayeredCountDelta) {
+        let worker = delta.worker_id as usize;
+        if worker >= self.worker_weights.len() {
+            self.worker_weights.resize(worker + 1, 0);
+        }
+        // A worker's running total only grows, so the newest report wins and
+        // the fleet total is the sum of the newest report from each.
+        if delta.weight_total > self.worker_weights[worker] {
+            self.total_weight += delta.weight_total - self.worker_weights[worker];
+            self.worker_weights[worker] = delta.weight_total;
+        }
+        let fidelity = self.fidelity[delta.layer as usize];
+        self.sketch.apply_layered_delta(&delta, fidelity);
+        self.sketch.set_total_weight(self.total_weight as usize);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Core execution engine
 // ---------------------------------------------------------------------------
@@ -507,9 +1441,9 @@ impl OctoAggregator for HllOctoAggregator {
 #[cfg(feature = "octo-runtime")]
 /// Runs the OctoSketch multi-threaded insert protocol.
 ///
-/// 1. Dispatches `inputs` across workers round-robin through per-worker channels.
-/// 2. Each worker maintains a child sketch, emitting deltas via an MPSC channel.
-/// 3. The aggregator blocks on the channel and applies deltas to the parent.
+/// 1. Routes `inputs` to workers per `config.partition`.
+/// 2. Each worker maintains a compact child sketch, emitting deltas on its own channel.
+/// 3. The aggregator applies deltas to the parent and, if configured, adjusts τ.
 /// 4. Returns the fully-merged parent sketch.
 pub fn run_octo<W, P>(
     inputs: &[DataInput<'_>],
@@ -528,335 +1462,737 @@ where
     runtime.finish()
 }
 
-#[cfg(all(test, feature = "octo-runtime"))]
-mod tests {
+#[cfg(test)]
+mod worker_tests {
     use super::*;
-    use crate::DataInput;
-
-    // -----------------------------------------------------------------------
-    // Layer 2 unit tests: child sketches + apply_delta
-    // -----------------------------------------------------------------------
 
     #[test]
-    fn cm_insert_emit_delta_emits_at_threshold() {
-        let mut worker_sketch = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(3, 64);
+    fn compact_worker_clears_the_counter_it_promotes() {
+        let mut worker = CmWorkerSketch::new(3, 64);
         let key = DataInput::U64(42);
         let mut deltas: Vec<CmDelta> = Vec::new();
 
-        // Insert CM_PROMASK-1 times: no delta yet.
-        for _ in 0..(crate::CM_PROMASK - 1) {
-            worker_sketch.insert_emit_delta(&key, &mut |d| deltas.push(d));
+        for _ in 0..(CM_PROMASK - 1) {
+            worker.insert_emit_delta(&key, CM_PROMASK, &mut |d| deltas.push(d));
         }
-        assert!(deltas.is_empty(), "should not emit before threshold");
+        assert!(deltas.is_empty(), "should not promote before the threshold");
 
-        // One more insert triggers the delta.
-        worker_sketch.insert_emit_delta(&key, &mut |d| deltas.push(d));
-        assert_eq!(deltas.len(), 3, "should emit one delta per row (3 rows)");
+        worker.insert_emit_delta(&key, CM_PROMASK, &mut |d| deltas.push(d));
+        assert_eq!(deltas.len(), 3, "one promotion per row");
         for d in &deltas {
-            assert_eq!(d.value, crate::CM_PROMASK);
+            assert_eq!(d.value, CM_PROMASK);
         }
-    }
-
-    #[test]
-    fn cm_apply_delta_increments_parent() {
-        let mut parent = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(3, 64);
-        let delta = CmDelta {
-            row: 1,
-            col: 5,
-            value: 100,
-        };
-        parent.apply_delta(delta);
-        assert_eq!(parent.as_storage().query_one_counter(1, 5), 100);
-
-        parent.apply_delta(delta);
-        assert_eq!(parent.as_storage().query_one_counter(1, 5), 200);
-    }
-
-    #[test]
-    fn count_child_emits_delta_at_threshold() {
-        let mut child = Count::<Vector2D<i32>, RegularPath>::with_dimensions(3, 64);
-        let key = DataInput::U64(99);
-        let mut deltas: Vec<CountDelta> = Vec::new();
-
-        // Insert enough times to trigger at least one delta.
-        for _ in 0..200 {
-            child.insert_emit_delta(&key, &mut |d| deltas.push(d));
-        }
-        // With COUNT_PROMASK = 63 and 3 rows, after 200 inserts we
-        // should have emitted at least 3 deltas (one per row per threshold).
         assert!(
-            deltas.len() >= 3,
-            "expected at least 3 deltas, got {}",
-            deltas.len()
+            worker.residual().iter().all(|&c| c == 0),
+            "Algorithm 1 clears the counter it promotes"
         );
     }
 
     #[test]
-    fn count_apply_delta_increments_parent() {
-        let mut parent = Count::<Vector2D<i32>, RegularPath>::with_dimensions(3, 64);
-        let delta = CountDelta {
-            row: 0,
-            col: 10,
-            value: -50,
-        };
-        parent.apply_delta(delta);
-        assert_eq!(parent.as_storage().query_one_counter(0, 10), -50);
+    fn compact_worker_uses_a_quarter_of_the_counter_memory() {
+        let (rows, cols) = (3usize, 4096usize);
+        let compact = CmWorkerSketch::new(rows, cols).counter_bytes();
+        let full = rows * cols * std::mem::size_of::<i32>();
+        assert_eq!(compact * 4, full, "one byte per counter instead of four");
     }
 
     #[test]
-    fn hll_child_emits_delta_on_improvement() {
+    fn compact_worker_honours_a_custom_threshold() {
+        let mut worker = CmWorkerSketch::new(1, 16);
+        let key = DataInput::U64(7);
+        let mut promotions = 0usize;
+        for _ in 0..100 {
+            worker.insert_emit_delta(&key, 10, &mut |_| promotions += 1);
+        }
+        assert_eq!(
+            promotions, 10,
+            "a threshold of 10 promotes every 10 inserts"
+        );
+    }
+
+    #[test]
+    fn compact_count_worker_promotes_on_magnitude_and_clears() {
+        let mut worker = CountWorkerSketch::new(3, 64);
+        let key = DataInput::U64(99);
+        let mut deltas: Vec<CountDelta> = Vec::new();
+        for _ in 0..200 {
+            worker.insert_emit_delta(&key, COUNT_PROMASK, &mut |d| deltas.push(d));
+        }
+        assert!(!deltas.is_empty());
+        for d in &deltas {
+            assert_eq!(d.value.unsigned_abs(), COUNT_PROMASK);
+        }
+        assert!(worker.residual().iter().all(|&c| c.unsigned_abs() < 31));
+    }
+
+    #[test]
+    fn keyed_deltas_carry_the_key_that_triggered_them() {
+        let mut worker = CmWorkerSketch::new(2, 8);
+        let key = DataInput::Str("flow-a");
+        let mut keyed: Vec<KeyedCmDelta> = Vec::new();
+        for _ in 0..CM_PROMASK {
+            worker.insert_emit_keyed_delta(&key, CM_PROMASK, &mut |d| keyed.push(d));
+        }
+        assert!(!keyed.is_empty());
+        for d in &keyed {
+            assert_eq!(d.key, input_to_owned(&key));
+        }
+    }
+
+    #[test]
+    fn dd_worker_promotes_and_clears_a_bucket() {
+        let mut worker = DdWorkerSketch::new(0.01);
+        let mut deltas: Vec<DdDelta> = Vec::new();
+        for _ in 0..CM_PROMASK {
+            worker.add_emit_delta(42.0, CM_PROMASK, &mut |d| deltas.push(d));
+        }
+        assert_eq!(deltas.len(), 1, "one promotion per tau samples");
+        assert_eq!(deltas[0].value as u32, CM_PROMASK);
+        assert!(
+            worker.residual().is_empty(),
+            "the promoted bucket must be cleared"
+        );
+    }
+
+    #[test]
+    fn dd_worker_drops_what_the_parent_would_drop() {
+        let mut worker = DdWorkerSketch::new(0.01);
+        let mut promoted = 0usize;
+        for value in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            for _ in 0..1_000 {
+                worker.add_emit_delta(value, 1, &mut |_| promoted += 1);
+            }
+        }
+        assert_eq!(
+            promoted, 0,
+            "non-positive and non-finite values are dropped"
+        );
+    }
+
+    #[test]
+    fn dd_promotion_bounds_the_quantile_rank_error_by_what_it_holds_back() {
+        let alpha = 0.01;
+        let mut worker = DdWorkerSketch::new(alpha);
+        let mut parent = DDSketch::new(alpha);
+        let mut exact: Vec<f64> = Vec::new();
+
+        let n = 200_000u64;
+        for i in 1..=n {
+            let value = 1.0 + (i as f64 * 7.0) % 999.0;
+            exact.push(value);
+            worker.add_emit_delta(value, DD_PROMASK, &mut |d| parent.apply_delta(d));
+        }
+        exact.sort_by(f64::total_cmp);
+
+        // Unlike a Count-Min row, an un-promoted bucket is missing from the
+        // parent outright, so the promotion error shows up as a rank shift
+        // bounded by the mass the worker still holds.
+        assert_eq!(
+            worker.held_back() + parent.get_count(),
+            n,
+            "every sample is either promoted or still held"
+        );
+        let rank_slack = worker.held_back() as f64 / n as f64;
+        assert!(
+            rank_slack < 0.05,
+            "a threshold of {DD_PROMASK} held back {rank_slack:.3} of the stream"
+        );
+
+        for q in [0.1, 0.5, 0.9, 0.99] {
+            let got = parent
+                .get_value_at_quantile(q)
+                .expect("parent received samples");
+            let lo = exact[(((q - rank_slack).max(0.0)) * (exact.len() - 1) as f64) as usize]
+                * (1.0 - alpha);
+            let hi = exact[(((q + rank_slack).min(1.0)) * (exact.len() - 1) as f64) as usize]
+                * (1.0 + alpha);
+            assert!(
+                (lo..=hi).contains(&got),
+                "q={q}: {got} outside [{lo}, {hi}] at rank slack {rank_slack:.3}"
+            );
+        }
+    }
+
+    #[test]
+    fn dd_a_higher_threshold_holds_back_more_of_a_sparse_stream() {
+        let alpha = 0.01;
+        let n = 20_000u64;
+        let mut held = Vec::new();
+        for threshold in [2u32, 8, 31] {
+            let mut worker = DdWorkerSketch::new(alpha);
+            for i in 1..=n {
+                worker.add_emit_delta(1.0 + (i as f64 * 7.0) % 999.0, threshold, &mut |_| {});
+            }
+            held.push((threshold, worker.held_back()));
+        }
+        assert!(
+            held[0].1 < held[1].1 && held[1].1 < held[2].1,
+            "held-back mass must grow with the threshold: {held:?}"
+        );
+    }
+
+    #[test]
+    fn threshold_for_error_follows_equation_four() {
+        // tau = eps * L1 / k'
+        assert_eq!(threshold_for_error(0.001, 1_000_000.0, 4), 250);
+        assert_eq!(threshold_for_error(0.001, 1_000_000.0, 1), MAX_PROMASK);
+        assert_eq!(threshold_for_error(1e-9, 1_000.0, 1), 1, "never below one");
+    }
+
+    #[test]
+    fn shared_threshold_is_visible_to_every_holder() {
+        let shared = OctoThreshold::new(31);
+        let clone = shared.clone();
+        shared.increase(4);
+        assert_eq!(clone.get(), 35);
+        clone.decrease(34);
+        assert_eq!(shared.get(), 1, "the floor is one");
+        clone.set(u32::MAX);
+        assert_eq!(shared.get(), MAX_PROMASK, "the ceiling is one byte");
+    }
+
+    #[test]
+    fn hll_threshold_zero_promotes_every_improvement() {
         let mut child = HyperLogLog::<Classic>::default();
-        let mut deltas: Vec<HllDelta> = Vec::new();
-
-        // First insert should always emit (register goes from 0 to something > 0).
-        child.insert_emit_delta(&DataInput::U64(1), &mut |d| deltas.push(d));
-        assert_eq!(deltas.len(), 1, "first insert should emit a delta");
-
-        // Inserting the same value again should NOT emit (register unchanged).
-        let len_before = deltas.len();
-        child.insert_emit_delta(&DataInput::U64(1), &mut |d| deltas.push(d));
-        assert_eq!(deltas.len(), len_before, "duplicate should not emit");
+        let mut deltas = 0usize;
+        child.insert_emit_delta_with_threshold(&DataInput::U64(1), 0, &mut |_| deltas += 1);
+        assert_eq!(deltas, 1);
+        child.insert_emit_delta_with_threshold(&DataInput::U64(1), 0, &mut |_| deltas += 1);
+        assert_eq!(deltas, 1, "a duplicate cannot improve a register");
     }
 
     #[test]
-    fn hll_apply_delta_updates_register() {
-        let mut parent = HyperLogLog::<Classic>::default();
-        let delta = HllDelta {
-            pos: 100,
-            value: 10,
-        };
-        parent.apply_delta(delta);
+    fn hll_threshold_holds_back_small_register_gains() {
+        let n = 20_000u64;
+        let mut promoted_at_zero = 0usize;
+        let mut promoted_at_four = 0usize;
+        let mut a = HyperLogLog::<Classic>::default();
+        let mut b = HyperLogLog::<Classic>::default();
+        for i in 0..n {
+            a.insert_emit_delta_with_threshold(&DataInput::U64(i), 0, &mut |_| {
+                promoted_at_zero += 1
+            });
+            b.insert_emit_delta_with_threshold(&DataInput::U64(i), 4, &mut |_| {
+                promoted_at_four += 1
+            });
+        }
+        assert!(
+            promoted_at_four < promoted_at_zero,
+            "a larger threshold must send fewer messages: {promoted_at_four} vs {promoted_at_zero}"
+        );
+    }
+}
 
-        // Apply a smaller value — should not change.
-        let smaller = HllDelta { pos: 100, value: 5 };
-        parent.apply_delta(smaller);
+#[cfg(all(test, feature = "octo-runtime"))]
+mod runtime_tests {
+    use super::*;
 
-        // Apply a larger value — should update.
-        let larger = HllDelta {
-            pos: 100,
-            value: 15,
-        };
-        parent.apply_delta(larger);
+    fn config(num_workers: usize) -> OctoConfig {
+        OctoConfig {
+            num_workers,
+            // CI runners may have fewer cores than the widest configuration here.
+            pin_cores: false,
+            queue_capacity: 8192,
+            ..OctoConfig::default()
+        }
     }
 
-    // -----------------------------------------------------------------------
-    // Layer 3 integration tests: run_octo
-    // -----------------------------------------------------------------------
-
     #[test]
-    fn run_octo_cm_matches_single_thread() {
-        let rows = 3;
-        let cols = 4096;
+    fn run_octo_cm_tracks_a_single_threaded_sketch() {
+        let (rows, cols) = (3usize, 4096usize);
         let n = 100_000u64;
-
         let inputs: Vec<DataInput<'_>> = (0..n).map(|i| DataInput::U64(i % 1024)).collect();
 
-        // Single-threaded reference.
         let mut reference = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
         for input in &inputs {
             reference.insert(input);
         }
 
-        // Multi-threaded via OctoSketch.
-        let config = OctoConfig {
-            num_workers: 4,
-            pin_cores: false, // don't pin in tests (CI may have few cores)
-            queue_capacity: 8192,
-        };
         let result = run_octo(
             &inputs,
-            &config,
+            &config(4),
             |_| CmOctoWorker::new(rows, cols),
-            || CmOctoAggregator {
-                sketch: CountMin::with_dimensions(rows, cols),
-            },
+            || CmOctoAggregator::new(rows, cols),
         );
 
-        // Verify estimates are close.
-        // OctoSketch child uses u8 counters, so there may be slight differences
-        // due to the promotion threshold batching, but the total counts should match.
+        // Hash partitioning puts each key on one worker, so at most one worker
+        // holds back up to tau of any key: k' = 1.
         for key_val in 0u64..1024 {
             let key = DataInput::U64(key_val);
-            let ref_est = reference.estimate(&key);
-            let octo_est = result.parent.sketch.estimate(&key);
-            // The octo estimate should be <= reference (some counts may be
-            // lost in the u8 remainder that didn't reach PROMASK).
+            let deficit = reference.estimate(&key) - result.parent.sketch.estimate(&key);
             assert!(
-                (ref_est - octo_est).abs() < 200,
-                "key {key_val}: ref={ref_est}, octo={octo_est}, diff={}",
-                (ref_est - octo_est).abs()
+                (0..CM_PROMASK as i32).contains(&deficit),
+                "key {key_val}: deficit {deficit} outside [0, tau)"
             );
         }
     }
 
     #[test]
-    fn run_octo_hll_cardinality() {
+    fn run_octo_hll_matches_a_single_threaded_sketch_exactly() {
         let n = 50_000u64;
         let inputs: Vec<DataInput<'_>> = (0..n).map(DataInput::U64).collect();
-
-        let config = OctoConfig {
-            num_workers: 4,
-            pin_cores: false,
-            queue_capacity: 16384,
-        };
+        let mut reference = HyperLogLog::<Classic>::default();
+        for input in &inputs {
+            reference.insert(input);
+        }
 
         let result = run_octo(
             &inputs,
-            &config,
+            &config(4),
             |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
+            HllOctoAggregator::new,
         );
-
-        let estimate = result.parent.sketch.estimate();
-        let truth = n as f64;
-        let error = (estimate as f64 - truth).abs() / truth;
-        assert!(
-            error < 0.05,
-            "HLL cardinality error {error:.4} exceeded 5% (truth {truth}, estimate {estimate})"
+        assert_eq!(
+            result.parent.sketch.registers_as_slice(),
+            reference.registers_as_slice()
         );
     }
 
     #[test]
-    fn run_octo_count_sketch_basic() {
-        let rows = 3;
-        let cols = 4096;
-        let n = 50_000u64;
-
-        let inputs: Vec<DataInput<'_>> = (0..n).map(|i| DataInput::U64(i % 512)).collect();
-
-        let config = OctoConfig {
-            num_workers: 2,
-            pin_cores: false,
-            queue_capacity: 8192,
+    fn hash_partitioning_sends_a_key_to_exactly_one_worker() {
+        let workers = 4usize;
+        let cfg = OctoConfig {
+            partition: OctoPartition::HashByKey,
+            ..config(workers)
         };
+        let mut runtime = OctoRuntime::new(
+            &cfg,
+            |worker_id| WorkerIdEmitter { worker_id },
+            || WorkerLoadAggregator {
+                loads: vec![0; workers],
+            },
+        );
+        // One key, many inserts: a hash partition must pile them all on one worker.
+        for _ in 0..1_000 {
+            runtime.insert(DataInput::U64(4_242));
+        }
+        let loads = runtime.finish().parent.loads;
+        assert_eq!(loads.iter().filter(|&&l| l > 0).count(), 1, "{loads:?}");
+        assert_eq!(loads.iter().sum::<u64>(), 1_000);
+    }
+
+    #[test]
+    fn round_robin_partitioning_still_spreads_inputs_evenly() {
+        let workers = 3usize;
+        let cfg = OctoConfig {
+            partition: OctoPartition::RoundRobin,
+            ..config(workers)
+        };
+        let mut runtime = OctoRuntime::new(
+            &cfg,
+            |worker_id| WorkerIdEmitter { worker_id },
+            || WorkerLoadAggregator {
+                loads: vec![0; workers],
+            },
+        );
+        for i in 0..10u64 {
+            runtime.insert(DataInput::U64(i));
+        }
+        assert_eq!(runtime.finish().parent.loads, vec![4, 3, 3]);
+    }
+
+    #[test]
+    fn a_shared_threshold_reaches_every_worker() {
+        let (rows, cols) = (2usize, 256usize);
+        let threshold = OctoThreshold::new(4);
+        let cfg = OctoConfig {
+            threshold: threshold.clone(),
+            ..config(2)
+        };
+        let inputs: Vec<DataInput<'_>> = (0..400u64).map(|i| DataInput::U64(i % 8)).collect();
+
+        let low = run_octo(
+            &inputs,
+            &cfg,
+            {
+                let threshold = threshold.clone();
+                move |_| CmOctoWorker::with_threshold(rows, cols, threshold.clone())
+            },
+            || CmOctoAggregator::new(rows, cols),
+        );
+
+        let high_threshold = OctoThreshold::new(64);
+        let high_cfg = OctoConfig {
+            threshold: high_threshold.clone(),
+            ..config(2)
+        };
+        let high = run_octo(
+            &inputs,
+            &high_cfg,
+            {
+                let threshold = high_threshold.clone();
+                move |_| CmOctoWorker::with_threshold(rows, cols, threshold.clone())
+            },
+            || CmOctoAggregator::new(rows, cols),
+        );
+
+        let probe = DataInput::U64(3);
+        assert!(
+            low.parent.sketch.estimate(&probe) > high.parent.sketch.estimate(&probe),
+            "a lower threshold must promote more of the count"
+        );
+    }
+
+    /// Drives `ThresholdController` over channels held at a fixed occupancy.
+    fn adjust_against_queue_len(
+        settings: &OctoAdaptiveThreshold,
+        threshold: &OctoThreshold,
+        queued: usize,
+        rounds: usize,
+    ) {
+        let (tx, rx) = bounded::<u8>(queued.max(1));
+        for _ in 0..queued {
+            tx.send(0).expect("queue has room");
+        }
+        let receivers = vec![Some(rx)];
+        let mut controller = ThresholdController::new(settings);
+        for _ in 0..rounds {
+            for _ in 0..ThresholdController::POLLS_BETWEEN_CLOCK_READS {
+                controller.maybe_adjust(&receivers, threshold);
+            }
+        }
+    }
+
+    #[test]
+    fn the_controller_raises_tau_when_the_queue_runs_long() {
+        let settings = OctoAdaptiveThreshold {
+            target_queue_len: 10,
+            alpha: 0.25,
+            interval: Duration::ZERO,
+            min_threshold: 1,
+            max_threshold: 200,
+        };
+        let threshold = OctoThreshold::new(31);
+        adjust_against_queue_len(&settings, &threshold, 500, 8);
+        assert!(
+            threshold.get() > 31,
+            "a queue far above target must push tau up, got {}",
+            threshold.get()
+        );
+    }
+
+    #[test]
+    fn the_controller_lowers_tau_when_the_queue_runs_short() {
+        let settings = OctoAdaptiveThreshold {
+            target_queue_len: 10,
+            alpha: 0.25,
+            interval: Duration::ZERO,
+            min_threshold: 4,
+            max_threshold: 200,
+        };
+        let threshold = OctoThreshold::new(31);
+        adjust_against_queue_len(&settings, &threshold, 0, 64);
+        assert_eq!(
+            threshold.get(),
+            4,
+            "an idle queue must walk tau down to its floor"
+        );
+    }
+
+    #[test]
+    fn the_controller_holds_tau_inside_the_dead_band() {
+        let settings = OctoAdaptiveThreshold {
+            target_queue_len: 10,
+            alpha: 0.25,
+            interval: Duration::ZERO,
+            min_threshold: 1,
+            max_threshold: 200,
+        };
+        let threshold = OctoThreshold::new(31);
+        adjust_against_queue_len(&settings, &threshold, 10, 8);
+        // Equation 1 has no previous sample on the first evaluation, so it
+        // predicts 10 + (10 - 0) = 20 and nudges tau once. Every later
+        // evaluation predicts 10, inside the [7.5, 12.5] dead band.
+        assert_eq!(
+            threshold.get(),
+            32,
+            "a queue held at target must settle after the initial transient"
+        );
+    }
+
+    #[test]
+    fn the_adaptive_controller_moves_tau_during_a_real_run() {
+        let (rows, cols) = (3usize, 1024usize);
+        let threshold = OctoThreshold::new(60);
+        let settings = OctoAdaptiveThreshold {
+            target_queue_len: 8,
+            alpha: 0.25,
+            interval: Duration::from_micros(1),
+            min_threshold: 4,
+            max_threshold: 120,
+        };
+        let cfg = OctoConfig {
+            num_workers: 4,
+            pin_cores: false,
+            queue_capacity: 4096,
+            threshold: threshold.clone(),
+            partition: OctoPartition::HashByKey,
+            adaptive: Some(settings.clone()),
+        };
+
+        let inputs: Vec<DataInput<'_>> =
+            (0..200_000u64).map(|i| DataInput::U64(i % 4096)).collect();
+        let result = run_octo(
+            &inputs,
+            &cfg,
+            {
+                let threshold = threshold.clone();
+                move |_| CmOctoWorker::with_threshold(rows, cols, threshold.clone())
+            },
+            || CmOctoAggregator::new(rows, cols),
+        );
+
+        let settled = threshold.get();
+        assert!(
+            (settings.min_threshold..=settings.max_threshold).contains(&settled),
+            "tau {settled} left the configured band"
+        );
+        assert_ne!(settled, 60, "the controller should have moved tau at all");
+        // Whatever tau settled at, the parent is still a usable sketch.
+        assert!(result.parent.sketch.estimate(&DataInput::U64(0)) > 0);
+    }
+
+    #[test]
+    fn the_topk_aggregator_rebuilds_the_heavy_hitter_heap_from_worker_keys() {
+        let (rows, cols, top_k) = (4usize, 2048usize, 8usize);
+        let mut inputs: Vec<DataInput<'_>> = Vec::new();
+        // Four unmistakable heavy hitters over a wide light tail.
+        for i in 0..4u64 {
+            for _ in 0..4_000 {
+                inputs.push(DataInput::U64(i));
+            }
+        }
+        for i in 1_000..6_000u64 {
+            inputs.push(DataInput::U64(i));
+        }
 
         let result = run_octo(
             &inputs,
-            &config,
-            |_| CountOctoWorker::new(rows, cols),
-            || CountOctoAggregator {
-                sketch: Count::with_dimensions(rows, cols),
-            },
+            &config(4),
+            |_| CmTopKOctoWorker::new(rows, cols),
+            || CmTopKOctoAggregator::new(rows, cols, top_k),
         );
 
-        // Each key appears ~97 times. Check a sample of keys.
-        let expected_per_key = (n / 512) as f64;
-        for key_val in [0u64, 100, 255, 511] {
-            let key = DataInput::U64(key_val);
-            let est = result.parent.sketch.estimate(&key);
+        let heap = result.parent.sketch.heap();
+        assert!(!heap.is_empty(), "the aggregator must have built a heap");
+        for hot in 0..4u64 {
             assert!(
-                (est - expected_per_key).abs() < expected_per_key * 0.5,
-                "key {key_val}: estimate={est}, expected~{expected_per_key}"
+                result
+                    .parent
+                    .sketch
+                    .heap()
+                    .find(&DataInput::U64(hot))
+                    .is_some(),
+                "heavy hitter {hot} missing from the aggregator heap"
             );
         }
     }
 
     #[test]
-    fn run_octo_single_worker() {
-        // Edge case: single worker should still work.
-        let inputs: Vec<DataInput<'_>> = (0..1000u64).map(DataInput::U64).collect();
-
-        let config = OctoConfig {
-            num_workers: 1,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
+    fn the_count_topk_aggregator_also_tracks_heavy_hitters() {
+        let (rows, cols, top_k) = (5usize, 2048usize, 8usize);
+        let mut inputs: Vec<DataInput<'_>> = Vec::new();
+        for i in 0..3u64 {
+            for _ in 0..5_000 {
+                inputs.push(DataInput::U64(i));
+            }
+        }
+        for i in 500..3_000u64 {
+            inputs.push(DataInput::U64(i));
+        }
 
         let result = run_octo(
             &inputs,
-            &config,
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
+            &config(4),
+            |_| CountTopKOctoWorker::new(rows, cols),
+            || CountTopKOctoAggregator::new(rows, cols, top_k),
+        );
+        for hot in 0..3u64 {
+            assert!(
+                result
+                    .parent
+                    .sketch
+                    .heap()
+                    .find(&DataInput::U64(hot))
+                    .is_some(),
+                "heavy hitter {hot} missing from the aggregator heap"
+            );
+        }
+    }
+
+    #[test]
+    fn run_octo_ddsketch_tracks_quantiles_of_the_stream() {
+        let alpha = 0.01;
+        let inputs: Vec<DataInput<'_>> = (1..=200_000u64)
+            .map(|i| DataInput::F64(1.0 + (i as f64 * 7.0) % 999.0))
+            .collect();
+        let mut exact: Vec<f64> = inputs
+            .iter()
+            .map(|i| match i {
+                DataInput::F64(v) => *v,
+                _ => unreachable!(),
+            })
+            .collect();
+        exact.sort_by(f64::total_cmp);
+
+        let result = run_octo(
+            &inputs,
+            &config(4),
+            |_| DdOctoWorker::new(alpha),
+            || DdOctoAggregator::new(alpha),
         );
 
-        let estimate = result.parent.sketch.estimate();
+        // Four workers each hold back their own partial buckets, so the rank
+        // slack is what the whole fleet has yet to promote.
+        let held_back = inputs.len() as u64 - result.parent.sketch.get_count();
+        let rank_slack = held_back as f64 / inputs.len() as f64;
+        assert!(rank_slack < 0.05, "held back {rank_slack:.3} of the stream");
+
+        for q in [0.1, 0.5, 0.9] {
+            let got = result
+                .parent
+                .sketch
+                .get_value_at_quantile(q)
+                .expect("parent received samples");
+            let lo = exact[(((q - rank_slack).max(0.0)) * (exact.len() - 1) as f64) as usize]
+                * (1.0 - alpha);
+            let hi = exact[(((q + rank_slack).min(1.0)) * (exact.len() - 1) as f64) as usize]
+                * (1.0 + alpha);
+            assert!(
+                (lo..=hi).contains(&got),
+                "q={q}: {got} outside [{lo}, {hi}] at rank slack {rank_slack:.3}"
+            );
+        }
+    }
+
+    #[test]
+    fn run_octo_univmon_tracks_heavy_hitters_and_total_weight() {
+        let (heap, rows, cols, layers) = (32usize, 3usize, 256usize, 6usize);
+        let tau = 8u32;
+        let threshold = OctoThreshold::new(tau);
+
+        let mut inputs: Vec<DataInput<'_>> = Vec::new();
+        for hot in 0..5u64 {
+            for _ in 0..4_000 {
+                inputs.push(DataInput::U64(hot));
+            }
+        }
+        for cold in 10_000..15_000u64 {
+            inputs.push(DataInput::U64(cold));
+        }
+
+        let cfg = OctoConfig {
+            threshold: threshold.clone(),
+            ..config(4)
+        };
+        let result = run_octo(
+            &inputs,
+            &cfg,
+            {
+                let threshold = threshold.clone();
+                move |worker_id| {
+                    UnivMonOctoWorker::with_threshold(
+                        worker_id,
+                        rows,
+                        cols,
+                        layers,
+                        threshold.clone(),
+                    )
+                }
+            },
+            || UnivMonOctoAggregator::new(heap, rows, cols, layers, tau),
+        );
+        let univmon = &result.parent.sketch;
+
+        // The fleet reports its running weight on messages it was already
+        // sending, so the aggregator's total trails by whatever arrived after
+        // each worker's last promotion - never overshoots.
         assert!(
-            estimate > 900 && estimate < 1100,
-            "single-worker HLL estimate {estimate} out of range for 1000 distinct keys"
+            univmon.bucket_size <= inputs.len(),
+            "reported weight {} exceeds the stream",
+            univmon.bucket_size
+        );
+        assert!(
+            univmon.bucket_size as f64 > inputs.len() as f64 * 0.9,
+            "reported weight {} trails the stream of {} by too much",
+            univmon.bucket_size,
+            inputs.len()
+        );
+
+        for hot in 0..5u64 {
+            assert!(
+                univmon.hh_layers[0].find(&DataInput::U64(hot)).is_some(),
+                "heavy hitter {hot} missing from the aggregator's layer-0 heap"
+            );
+        }
+        assert!(
+            univmon.candidates_complete().iter().all(|c| !c),
+            "a promoted-only aggregator must not claim complete candidate sets"
         );
     }
 
     #[test]
-    fn octo_runtime_streaming_cm_matches_batch_api() {
-        let rows = 3;
-        let cols = 4096;
-        let n = 30_000u64;
-        let inputs: Vec<DataInput<'_>> = (0..n).map(|i| DataInput::U64(i % 1024)).collect();
-        let config = OctoConfig {
-            num_workers: 4,
-            pin_cores: false,
-            queue_capacity: 8192,
-        };
+    fn octo_runtime_streaming_matches_the_batch_helper() {
+        let (rows, cols) = (3usize, 4096usize);
+        let inputs: Vec<DataInput<'_>> = (0..30_000u64).map(|i| DataInput::U64(i % 1024)).collect();
+        let cfg = config(4);
 
-        let batch_result = run_octo(
+        let batch = run_octo(
             &inputs,
-            &config,
+            &cfg,
             |_| CmOctoWorker::new(rows, cols),
-            || CmOctoAggregator {
-                sketch: CountMin::with_dimensions(rows, cols),
-            },
+            || CmOctoAggregator::new(rows, cols),
         );
 
         let mut runtime = OctoRuntime::new(
-            &config,
+            &cfg,
             move |_| CmOctoWorker::new(rows, cols),
-            move || CmOctoAggregator {
-                sketch: CountMin::with_dimensions(rows, cols),
-            },
+            move || CmOctoAggregator::new(rows, cols),
         );
         for input in &inputs {
             runtime.insert(input.clone());
         }
-        let streaming_result = runtime.finish();
+        let streamed = runtime.finish();
 
         for key_val in 0u64..128 {
             let key = DataInput::U64(key_val);
-            let batch_est = batch_result.parent.sketch.estimate(&key);
-            let stream_est = streaming_result.parent.sketch.estimate(&key);
-            assert_eq!(batch_est, stream_est, "key {key_val} mismatch");
+            assert_eq!(
+                batch.parent.sketch.estimate(&key),
+                streamed.parent.sketch.estimate(&key),
+                "key {key_val}"
+            );
         }
     }
 
     #[test]
-    fn octo_runtime_mixed_insert_and_batch_hll() {
-        let config = OctoConfig {
-            num_workers: 2,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
-        let mut runtime = OctoRuntime::new(
-            &config,
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
-        );
+    fn octo_runtime_close_is_idempotent() {
+        let runtime =
+            OctoRuntime::new(&config(2), |_| HllOctoWorker::new(), HllOctoAggregator::new);
+        runtime.close();
+        runtime.close();
+        assert_eq!(runtime.finish().parent.sketch.estimate(), 0);
+    }
 
+    #[test]
+    #[should_panic(expected = "cannot insert after runtime has been closed")]
+    fn octo_runtime_insert_after_close_panics() {
+        let mut runtime =
+            OctoRuntime::new(&config(2), |_| HllOctoWorker::new(), HllOctoAggregator::new);
+        runtime.close();
         runtime.insert(DataInput::U64(1));
-        runtime.insert(DataInput::U64(2));
-        let batch: Vec<DataInput<'_>> = (3..2000).map(DataInput::U64).collect();
-        runtime.insert_batch(&batch);
-        let result = runtime.finish();
-        let estimate = result.parent.sketch.estimate();
-        assert!(
-            estimate > 1700 && estimate < 2300,
-            "runtime mixed insert+batch estimate {estimate} is out of expected range"
-        );
+    }
+
+    #[test]
+    fn octo_runtime_empty_stream_finishes() {
+        let runtime =
+            OctoRuntime::new(&config(4), |_| HllOctoWorker::new(), HllOctoAggregator::new);
+        assert_eq!(runtime.finish().parent.sketch.estimate(), 0);
     }
 
     #[test]
     fn octo_runtime_live_read_handle_observes_progress() {
-        let config = OctoConfig {
-            num_workers: 2,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
         let mut runtime = OctoRuntime::new(
-            &config,
+            &config(2),
             |_| CountingWorker,
             || CountingAggregator { total: 0 },
         );
@@ -867,81 +2203,26 @@ mod tests {
         }
         std::thread::sleep(std::time::Duration::from_millis(5));
         let observed = reader.with_parent(|p| p.total);
-        assert!(
-            observed <= 64,
-            "live reader should observe a partial or complete total"
-        );
+        assert!(observed <= 64);
 
         let result = runtime.finish();
-        assert_eq!(
-            result.parent.total, 64,
-            "all inserted items should be accounted for"
-        );
-        assert!(
-            result.parent.total >= observed,
-            "final total should not be less than live snapshot"
-        );
+        assert_eq!(result.parent.total, 64);
+        assert!(result.parent.total >= observed);
     }
 
     #[test]
-    fn octo_runtime_close_is_idempotent() {
-        let config = OctoConfig {
-            num_workers: 2,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
-        let runtime = OctoRuntime::new(
-            &config,
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
-        );
-        runtime.close();
-        runtime.close();
-        let result = runtime.finish();
-        assert_eq!(result.parent.sketch.estimate(), 0);
-    }
-
-    #[test]
-    #[should_panic(expected = "cannot insert after runtime has been closed")]
-    fn octo_runtime_insert_after_close_panics() {
-        let config = OctoConfig {
-            num_workers: 2,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
+    fn octo_runtime_close_preserves_queued_items() {
+        let n = 257u64;
         let mut runtime = OctoRuntime::new(
-            &config,
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
+            &config(4),
+            |_| CountingWorker,
+            || CountingAggregator { total: 0 },
         );
+        for i in 0..n {
+            runtime.insert(DataInput::U64(i + 42));
+        }
         runtime.close();
-        runtime.insert(DataInput::U64(1));
-    }
-
-    #[test]
-    fn octo_runtime_empty_stream_finishes() {
-        let config = OctoConfig {
-            num_workers: 4,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
-        let runtime = OctoRuntime::new(
-            &config,
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
-        );
-        let result = runtime.finish();
-        let estimate = result.parent.sketch.estimate();
-        assert!(
-            estimate == 0,
-            "empty runtime should estimate 0 cardinality, got {estimate}"
-        );
+        assert_eq!(runtime.finish().parent.total, n);
     }
 
     struct CountingWorker;
@@ -967,31 +2248,6 @@ mod tests {
         fn apply(&mut self, delta: Self::Delta) {
             self.total += delta;
         }
-    }
-
-    #[test]
-    fn octo_runtime_close_preserves_queued_items_without_dispatcher() {
-        let config = OctoConfig {
-            num_workers: 4,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
-        let n = 257usize;
-        let mut runtime = OctoRuntime::new(
-            &config,
-            |_| CountingWorker,
-            || CountingAggregator { total: 0 },
-        );
-
-        for i in 0..n as u64 {
-            runtime.insert(DataInput::U64(i + 42));
-        }
-        runtime.close();
-        let result = runtime.finish();
-        assert_eq!(
-            result.parent.total, n as u64,
-            "runtime close should preserve already queued items"
-        );
     }
 
     struct WorkerIdEmitter {
@@ -1020,29 +2276,214 @@ mod tests {
             self.loads[delta] += 1;
         }
     }
+}
+
+#[cfg(test)]
+mod univmon_tests {
+    use super::*;
+    use crate::L2HH;
+
+    const HEAP: usize = 32;
+    const ROWS: usize = 3;
+    const COLS: usize = 256;
+    const LAYERS: usize = 6;
+
+    fn layer_counters(sketch: &UnivMon, layer: usize) -> Vec<i64> {
+        let L2HH::COUNT(inner) = &sketch.l2_sketch_layers[layer];
+        (0..inner.rows())
+            .flat_map(|r| (0..inner.cols()).map(move |c| (r, c)))
+            .map(|(r, c)| inner.as_storage().query_one_counter(r, c))
+            .collect()
+    }
+
+    fn heap_contents(sketch: &UnivMon, layer: usize) -> Vec<(HeapItem, i64)> {
+        let mut items: Vec<(HeapItem, i64)> = sketch.hh_layers[layer]
+            .heap()
+            .iter()
+            .map(|i| (i.key.clone(), i.count))
+            .collect();
+        items.sort_by(|a, b| {
+            b.1.cmp(&a.1)
+                .then_with(|| format!("{:?}", a.0).cmp(&format!("{:?}", b.0)))
+        });
+        items
+    }
+
+    fn stream(n: u64) -> Vec<DataInput<'static>> {
+        // A skewed stream: a few keys carry most of the weight.
+        (0..n)
+            .map(|i| {
+                let key = match i % 10 {
+                    0..=4 => i % 5,
+                    5..=7 => 100 + (i % 40),
+                    _ => 1_000 + (i % 900),
+                };
+                DataInput::U64(key)
+            })
+            .collect()
+    }
 
     #[test]
-    fn octo_runtime_round_robin_selector_distributes_deterministically() {
-        let num_workers = 3;
-        let inserts = 10u64;
-        let config = OctoConfig {
-            num_workers,
-            pin_cores: false,
-            queue_capacity: 4096,
-        };
-        let mut runtime = OctoRuntime::new(
-            &config,
-            |worker_id| WorkerIdEmitter { worker_id },
-            || WorkerLoadAggregator {
-                loads: vec![0; num_workers],
-            },
-        );
-
-        for i in 0..inserts {
-            runtime.insert(DataInput::U64(i));
+    fn a_worker_picks_the_same_layers_as_a_single_threaded_insert() {
+        let reference = UnivMon::init_univmon(HEAP, ROWS, COLS, LAYERS);
+        for key in 0..5_000u64 {
+            let input = DataInput::U64(key);
+            let from_hash =
+                bottom_layer_for_hash(hash64_seeded(BOTTOM_LAYER_FINDER, &input), LAYERS);
+            assert_eq!(
+                from_hash,
+                reference.bottom_layer_for(&input),
+                "key {key} routed to a different layer set"
+            );
+            assert!(from_hash < LAYERS);
         }
-        let result = runtime.finish();
+    }
 
-        assert_eq!(result.parent.loads, vec![4, 3, 3]);
+    #[test]
+    fn one_worker_at_threshold_one_reproduces_a_single_threaded_univmon() {
+        // A threshold of 1 promotes every counter touch, and a single worker
+        // applies them in stream order, so the aggregator must land in exactly
+        // the state a single-threaded insert loop would.
+        let inputs = stream(20_000);
+
+        let mut reference = UnivMon::init_univmon(HEAP, ROWS, COLS, LAYERS);
+        for input in &inputs {
+            reference.insert(input, 1);
+        }
+
+        let mut worker =
+            UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, OctoThreshold::new(1));
+        let mut aggregator = UnivMonOctoAggregator::new(HEAP, ROWS, COLS, LAYERS, 1);
+        for input in &inputs {
+            let mut promoted = Vec::new();
+            worker.process(input, &mut |d| promoted.push(d));
+            for delta in promoted {
+                aggregator.apply(delta);
+            }
+        }
+        let octo = &aggregator.sketch;
+
+        assert_eq!(octo.bucket_size, reference.bucket_size, "total weight");
+        assert_eq!(
+            octo.candidates_complete(),
+            reference.candidates_complete(),
+            "candidate completeness"
+        );
+        for layer in 0..LAYERS {
+            assert_eq!(
+                layer_counters(octo, layer),
+                layer_counters(&reference, layer),
+                "layer {layer} counters"
+            );
+            assert_eq!(
+                octo.l2_sketch_layers[layer].get_l2(),
+                reference.l2_sketch_layers[layer].get_l2(),
+                "layer {layer} L2"
+            );
+            assert_eq!(
+                heap_contents(octo, layer),
+                heap_contents(&reference, layer),
+                "layer {layer} heavy-hitter heap"
+            );
+        }
+        assert_eq!(
+            octo.calc_g_sum(|x| x, false),
+            reference.calc_g_sum(|x| x, false),
+            "g-sum query"
+        );
+    }
+
+    #[test]
+    fn promotion_conserves_every_layer_counter() {
+        let inputs = stream(30_000);
+        let threshold = 31u32;
+
+        let mut reference = UnivMon::init_univmon(HEAP, ROWS, COLS, LAYERS);
+        for input in &inputs {
+            reference.insert(input, 1);
+        }
+
+        let mut worker =
+            UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, OctoThreshold::new(threshold));
+        let mut aggregator = UnivMonOctoAggregator::new(HEAP, ROWS, COLS, LAYERS, threshold);
+        for input in &inputs {
+            let mut promoted = Vec::new();
+            worker.process(input, &mut |d| promoted.push(d));
+            for delta in promoted {
+                aggregator.apply(delta);
+            }
+        }
+
+        for layer in 0..LAYERS {
+            let promoted = layer_counters(&aggregator.sketch, layer);
+            let exact = layer_counters(&reference, layer);
+            let residual = worker.layers[layer].residual();
+            for (cell, ((&p, &e), &r)) in
+                promoted.iter().zip(exact.iter()).zip(residual).enumerate()
+            {
+                assert_eq!(
+                    p + r as i64,
+                    e,
+                    "layer {layer} cell {cell}: promoted {p} plus residual {r} != {e}"
+                );
+                assert!(
+                    r.unsigned_abs() < threshold as u8,
+                    "layer {layer} cell {cell}: residual {r} should have been promoted"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn completeness_is_withdrawn_exactly_where_the_layer_thresholds() {
+        let base = 8u32;
+        let inputs = stream(5_000);
+        let mut worker =
+            UnivMonOctoWorker::with_threshold(0, ROWS, COLS, LAYERS, OctoThreshold::new(base));
+        let mut aggregator = UnivMonOctoAggregator::new(HEAP, ROWS, COLS, LAYERS, base);
+        for input in &inputs {
+            let mut promoted = Vec::new();
+            worker.process(input, &mut |d| promoted.push(d));
+            for delta in promoted {
+                aggregator.apply(delta);
+            }
+        }
+
+        for (layer, complete) in aggregator.sketch.candidates_complete().iter().enumerate() {
+            if univmon_layer_threshold(base, layer) > 1 {
+                // The aggregator provably never saw the keys that stayed under
+                // this layer's threshold.
+                assert!(
+                    !complete,
+                    "layer {layer} thresholds at {} yet claims completeness",
+                    univmon_layer_threshold(base, layer)
+                );
+            }
+        }
+        // The rule has to actually bite somewhere, or the test proves nothing.
+        assert!(
+            (0..LAYERS).any(|layer| univmon_layer_threshold(base, layer) > 1),
+            "pick a base threshold that thresholds at least one layer"
+        );
+    }
+
+    #[test]
+    fn the_layer_threshold_tracks_how_little_traffic_a_deep_layer_sees() {
+        // Layer L receives roughly n / 2^L of the stream, so its threshold
+        // halves with it and bottoms out at 1.
+        assert_eq!(univmon_layer_threshold(32, 0), 32);
+        assert_eq!(univmon_layer_threshold(32, 1), 16);
+        assert_eq!(univmon_layer_threshold(32, 5), 1);
+        assert_eq!(univmon_layer_threshold(32, 40), 1, "no shift overflow");
+        assert_eq!(univmon_layer_threshold(1, 0), 1);
+    }
+
+    #[test]
+    fn the_worker_holds_one_byte_per_counter_and_no_keys() {
+        let worker = UnivMonOctoWorker::new(0, ROWS, COLS, LAYERS);
+        assert_eq!(worker.counter_bytes(), ROWS * COLS * LAYERS);
+        // A UnivMon layer stores i64 counters plus a heap of owned keys.
+        let parent_counter_bytes = ROWS * COLS * LAYERS * std::mem::size_of::<i64>();
+        assert_eq!(worker.counter_bytes() * 8, parent_counter_bytes);
     }
 }

--- a/src/sketch_framework/octo.rs
+++ b/src/sketch_framework/octo.rs
@@ -90,13 +90,14 @@ pub trait OctoWorker: Send {
     /// Promote everything still held back, so the aggregator can be queried
     /// against the whole stream so far.
     ///
-    /// A worker holds any counter that has not reached τ. For Count-Min and
-    /// Count that only makes the parent low by under τ per cell, but for a
-    /// bucket histogram or a max-register sketch an un-promoted cell is
-    /// *absent* from the parent rather than merely lagging, which is a
-    /// different kind of wrong. Flushing costs one message per non-empty cell -
-    /// as much as shipping the sketch - so it belongs at the point a stream is
-    /// handed over for querying, not on a timer.
+    /// A worker holds any counter that has not reached τ, and every worker
+    /// holds its own, so a shared cell trails by up to `workers · (τ - 1)`.
+    /// For Count-Min and Count that is only a low counter, but for a bucket
+    /// histogram or a max-register sketch an un-promoted cell is *absent* from
+    /// the parent rather than lagging, which is a different kind of wrong.
+    /// Flushing costs one message per non-empty cell - as much as shipping the
+    /// sketch - so it belongs at the point a stream is handed over for
+    /// querying, not on a timer.
     ///
     /// The default does nothing, for workers that hold nothing back.
     fn flush<F>(&mut self, emit: &mut F)
@@ -207,7 +208,12 @@ impl CmWorkerSketch {
         threshold: u32,
         emit: &mut impl FnMut(CmDelta),
     ) {
-        debug_assert_eq!(hashes.len(), self.rows, "one hash per row");
+        assert_eq!(
+            hashes.len(),
+            self.rows,
+            "one hash per row; a plan built for a different geometry would \
+             leave the untouched rows at zero and every estimate at zero"
+        );
         let threshold = threshold.clamp(1, MAX_PROMASK) as u8;
         for (r, hashed) in hashes.iter().copied().enumerate() {
             let col = ((hashed & LOWER_32_MASK) as usize) % self.cols;
@@ -321,7 +327,12 @@ impl CountWorkerSketch {
         threshold: u32,
         emit: &mut impl FnMut(CountDelta),
     ) {
-        debug_assert_eq!(hashes.len(), self.rows, "one hash per row");
+        assert_eq!(
+            hashes.len(),
+            self.rows,
+            "one hash per row; a plan built for a different geometry would \
+             leave the untouched rows at zero and every estimate at zero"
+        );
         let threshold = threshold.clamp(1, MAX_PROMASK) as i8;
         for (r, hashed) in hashes.iter().copied().enumerate() {
             let col = ((hashed & LOWER_32_MASK) as usize) % self.cols;
@@ -996,6 +1007,10 @@ where
             tx.send(WorkerMsg::Flush(ack_tx.clone()))
                 .expect("worker receiver dropped while runtime is active");
         }
+        // Drop the local sender, or `recv` can never report `Disconnected` and a
+        // worker that dies mid-flush - the aggregator panicking behind it, say -
+        // leaves this waiting forever instead of failing.
+        drop(ack_tx);
         for _ in 0..core.worker_input_txs.len() {
             ack_rx.recv().expect("worker dropped during flush");
         }
@@ -1178,11 +1193,16 @@ impl OctoWorker for CmTopKOctoWorker {
     }
 
     // No flush: every delta carries the key that produced it, and a worker
-    // keeps no key storage - that is the point of Idea 3. A residual cell
-    // cannot be attributed back to a key, so it stays where it is. The parent's
-    // counters are low by under tau per cell, which is the same bound the
-    // unkeyed workers carry between flushes, and the heavy-hitter heap does not
-    // depend on the residue.
+    // keeps no key storage - that is the point of Idea 3 - so a residual cell
+    // cannot be attributed back to a key and has to stay where it is.
+    //
+    // The consequence is not just a low counter. The aggregator only ever
+    // learns a key exists from a delta, so under HashByKey a key is invisible
+    // to it until that key occurs tau times on its worker. Below that the
+    // heap does not contain it at all, and its estimate is zero - see
+    // `a_key_below_the_threshold_never_reaches_the_topk_aggregator`. Size tau
+    // well under the frequency you care about, or use the unkeyed pair and
+    // track keys yourself.
 }
 
 /// Count-Min parent that also maintains the only heavy-hitter heap in the
@@ -1326,12 +1346,8 @@ impl OctoWorker for CountTopKOctoWorker {
         );
     }
 
-    // No flush: every delta carries the key that produced it, and a worker
-    // keeps no key storage - that is the point of Idea 3. A residual cell
-    // cannot be attributed back to a key, so it stays where it is. The parent's
-    // counters are low by under tau per cell, which is the same bound the
-    // unkeyed workers carry between flushes, and the heavy-hitter heap does not
-    // depend on the residue.
+    // No flush, for the same reason as CmTopKOctoWorker: a key the aggregator
+    // has never been sent is absent from the heap, not merely undercounted.
 }
 
 /// Count-sketch parent holding the pipeline's only heavy-hitter heap.
@@ -2445,6 +2461,18 @@ mod worker_tests {
     }
 
     #[test]
+    #[should_panic(expected = "one hash per row")]
+    fn a_worker_refuses_hashes_built_for_a_different_geometry() {
+        // The hashes are a public entry point, so a plan/worker mismatch has to
+        // fail loudly. Silently using the rows it was given would leave the rest
+        // at zero, and Count-Min's min-over-rows estimate is then zero for
+        // every key.
+        let mut worker = CmWorkerSketch::new(4, 16);
+        let hashes = CmWorkerSketch::hashes(2, &DataInput::U64(1));
+        worker.insert_hashes_emit_delta(&hashes, CM_PROMASK, &mut |_| {});
+    }
+
+    #[test]
     fn threshold_for_error_follows_equation_four() {
         // tau = eps * L1 / k'
         assert_eq!(threshold_for_error(0.0004, 1_000_000.0, 4), 100);
@@ -2878,6 +2906,49 @@ mod runtime_tests {
     }
 
     #[test]
+    fn a_key_below_the_threshold_never_reaches_the_topk_aggregator() {
+        // The keyed workers keep no key storage and so cannot flush, and the
+        // aggregator only learns a key exists from a delta. Under HashByKey a
+        // key lands on one worker, so it becomes visible exactly when it occurs
+        // tau times. This is the boundary, in both directions.
+        let (rows, cols, top_k) = (3usize, 1024usize, 32usize);
+        let tau = CM_PROMASK;
+        let run = |occurrences: u32| {
+            let mut inputs: Vec<DataInput<'_>> = Vec::new();
+            for key in 0..20u64 {
+                for _ in 0..occurrences {
+                    inputs.push(DataInput::U64(key));
+                }
+            }
+            run_octo(&inputs, &config(4), CmTopKOctoPlan::new(rows, cols), || {
+                CmTopKOctoAggregator::new(rows, cols, top_k)
+            })
+            .parent
+            .sketch
+        };
+
+        let below = run(tau - 1);
+        assert_eq!(
+            below.heap().len(),
+            0,
+            "a key that never reaches tau is absent from the heap entirely"
+        );
+        assert_eq!(
+            below.estimate(&DataInput::U64(0)),
+            0,
+            "and its counter never left the worker"
+        );
+
+        let at = run(tau);
+        assert_eq!(
+            at.heap().len(),
+            20,
+            "one more occurrence per key makes every one of them a candidate"
+        );
+        assert!(at.estimate(&DataInput::U64(0)) >= tau as i32);
+    }
+
+    #[test]
     fn the_count_topk_aggregator_also_tracks_heavy_hitters() {
         let (rows, cols, top_k) = (5usize, 2048usize, 8usize);
         let mut inputs: Vec<DataInput<'_>> = Vec::new();
@@ -3108,6 +3179,52 @@ mod runtime_tests {
             runtime.finish().parent.sketch.get_count(),
             values.len() as u64
         );
+    }
+
+    struct PanicOnFlushWorker;
+
+    impl OctoWorker for PanicOnFlushWorker {
+        type Delta = u64;
+        type Payload = ();
+
+        fn process<F>(&mut self, _payload: &(), emit: &mut F)
+        where
+            F: FnMut(Self::Delta),
+        {
+            emit(1);
+        }
+
+        fn flush<F>(&mut self, _emit: &mut F)
+        where
+            F: FnMut(Self::Delta),
+        {
+            panic!("worker died during flush");
+        }
+    }
+
+    struct PanicOnFlushPlan;
+
+    impl OctoPlan for PanicOnFlushPlan {
+        type Worker = PanicOnFlushWorker;
+
+        fn worker(&self, _worker_id: usize) -> Self::Worker {
+            PanicOnFlushWorker
+        }
+
+        fn prepare(&self, _input: &DataInput<'_>) {}
+    }
+
+    #[test]
+    #[should_panic(expected = "worker dropped during flush")]
+    fn a_worker_that_dies_mid_flush_fails_the_flush_rather_than_hanging_it() {
+        // The acknowledgement channel has to observe every sender going away,
+        // which means the caller's own copy must be dropped first. Otherwise
+        // this waits forever instead of reporting.
+        let mut runtime = OctoRuntime::new(&config(2), PanicOnFlushPlan, || CountingAggregator {
+            total: 0,
+        });
+        runtime.insert(DataInput::U64(1));
+        runtime.flush();
     }
 
     #[test]

--- a/src/sketch_framework/univmon.rs
+++ b/src/sketch_framework/univmon.rs
@@ -193,8 +193,17 @@ impl UnivMon {
     /// Overwrites the total weight the sketch believes it has seen.
     ///
     /// An OctoSketch aggregator never observes the raw stream, so it restores
-    /// this from the running totals its workers report.
+    /// this from the running totals its workers report. This *assigns* where
+    /// `insert` and `merge` accumulate, so a sketch fed by deltas must not also
+    /// be inserted into or merged with: the next delta would erase whatever
+    /// those added. Feeding one exclusively through `apply_layered_delta` and
+    /// this method is the supported arrangement.
     pub fn set_total_weight(&mut self, weight: usize) {
+        debug_assert_ne!(
+            self.update_mode,
+            UnivMonUpdateMode::Terminal,
+            "a terminal-mode UnivMon cannot be fed by the delta path"
+        );
         self.bucket_size = weight;
         if self.update_mode == UnivMonUpdateMode::Unset {
             self.update_mode = UnivMonUpdateMode::Standard;

--- a/src/sketch_framework/univmon.rs
+++ b/src/sketch_framework/univmon.rs
@@ -29,6 +29,7 @@ use crate::common::{
     heap_item_to_sketch_input,
 };
 use crate::common::{L2HH, Vector1D};
+use crate::octo_delta::LayeredCountDelta;
 use crate::sketches::countsketch_topk::CountL2HH;
 use rmp_serde::{
     decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice, to_vec_named,
@@ -83,6 +84,28 @@ impl Default for UnivMon {
     }
 }
 
+/// Deepest pyramid layer the given key hash reaches.
+#[inline(always)]
+pub fn bottom_layer_for_hash(hash: u64, layer_size: usize) -> usize {
+    for l in 1..layer_size {
+        if ((hash >> l) & 1) == 0 {
+            return l - 1;
+        }
+    }
+    layer_size - 1
+}
+
+/// How much of the stream reached an aggregator being fed `LayeredCountDelta`s.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnivMonDeltaFidelity {
+    /// Every insert was promoted, so candidate sets can still be complete.
+    /// Only true at a promotion threshold of 1.
+    EveryInsert,
+    /// Only counters that crossed the threshold arrived; candidate sets are
+    /// partial by construction.
+    PromotedOnly,
+}
+
 impl UnivMon {
     /// Creates a UnivMon instance with explicit dimensions.
     pub fn init_univmon(
@@ -134,12 +157,84 @@ impl UnivMon {
 
     #[inline(always)]
     fn find_bottom_layer_num(&self, hash: u64, layer: usize) -> usize {
-        for l in 1..layer {
-            if ((hash >> l) & 1) == 0 {
-                return l - 1;
-            }
+        bottom_layer_for_hash(hash, layer)
+    }
+
+    /// Deepest pyramid layer an insert of `key` reaches; it touches `0..=this`.
+    ///
+    /// A pure function of the key's hash, so an OctoSketch worker picks exactly
+    /// the same layers as a single-threaded insert would.
+    pub fn bottom_layer_for(&self, key: &DataInput) -> usize {
+        bottom_layer_for_hash(hash64_seeded(BOTTOM_LAYER_FINDER, key), self.layer_size)
+    }
+
+    /// Whether each layer's heavy-hitter heap still holds every key that layer
+    /// received. Queries widen their threshold on the layers where it does not.
+    pub fn candidates_complete(&self) -> &[bool] {
+        &self.candidate_complete
+    }
+
+    /// Marks every layer's candidate set as partial.
+    ///
+    /// An OctoSketch aggregator calls this up front whenever its workers
+    /// promote above a threshold of 1: a layer that received traffic but never
+    /// promoted any of it sends the aggregator nothing at all, so waiting for a
+    /// delta to arrive before lowering the flag would leave exactly those
+    /// layers claiming a completeness they cannot have.
+    pub fn mark_candidates_incomplete(&mut self) {
+        self.candidate_complete.fill(false);
+    }
+
+    /// Marks one layer's candidate set as partial.
+    pub fn mark_layer_candidates_incomplete(&mut self, layer: usize) {
+        self.candidate_complete[layer] = false;
+    }
+
+    /// Overwrites the total weight the sketch believes it has seen.
+    ///
+    /// An OctoSketch aggregator never observes the raw stream, so it restores
+    /// this from the running totals its workers report.
+    pub fn set_total_weight(&mut self, weight: usize) {
+        self.bucket_size = weight;
+        if self.update_mode == UnivMonUpdateMode::Unset {
+            self.update_mode = UnivMonUpdateMode::Standard;
         }
-        layer - 1
+    }
+
+    /// Applies one delta promoted by an OctoSketch worker.
+    ///
+    /// Mirrors `update` for a single layer: the counter lands, the layer's
+    /// estimate is re-read, and the layer's heavy-hitter heap follows - which
+    /// is Algorithm 2 of the OctoSketch paper.
+    pub fn apply_layered_delta(
+        &mut self,
+        delta: &LayeredCountDelta,
+        fidelity: UnivMonDeltaFidelity,
+    ) {
+        if self.update_mode == UnivMonUpdateMode::Unset {
+            self.update_mode = UnivMonUpdateMode::Standard;
+        }
+        let layer = delta.layer as usize;
+        assert!(
+            layer < self.layer_size,
+            "delta names layer {layer} but this pyramid has {} layers",
+            self.layer_size
+        );
+
+        self.l2_sketch_layers[layer].apply_delta(delta.delta);
+        let key = heap_item_to_sketch_input(&delta.key);
+        let count = self.l2_sketch_layers[layer].estimate(&key);
+        let heap_kept_everything = self.hh_layers[layer].update(&key, count as i64);
+
+        // A worker holds back every counter that has not reached the promotion
+        // threshold, so unless the threshold is 1 the aggregator has provably
+        // not seen every key this layer received and its candidate set cannot
+        // be called complete. Claiming otherwise would send `heavy_threshold`
+        // down the permissive branch and overcount.
+        let complete = heap_kept_everything && fidelity == UnivMonDeltaFidelity::EveryInsert;
+        if !complete {
+            self.candidate_complete[layer] = false;
+        }
     }
 
     #[inline(always)]
@@ -808,94 +903,6 @@ mod tests {
         assert_eq!(um.calc_l1(), 131.0, "L1 estimation incorrect");
     }
 
-    // #[test]
-    // fn univmon_different_seeds_maintain_accuracy() {
-    //     // Verify that using different seed indices doesn't break basic accuracy
-    //     // Create two UnivMons with same config but verify both maintain accuracy
-
-    //     let mut um1 = UnivMon::new_univmon_pyramid(20, 3, 2048, 10, 0);
-    //     let mut um2 = UnivMon::new_univmon_pyramid(20, 3, 2048, 10, 1); // Different pool_idx
-
-    //     // Insert same data into both with more flows for better stability
-    //     let flows = [
-    //         ("flow_a", 150),
-    //         ("flow_b", 200),
-    //         ("flow_c", 100),
-    //         ("flow_d", 180),
-    //         ("flow_e", 120),
-    //     ];
-
-    //     let true_l1 = 750f64;
-
-    //     for (key, count) in &flows {
-    //         let bottom1 = bottom_layer_for(&um1, key);
-    //         let bottom2 = bottom_layer_for(&um2, key);
-    //         um1.univmon_processing(key, *count, bottom1);
-    //         um2.univmon_processing(key, *count, bottom2);
-    //     }
-
-    //     // Both should estimate L1 with reasonable accuracy
-    //     let est_l1_1 = um1.calc_l1();
-    //     let est_l1_2 = um2.calc_l1();
-
-    //     let error_1 = ((est_l1_1 - true_l1).abs()) / true_l1;
-    //     let error_2 = ((est_l1_2 - true_l1).abs()) / true_l1;
-
-    //     assert!(
-    //         est_l1_1 == true_l1,
-    //         "UnivMon 1 L1 estimate {} should be reasonably accurate (error: {:.2}%)",
-    //         est_l1_1,
-    //         error_1 * 100.0
-    //     );
-    //     assert!(
-    //         est_l1_1 == true_l1,
-    //         "UnivMon 2 L1 estimate {} should be reasonably accurate (error: {:.2}%)",
-    //         est_l1_2,
-    //         error_2 * 100.0
-    //     );
-    // }
-
-    // #[test]
-    // fn test_layer_update_correctness() {
-    //     // 1. Initialize UnivMon with enough layers
-    //     let layers = 8;
-    //     // Small dimensions to make debugging easier, but enough to avoid collisions in this simple test
-    //     let mut um = UnivMon::init_univmon(10, 5, 128, layers, 0);
-
-    //     let key = "test_key_layer_logic";
-    //     let value = 10;
-
-    //     // 2. Pre-calculate the expected bottom layer for this key
-    //     // We use the same hasher the struct uses internally
-    //     let hash = hash64_seeded(BOTTOM_LAYER_FINDER, &DataInput::Str(key));
-    //     let expected_bottom = um.find_bottom_layer_num(hash, layers);
-
-    //     // 3. Perform Update
-    //     um.univmon_processing(key, value, expected_bottom);
-
-    //     // 4. Verification Loop
-    //     for i in 0..layers {
-    //         // Check Heap Presence
-    //         let in_heap = um.hh_layers[i].find(key).is_some();
-
-    //         // Check Sketch Estimate
-    //         // We use estimate() to see if the counter was incremented
-    //         let count_est = um.cs_layers[i].get_estimate(&DataInput::Str(key));
-
-    //         if i <= expected_bottom {
-    //             // Case A: Layers the item SHOULD exist in
-    //             assert!(in_heap, "Key should be in heap for layer {}", i);
-    //             assert_eq!(count_est, value, "Sketch at layer {} should track count", i);
-    //         } else {
-    //             // Case B: Layers the item should NOT exist in (it was sampled out)
-    //             assert!(!in_heap, "Key should NOT be in heap for layer {}", i);
-    //             // Ideally 0, but technically collisions could occur.
-    //             // With 'value=10' and empty sketch, it should be 0.
-    //             assert_eq!(count_est, 0, "Sketch at layer {} should be empty", i);
-    //         }
-    //     }
-    // }
-
     #[test]
     fn test_statistical_accuracy() {
         // 1. Setup: Larger sketch for statistical significance
@@ -1017,307 +1024,3 @@ mod tests {
         }
     }
 }
-
-// following out-dated code contains pyramid optimization that is potentially useful
-// #[derive(Serialize, Deserialize, Clone, Debug)]
-// pub struct UnivMon {
-//     pub k: usize,
-//     pub row: usize,
-//     pub col: usize,
-//     pub layer: usize,
-//     pub cs_layers: Vector1D<L2HH>,
-//     pub hh_layers: Vector1D<HHHeap>,
-//     pub pool_idx: i64,
-//     pub heap_update: i32,
-//     pub bucket_size: usize,
-// }
-//
-// impl UnivMon {
-//     pub fn init_univmon(k: usize, r: usize, c: usize, l: usize, p_idx: i64) -> Self {
-//         // Create cs_layers - each layer needs different seeds
-//         // Layer i uses SEEDLIST[i] for hashing
-//         let cs_vec: Vec<L2HH> = (0..l)
-//             .map(|i| L2HH::COUNT(CountL2HH::with_dimensions_and_seed(r, c, i)))
-//             .collect();
-//         // Create hh_layers
-//         let hh_vec: Vec<HHHeap> = (0..l).map(|_| HHHeap::new(k)).collect();
-//
-//         UnivMon {
-//             k,
-//             row: r,
-//             col: c,
-//             layer: l,
-//             cs_layers: Vector1D::from_vec(cs_vec),
-//             hh_layers: Vector1D::from_vec(hh_vec),
-//             pool_idx: p_idx,
-//             heap_update: 0,
-//             bucket_size: 0,
-//         }
-//     }
-//
-//     pub fn get_bucket_size(&self) -> usize {
-//         self.bucket_size
-//     }
-//
-//     pub fn new_univmon_pyramid(k: usize, r: usize, c: usize, l: usize, p_idx: i64) -> Self {
-//         // 8 is ELEPHANT_LAYER in PromSketch
-//         // Each layer i uses SEEDLIST[i] for hashing
-//         let cs_vec: Vec<L2HH> = if l <= 8 {
-//             (0..l)
-//                 .map(|i| L2HH::COUNT(CountL2HH::with_dimensions_and_seed(3, 2048, i)))
-//                 .collect()
-//         } else {
-//             (0..8)
-//                 .map(|i| L2HH::COUNT(CountL2HH::with_dimensions_and_seed(3, 2048, i)))
-//                 .chain((8..l).map(|i| L2HH::COUNT(CountL2HH::with_dimensions_and_seed(3, 512, i))))
-//                 .collect()
-//         };
-//
-//         let hh_vec: Vec<HHHeap> = if l <= 8 {
-//             (0..l).map(|_| HHHeap::new(k)).collect()
-//         } else {
-//             (0..l).map(|_| HHHeap::new(100)).collect()
-//         };
-//
-//         UnivMon {
-//             k,
-//             row: r,
-//             col: c,
-//             layer: l,
-//             cs_layers: Vector1D::from_vec(cs_vec),
-//             hh_layers: Vector1D::from_vec(hh_vec),
-//             pool_idx: p_idx,
-//             heap_update: 0,
-//             bucket_size: 0,
-//         }
-//     }
-//
-//     // pub fn free(&mut self) {
-//     //     self.bucket_size = 0;
-//
-//     //     self.cs_layers.clear();
-//     //     self.hh_layers.clear();
-//     // }
-//
-//     // well... I'm not confident about this function
-//     // pub fn get_memory_kb(&self) -> f64 {
-//     //     let mut total = 0.0;
-//     //     for i in 0..self.layer {
-//     //         total += self.hh_layers[i].get_memory_bytes();
-//     //     }
-//     //     return (2048.0 * 3.0 * (self.layer as f64) * 8.0 + total) / 1024.0;
-//     // }
-//
-//     // pub fn get_memory_kb_pyramid(&self) -> f64 {
-//     //     let mut total = 0.0;
-//     //     for i in 0..self.layer {
-//     //         total += self.hh_layers[i].get_memory_bytes();
-//     //     }
-//     //     // again, hard code the ELEPHANT_LAYER for now
-//     //     if self.layer <= 8 {
-//     //         return (2048.0 * 3.0 * (self.layer as f64) * 8.0 + total) / 1024.0;
-//     //     } else {
-//     //         return ((2048.0 * 3.0 * 8.0 + 512.0 * 3.0 * (self.layer as f64 - 8.0)) * 8.0 + total)
-//     //             / 1024.0;
-//     //     }
-//     // }
-//
-//     // update univmon
-//     pub fn find_bottom_layer_num(&self, hash: u64, layer: usize) -> usize {
-//         for l in 1..layer {
-//             if ((hash >> l) & 1) == 0 {
-//                 return l - 1;
-//             }
-//         }
-//         layer - 1
-//     }
-//
-//     pub fn update(&mut self, key: &str, value: i64, bottom_layer_num: usize) {
-//         for i in 0..=bottom_layer_num {
-//             let count = if i == 0 {
-//                 self.cs_layers[i].update_and_est(&DataInput::Str(key), value)
-//             } else {
-//                 self.cs_layers[i].update_and_est_without_l2(&DataInput::Str(key), value)
-//             };
-//             self.hh_layers[i].update(key, count as i64);
-//         }
-//     }
-//
-//     pub fn update_optimized(&mut self, key: &str, value: i64, bottom_layer_num: usize) {
-//         // hardcode again
-//         if bottom_layer_num < 8 {
-//             if bottom_layer_num > 0 {
-//                 // let mut median = self.cs_layers[bottom_layer_num].update_and_est_without_l2(key, value);
-//                 let mut median = self.cs_layers[bottom_layer_num]
-//                     .update_and_est_without_l2(&DataInput::Str(key), value);
-//                 for l in (1..=bottom_layer_num).rev() {
-//                     self.hh_layers[l].update(key, median as i64);
-//                 }
-//                 // median = self.cs_layers[0].update_and_est(key, value);
-//                 median = self.cs_layers[0].update_and_est(&DataInput::Str(key), value);
-//                 self.hh_layers[0].update(key, median as i64);
-//             } else {
-//                 // let median = self.cs_layers[0].update_and_est(key, value);
-//                 let median = self.cs_layers[0].update_and_est(&DataInput::Str(key), value);
-//                 self.hh_layers[0].update(key, median as i64);
-//             }
-//         } else {
-//             // let mut median = self.cs_layers[bottom_layer_num].update_and_est_without_l2(key, value);
-//             let mut median = self.cs_layers[bottom_layer_num]
-//                 .update_and_est_without_l2(&DataInput::Str(key), value);
-//             for l in (1..=bottom_layer_num).rev() {
-//                 self.hh_layers[l].update(key, median as i64);
-//             }
-//             // median = self.cs_layers[0].update_and_est(key, value);
-//             median = self.cs_layers[0].update_and_est(&DataInput::Str(key), value);
-//             self.hh_layers[0].update(key, median as i64);
-//         }
-//     }
-//
-//     pub fn update_pyramid(&mut self, key: &str, value: i64, bottom_layer_num: usize) {
-//         // hardcode one more time
-//         if bottom_layer_num < 8 {
-//             for l in (0..=bottom_layer_num).rev() {
-//                 let median = if l == 0 {
-//                     self.cs_layers[l].update_and_est(&DataInput::Str(key), value)
-//                 } else {
-//                     self.cs_layers[l].update_and_est_without_l2(&DataInput::Str(key), value)
-//                 };
-//                 self.hh_layers[l].update(key, median as i64);
-//             }
-//         } else {
-//             let mut median;
-//             for l in (0..=7).rev() {
-//                 if l == 0 {
-//                     // median = self.cs_layers[l].update_and_est(key, value);
-//                     median = self.cs_layers[l].update_and_est(&DataInput::Str(key), value);
-//                 } else {
-//                     // median = self.cs_layers[l].update_and_est_without_l2(key, value);
-//                     median =
-//                         self.cs_layers[l].update_and_est_without_l2(&DataInput::Str(key), value);
-//                 }
-//                 self.hh_layers[l].update(key, median as i64);
-//             }
-//             for l in (8..=bottom_layer_num).rev() {
-//                 // median = self.cs_layers[l].update_and_est_without_l2(key, value);
-//                 median = self.cs_layers[l].update_and_est_without_l2(&DataInput::Str(key), value);
-//                 self.hh_layers[l].update(key, median as i64);
-//             }
-//         }
-//     }
-//
-//     pub fn univmon_processing(&mut self, key: &str, value: i64, bottom_layer_num: usize) {
-//         self.bucket_size += value as usize;
-//         self.update(key, value, bottom_layer_num);
-//     }
-//
-//     pub fn univmon_processing_optimized(&mut self, key: &str, value: i64, bottom_layer_num: usize) {
-//         self.bucket_size += value as usize;
-//         self.update_optimized(key, value, bottom_layer_num);
-//     }
-//
-//     // pub fn print_hh_layer(&self) {
-//     //     print!("Print HH_Layer: ");
-//     //     for i in 0..self.layer {
-//     //         println!("layer {}: ", i);
-//     //         self.hh_layers[i].print_heap();
-//     //     }
-//     // }
-//
-//     pub fn calc_g_sum_heuristic<F>(&self, g: F, is_card: bool) -> f64
-//     where
-//         F: Fn(f64) -> f64,
-//     {
-//         let mut y = vec![0.0; self.layer];
-//         let mut tmp: f64;
-//
-//         let l2_value = self.cs_layers[self.layer - 1].get_l2();
-//         let mut threshold = (l2_value * 0.01) as i64;
-//         if !is_card {
-//             threshold = 0;
-//         }
-//
-//         tmp = 0.0;
-//         for item in self.hh_layers[self.layer - 1].heap() {
-//             if item.count > threshold {
-//                 tmp += g(item.count as f64);
-//             }
-//         }
-//         y[self.layer - 1] = tmp;
-//
-//         for i in (0..(self.layer - 1)).rev() {
-//             tmp = 0.0;
-//             let l2_value = self.cs_layers[i].get_l2();
-//             let mut threshold = (l2_value * 0.01) as i64;
-//             if !is_card {
-//                 threshold = 0;
-//             }
-//
-//             for item in self.hh_layers[i].heap() {
-//                 if item.count > threshold {
-//                     // let hash = (hash64_seeded(CANONICAL_HASH_SEED, &item.key) >> (i+1)) & 1;
-//                     // let hash = (hash64_seeded(CANONICAL_HASH_SEED, &DataInput::Str(&item.key)) >> (i + 1)) & 1;
-//                     let hash =
-//                         (hash64_seeded(BOTTOM_LAYER_FINDER, &DataInput::Str(&item.key)) >> (i + 1)) & 1;
-//                     let coe = 1.0 - 2.0 * (hash as f64);
-//                     tmp += coe * g(item.count as f64);
-//                 }
-//             }
-//             y[i] = 2.0 * y[i + 1] + tmp;
-//         }
-//
-//         y[0]
-//     }
-//
-//     pub fn calc_g_sum<F>(&self, g: F, is_card: bool) -> f64
-//     where
-//         F: Fn(f64) -> f64,
-//     {
-//         self.calc_g_sum_heuristic(g, is_card)
-//     }
-//
-//     pub fn calc_l1(&self) -> f64 {
-//         self.calc_g_sum(|x| x, false)
-//     }
-//
-//     pub fn calc_l2(&self) -> f64 {
-//         let tmp = self.calc_g_sum(|x| x * x, false);
-//         tmp.sqrt()
-//     }
-//
-//     pub fn calc_entropy(&self) -> f64 {
-//         let tmp = self.calc_g_sum(
-//             |x| {
-//                 if x > 0.0 { x * x.log2() } else { 0.0 }
-//             },
-//             false,
-//         );
-//         (self.bucket_size as f64).log2() - tmp / (self.bucket_size as f64)
-//     }
-//
-//     pub fn calc_card(&self) -> f64 {
-//         self.calc_g_sum(|_| 1.0, true)
-//     }
-//
-//     pub fn merge_with(&mut self, other: &UnivMon) {
-//         for i in 0..self.layer {
-//             self.cs_layers[i].merge(&other.cs_layers[i]);
-//
-//             let mut topk = HHHeap::new(self.k);
-//             for item in self.hh_layers[i].heap() {
-//                 topk.update(&item.key, item.count);
-//             }
-//
-//             for item in other.hh_layers[i].heap() {
-//                 let count = if let Some(index) = topk.find(&item.key) {
-//                     topk.heap()[index].count + item.count
-//                 } else {
-//                     item.count
-//                 };
-//                 topk.update(&item.key, count);
-//             }
-//
-//             self.hh_layers[i] = topk;
-//         }
-//     }
-// }

--- a/src/sketches/countminsketch.rs
+++ b/src/sketches/countminsketch.rs
@@ -11,7 +11,8 @@
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
-use crate::octo_delta::{CM_PROMASK, CmDelta};
+use crate::input_to_owned;
+use crate::octo_delta::{CM_PROMASK, CmDelta, KeyedCmDelta, MAX_PROMASK};
 use crate::{
     DataInput, DefaultMatrixI32, DefaultMatrixI64, DefaultMatrixI128, DefaultXxHasher, FastPath,
     FastPathHasher, FixedMatrix, MatrixFastHash, MatrixStorage, NitroTarget, QuickMatrixI64,
@@ -331,9 +332,23 @@ where
 pub type CountMinF64<H = DefaultXxHasher> = CountMin<Vector2D<f64>, RegularPath, H>;
 
 impl<S: MatrixStorage<Counter = i32>, H: SketchHasher> CountMin<S, RegularPath, H> {
-    /// Inserts an observation and emits a delta when the counter crosses a threshold.
+    /// Inserts an observation, emitting a delta at every promotion of the
+    /// default threshold `CM_PROMASK`.
     #[inline(always)]
     pub fn insert_emit_delta(&mut self, value: &DataInput, emit: &mut impl FnMut(CmDelta)) {
+        self.insert_emit_delta_with_threshold(value, CM_PROMASK, emit);
+    }
+
+    /// Inserts an observation, emitting a delta and clearing the counter each
+    /// time a row counter reaches `threshold` (OctoSketch Algorithm 1).
+    #[inline(always)]
+    pub fn insert_emit_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(CmDelta),
+    ) {
+        let threshold = threshold.clamp(1, MAX_PROMASK) as i32;
         let rows = self.counts.rows();
         let cols = self.counts.cols();
         for r in 0..rows {
@@ -341,14 +356,32 @@ impl<S: MatrixStorage<Counter = i32>, H: SketchHasher> CountMin<S, RegularPath, 
             let col = ((hashed & LOWER_32_MASK) as usize) % cols;
             self.counts.increment_by_row(r, col, 1);
             let current = self.counts.query_one_counter(r, col);
-            if current % CM_PROMASK as i32 == 0 {
+            if current >= threshold {
                 emit(CmDelta {
-                    row: r as u16,
-                    col: col as u16,
-                    value: CM_PROMASK,
+                    row: r as u32,
+                    col: col as u32,
+                    value: current as u32,
                 });
+                self.counts.update_one_counter(r, col, |c, _| *c = 0, ());
             }
         }
+    }
+
+    /// As `insert_emit_delta_with_threshold`, but every delta carries the flow
+    /// key so an aggregator can maintain the heavy-hitter heap that workers
+    /// no longer keep.
+    pub fn insert_emit_keyed_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(KeyedCmDelta),
+    ) {
+        self.insert_emit_delta_with_threshold(value, threshold, &mut |delta| {
+            emit(KeyedCmDelta {
+                key: input_to_owned(value),
+                delta,
+            })
+        });
     }
 }
 
@@ -356,9 +389,22 @@ impl<S, H: SketchHasher> CountMin<S, FastPath, H>
 where
     S: MatrixStorage<Counter = i32> + FastPathHasher<H>,
 {
-    /// Inserts an observation via fast-path and emits a delta at threshold crossings.
+    /// Inserts an observation via fast-path, emitting a delta at every
+    /// promotion of the default threshold `CM_PROMASK`.
     #[inline(always)]
     pub fn insert_emit_delta(&mut self, value: &DataInput, emit: &mut impl FnMut(CmDelta)) {
+        self.insert_emit_delta_with_threshold(value, CM_PROMASK, emit);
+    }
+
+    /// Fast-path counterpart of the regular-path threshold API.
+    #[inline(always)]
+    pub fn insert_emit_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(CmDelta),
+    ) {
+        let threshold = threshold.clamp(1, MAX_PROMASK) as i32;
         let hashed_val = <S as FastPathHasher<H>>::hash_for_matrix(&self.counts, value);
         let rows = self.counts.rows();
         let cols = self.counts.cols();
@@ -366,14 +412,30 @@ where
             let col = hashed_val.col_for_row(r, cols);
             self.counts.increment_by_row(r, col, 1);
             let current = self.counts.query_one_counter(r, col);
-            if current % CM_PROMASK as i32 == 0 {
+            if current >= threshold {
                 emit(CmDelta {
-                    row: r as u16,
-                    col: col as u16,
-                    value: CM_PROMASK,
+                    row: r as u32,
+                    col: col as u32,
+                    value: current as u32,
                 });
+                self.counts.update_one_counter(r, col, |c, _| *c = 0, ());
             }
         }
+    }
+
+    /// Fast-path counterpart of `insert_emit_keyed_delta_with_threshold`.
+    pub fn insert_emit_keyed_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(KeyedCmDelta),
+    ) {
+        self.insert_emit_delta_with_threshold(value, threshold, &mut |delta| {
+            emit(KeyedCmDelta {
+                key: input_to_owned(value),
+                delta,
+            })
+        });
     }
 }
 

--- a/src/sketches/countsketch.rs
+++ b/src/sketches/countsketch.rs
@@ -548,12 +548,28 @@ impl<H: SketchHasher> NitroTarget for Count<Vector2D<i32>, FastPath, H> {
     }
 }
 
-use crate::octo_delta::{COUNT_PROMASK, CountDelta};
+use crate::input_to_owned;
+use crate::octo_delta::{COUNT_PROMASK, CountDelta, KeyedCountDelta, MAX_PROMASK};
 
 impl<S: MatrixStorage<Counter = i32>, H: SketchHasher> Count<S, RegularPath, H> {
-    /// Inserts a value and emits a delta when any counter exceeds the promotion threshold.
+    /// Inserts a value, emitting a delta at every promotion of the default
+    /// threshold `COUNT_PROMASK`.
     #[inline(always)]
     pub fn insert_emit_delta(&mut self, value: &DataInput, emit: &mut impl FnMut(CountDelta)) {
+        self.insert_emit_delta_with_threshold(value, COUNT_PROMASK, emit);
+    }
+
+    /// Inserts a value, emitting a delta and clearing the counter each time
+    /// `|counter|` reaches `threshold`. Count sketch counters are signed, so
+    /// the magnitude is what the threshold is applied to (§4.4).
+    #[inline(always)]
+    pub fn insert_emit_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(CountDelta),
+    ) {
+        let threshold = threshold.clamp(1, MAX_PROMASK);
         let rows = self.counts.rows();
         let cols = self.counts.cols();
         for r in 0..rows {
@@ -562,15 +578,31 @@ impl<S: MatrixStorage<Counter = i32>, H: SketchHasher> Count<S, RegularPath, H> 
             let sign: i32 = if ((hashed >> 63) & 1) == 1 { 1 } else { -1 };
             self.counts.increment_by_row(r, col, sign);
             let current = self.counts.query_one_counter(r, col);
-            if current.unsigned_abs() >= COUNT_PROMASK as u32 {
+            if current.unsigned_abs() >= threshold {
                 emit(CountDelta {
-                    row: r as u16,
-                    col: col as u16,
-                    value: current as i8,
+                    row: r as u32,
+                    col: col as u32,
+                    value: current,
                 });
                 self.counts.update_one_counter(r, col, |c, _| *c = 0, ());
             }
         }
+    }
+
+    /// As `insert_emit_delta_with_threshold`, but every delta carries the flow
+    /// key so an aggregator can maintain a heavy-hitter heap.
+    pub fn insert_emit_keyed_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(KeyedCountDelta),
+    ) {
+        self.insert_emit_delta_with_threshold(value, threshold, &mut |delta| {
+            emit(KeyedCountDelta {
+                key: input_to_owned(value),
+                delta,
+            })
+        });
     }
 }
 
@@ -578,9 +610,22 @@ impl<S, H: SketchHasher> Count<S, FastPath, H>
 where
     S: MatrixStorage<Counter = i32> + FastPathHasher<H>,
 {
-    /// Inserts a value using the fast path and emits a delta on counter overflow.
+    /// Inserts a value using the fast path, emitting a delta at every
+    /// promotion of the default threshold `COUNT_PROMASK`.
     #[inline(always)]
     pub fn insert_emit_delta(&mut self, value: &DataInput, emit: &mut impl FnMut(CountDelta)) {
+        self.insert_emit_delta_with_threshold(value, COUNT_PROMASK, emit);
+    }
+
+    /// Fast-path counterpart of the regular-path threshold API.
+    #[inline(always)]
+    pub fn insert_emit_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(CountDelta),
+    ) {
+        let threshold = threshold.clamp(1, MAX_PROMASK);
         let hashed_val = <S as FastPathHasher<H>>::hash_for_matrix(&self.counts, value);
         let rows = self.counts.rows();
         let cols = self.counts.cols();
@@ -589,15 +634,30 @@ where
             let sign = hashed_val.sign_for_row(r);
             self.counts.increment_by_row(r, col, sign);
             let current = self.counts.query_one_counter(r, col);
-            if current.unsigned_abs() >= COUNT_PROMASK as u32 {
+            if current.unsigned_abs() >= threshold {
                 emit(CountDelta {
-                    row: r as u16,
-                    col: col as u16,
-                    value: current as i8,
+                    row: r as u32,
+                    col: col as u32,
+                    value: current,
                 });
                 self.counts.update_one_counter(r, col, |c, _| *c = 0, ());
             }
         }
+    }
+
+    /// Fast-path counterpart of `insert_emit_keyed_delta_with_threshold`.
+    pub fn insert_emit_keyed_delta_with_threshold(
+        &mut self,
+        value: &DataInput,
+        threshold: u32,
+        emit: &mut impl FnMut(KeyedCountDelta),
+    ) {
+        self.insert_emit_delta_with_threshold(value, threshold, &mut |delta| {
+            emit(KeyedCountDelta {
+                key: input_to_owned(value),
+                delta,
+            })
+        });
     }
 }
 
@@ -610,7 +670,7 @@ where
         self.counts.increment_by_row(
             delta.row as usize,
             delta.col as usize,
-            S::Counter::from(delta.value as i32),
+            S::Counter::from(delta.value),
         );
     }
 }

--- a/src/sketches/countsketch_topk.rs
+++ b/src/sketches/countsketch_topk.rs
@@ -12,6 +12,7 @@ use rmp_serde::{
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
+use crate::octo_delta::CountDelta;
 use crate::sketches::countsketch::CountSketchCounter;
 use crate::{
     Count, DataInput, DefaultMatrixI32, DefaultMatrixI64, DefaultMatrixI128, DefaultXxHasher,
@@ -910,6 +911,24 @@ mod tests {
 // file stays focused on plain Count Sketch.
 // =====================================================================
 
+/// Column and sign `CountL2HH` uses for `row`, given its 128-bit key hash.
+///
+/// Shared with the OctoSketch worker sketches so a worker and its parent can
+/// never disagree about which cell a key lands in.
+#[inline(always)]
+pub fn l2hh_cell_for_row(
+    hashed_val: u128,
+    row: usize,
+    cols: usize,
+    mask_bits: u32,
+) -> (usize, i64) {
+    let mask = (1u128 << mask_bits) - 1;
+    let hashed = (hashed_val >> (row * mask_bits as usize)) & mask;
+    let col = (hashed as usize) % cols;
+    let bit = ((hashed_val >> (127 - row)) & 1) as i64;
+    (col, -(1 - 2 * bit))
+}
+
 /// Count Sketch augmented with per-row L2 norm tracking for heavy-hitter detection.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "")]
@@ -1009,33 +1028,48 @@ impl<H: SketchHasher> CountL2HH<H> {
 
     /// Inserts with hash optimization using precomputed hash value.
     pub fn fast_insert_with_count_and_hash(&mut self, hashed_val: u128, c: i64) {
-        let mask_bits = self.counts.get_mask_bits() as usize;
-        let mask = (1u128 << mask_bits) - 1;
-        let mut shift_amount = 0;
-        let mut sign_bit_pos = 127;
-
+        let mask_bits = self.counts.get_mask_bits();
         for i in 0..self.row {
-            let hashed = (hashed_val >> shift_amount) & mask;
-            let idx = (hashed as usize) % self.col;
-            let bit = ((hashed_val >> sign_bit_pos) & 1) as i64;
-            let sign_bit = -(1 - 2 * bit);
-
+            let (idx, sign_bit) = l2hh_cell_for_row(hashed_val, i, self.col, mask_bits);
             let old_value = self.counts.query_one_counter(i, idx);
-            let new_value = old_value + sign_bit * c;
-            self.counts[i][idx] = new_value;
-
-            // Saturating i128 intermediate so extreme counts degrade
-            // gracefully instead of wrapping (matches merge-path semantics,
-            // which also clamps to [0, i64::MAX]: L2^2 can never go negative,
-            // even when a decrement follows prior saturation).
-            let old_l2 = self.l2.as_slice()[i] as i128;
-            let new_l2 = old_l2 + (new_value as i128) * (new_value as i128)
-                - (old_value as i128) * (old_value as i128);
-            self.l2[i] = new_l2.clamp(0, i64::MAX as i128) as i64;
-
-            shift_amount += mask_bits;
-            sign_bit_pos -= 1;
+            self.write_counter(i, idx, old_value + sign_bit * c);
         }
+    }
+
+    /// Writes one counter and carries the row's L2 accumulator with it.
+    ///
+    /// Saturating i128 intermediate so extreme counts degrade gracefully
+    /// instead of wrapping (matches merge-path semantics, which also clamps to
+    /// [0, i64::MAX]: L2^2 can never go negative, even when a decrement follows
+    /// prior saturation).
+    #[inline(always)]
+    fn write_counter(&mut self, row: usize, col: usize, new_value: i64) {
+        let old_value = self.counts.query_one_counter(row, col);
+        self.counts[row][col] = new_value;
+        let old_l2 = self.l2.as_slice()[row] as i128;
+        let new_l2 = old_l2 + (new_value as i128) * (new_value as i128)
+            - (old_value as i128) * (old_value as i128);
+        self.l2[row] = new_l2.clamp(0, i64::MAX as i128) as i64;
+    }
+
+    /// Seed offset this sketch hashes with; UnivMon gives each layer its own.
+    pub fn seed_idx(&self) -> usize {
+        self.seed_idx
+    }
+
+    /// Column-mask width used to slice the 128-bit hash into per-row indices.
+    pub fn mask_bits(&self) -> u32 {
+        self.counts.get_mask_bits()
+    }
+
+    /// Applies a counter delta promoted by an OctoSketch worker.
+    ///
+    /// The row's L2 accumulator is carried along exactly, so a parent fed only
+    /// deltas reports the same `get_l2` as one fed the raw stream.
+    pub fn apply_delta(&mut self, delta: CountDelta) {
+        let (row, col) = (delta.row as usize, delta.col as usize);
+        let new_value = self.counts.query_one_counter(row, col) + delta.value as i64;
+        self.write_counter(row, col, new_value);
     }
 
     /// Inserts without L2 update using precomputed hash value.

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -292,6 +292,17 @@ impl DDSketch {
         if delta.value == 0 {
             return;
         }
+        // `merge` checks that the two sketches share an alpha; a delta carries
+        // no alpha to check, so bound the index by what this sketch's own
+        // mapping can produce. A worker built with a much finer alpha would
+        // otherwise hand over an index near i32::MAX and grow the dense store
+        // across the whole gap. Out-of-range values are dropped, which is what
+        // `add` already does with values it cannot index.
+        let (min_indexable, max_indexable) = ddsketch_indexable_bounds(self.alpha);
+        let (lowest, highest) = (self.key_for(min_indexable), self.key_for(max_indexable));
+        if delta.index < lowest || delta.index > highest {
+            return;
+        }
         self.store.ensure(delta.index);
         let slot = (delta.index - self.store.offset) as usize;
         self.store.counts.as_mut_slice()[slot] += delta.value;

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -19,6 +19,7 @@ use crate::DataInput;
 use crate::common::input::data_input_to_f64;
 use crate::common::numerical::NumericalValue;
 use crate::common::structures::Vector1D;
+use crate::octo_delta::DdDelta;
 use rmp_serde::decode::Error as RmpDecodeError;
 use rmp_serde::encode::Error as RmpEncodeError;
 use rmp_serde::{from_slice, to_vec_named};
@@ -264,6 +265,46 @@ impl DDSketch {
 
         let k = self.key_for(v);
         self.store.add_one(k);
+    }
+
+    /// Bucket index a value maps to, or `None` if `add` would have dropped it.
+    ///
+    /// Exposed so an OctoSketch worker can hold one-byte counters over the same
+    /// bucket space without duplicating the logarithmic mapping.
+    pub fn bucket_index_for(&self, value: f64) -> Option<i32> {
+        if !(value.is_finite() && value > 0.0) {
+            return None;
+        }
+        let (min_indexable, max_indexable) = ddsketch_indexable_bounds(self.alpha);
+        if value < min_indexable || value > max_indexable {
+            return None;
+        }
+        Some(self.key_for(value))
+    }
+
+    /// Adds a promoted bucket count from an OctoSketch worker.
+    ///
+    /// A delta carries only a bucket and a count, so `sum`, `min` and `max` are
+    /// advanced with the bucket's representative value - the same α-bounded
+    /// estimate a deserialize-and-recompute produces. Quantiles and `count`
+    /// stay exact with respect to the bucket store.
+    pub fn apply_delta(&mut self, delta: DdDelta) {
+        if delta.value == 0 {
+            return;
+        }
+        self.store.ensure(delta.index);
+        let slot = (delta.index - self.store.offset) as usize;
+        self.store.counts.as_mut_slice()[slot] += delta.value;
+
+        let representative = self.bin_representative(delta.index);
+        self.count += delta.value;
+        self.sum += representative * delta.value as f64;
+        if representative < self.min {
+            self.min = representative;
+        }
+        if representative > self.max {
+            self.max = representative;
+        }
     }
 
     /// Returns the estimated value at quantile `q` (in `[0, 1]`), or `None` if the sketch is empty.

--- a/src/sketches/hll.rs
+++ b/src/sketches/hll.rs
@@ -380,6 +380,7 @@ impl<Registers: HllRegisterStorage> HyperLogLogHIPImpl<Registers> {
 }
 
 use crate::octo_delta::{HLL_PROMASK, HllDelta};
+use crate::sketch_framework::octo::max_hll_threshold;
 
 impl<Variant, Registers: HllRegisterStorage, H: SketchHasher>
     HyperLogLogImpl<Variant, Registers, H>
@@ -410,6 +411,11 @@ impl<Variant, Registers: HllRegisterStorage, H: SketchHasher>
         threshold: u8,
         emit: &mut impl FnMut(HllDelta),
     ) {
+        // A register holds a leading-zero count of at most `64 - PRECISION + 1`,
+        // so the gain `2^C' - 2^C` never reaches `2^(64 - PRECISION)`. Above
+        // that a threshold is unsatisfiable and the parent would stay empty
+        // rather than merely lag, so cap it at the largest one that can fire.
+        let threshold = threshold.min(max_hll_threshold(Registers::PRECISION as u8));
         let bucket_num = ((hashed_val >> Registers::REGISTER_BITS) & Registers::P_MASK) as usize;
         let leading_zero =
             ((hashed_val << Registers::PRECISION) + Registers::P_MASK).leading_zeros() as u8 + 1;

--- a/src/sketches/hll.rs
+++ b/src/sketches/hll.rs
@@ -379,36 +379,72 @@ impl<Registers: HllRegisterStorage> HyperLogLogHIPImpl<Registers> {
     }
 }
 
-use crate::octo_delta::HllDelta;
+use crate::octo_delta::{HLL_PROMASK, HllDelta};
 
 impl<Variant, Registers: HllRegisterStorage, H: SketchHasher>
     HyperLogLogImpl<Variant, Registers, H>
 {
     #[inline(always)]
-    /// Inserts a hashed value and emits a delta when a register increases.
+    /// Inserts a hashed value, promoting register improvements at the default
+    /// threshold `HLL_PROMASK`.
     pub fn insert_emit_delta_with_hash(
         &mut self,
         hashed_val: u64,
+        emit: &mut impl FnMut(HllDelta),
+    ) {
+        self.insert_emit_delta_with_hash_and_threshold(hashed_val, HLL_PROMASK, emit);
+    }
+
+    #[inline(always)]
+    /// Inserts a hashed value and promotes the register when the improvement is
+    /// large enough.
+    ///
+    /// Cardinality sketches merge by `max`, so a worker never clears a
+    /// register; it promotes one only when `|2^C' - 2^C| >= 2^threshold`, the
+    /// rule the paper gives for HyperLogLog (§4.4). A threshold of 0 promotes
+    /// every improvement and makes the aggregator exactly equal to a
+    /// single-threaded sketch.
+    pub fn insert_emit_delta_with_hash_and_threshold(
+        &mut self,
+        hashed_val: u64,
+        threshold: u8,
         emit: &mut impl FnMut(HllDelta),
     ) {
         let bucket_num = ((hashed_val >> Registers::REGISTER_BITS) & Registers::P_MASK) as usize;
         let leading_zero =
             ((hashed_val << Registers::PRECISION) + Registers::P_MASK).leading_zeros() as u8 + 1;
         let regs = self.registers.as_mut_slice();
-        if leading_zero > regs[bucket_num] {
+        let previous = regs[bucket_num];
+        if leading_zero > previous {
             regs[bucket_num] = leading_zero;
-            emit(HllDelta {
-                pos: bucket_num as u16,
-                value: leading_zero,
-            });
+            if pow2_saturating(leading_zero) - pow2_saturating(previous)
+                >= pow2_saturating(threshold)
+            {
+                emit(HllDelta {
+                    pos: bucket_num as u32,
+                    value: leading_zero,
+                });
+            }
         }
     }
 
     #[inline(always)]
-    /// Hashes an input, inserts it, and emits a delta when needed.
+    /// Hashes an input, inserts it, and emits a delta at the default threshold.
     pub fn insert_emit_delta(&mut self, obj: &DataInput, emit: &mut impl FnMut(HllDelta)) {
+        self.insert_emit_delta_with_threshold(obj, HLL_PROMASK, emit);
+    }
+
+    #[inline(always)]
+    /// Hashes an input, inserts it, and promotes the register when the
+    /// improvement clears `threshold`.
+    pub fn insert_emit_delta_with_threshold(
+        &mut self,
+        obj: &DataInput,
+        threshold: u8,
+        emit: &mut impl FnMut(HllDelta),
+    ) {
         let hashed_val = H::hash64_seeded(CANONICAL_HASH_SEED, obj);
-        self.insert_emit_delta_with_hash(hashed_val, emit);
+        self.insert_emit_delta_with_hash_and_threshold(hashed_val, threshold, emit);
     }
 
     /// Applies one externally emitted HLL delta.
@@ -419,6 +455,12 @@ impl<Variant, Registers: HllRegisterStorage, H: SketchHasher>
             regs[pos] = delta.value;
         }
     }
+}
+
+/// `2^exp`, saturating rather than overflowing for out-of-range registers.
+#[inline(always)]
+fn pow2_saturating(exp: u8) -> u128 {
+    if exp >= 127 { u128::MAX } else { 1u128 << exp }
 }
 
 #[cfg(test)]

--- a/src/sketches/hll.rs
+++ b/src/sketches/hll.rs
@@ -168,10 +168,18 @@ impl<Variant, Registers: HllRegisterStorage, H: SketchHasher>
 impl<Variant, Registers: HllRegisterStorage, H: SketchHasher>
     HyperLogLogImpl<Variant, Registers, H>
 {
+    /// The hash this sketch indexes `obj` by.
+    ///
+    /// Exposed so a caller can hash on its own thread and hand a worker the
+    /// result, leaving nothing borrowed to cross the boundary.
+    #[inline(always)]
+    pub fn canonical_hash(obj: &DataInput) -> u64 {
+        H::hash64_seeded(CANONICAL_HASH_SEED, obj)
+    }
+
     /// Hashes and inserts a single input value into the sketch.
     pub fn insert(&mut self, obj: &DataInput) {
-        let hashed_val = H::hash64_seeded(CANONICAL_HASH_SEED, obj);
-        self.insert_with_hash(hashed_val);
+        self.insert_with_hash(Self::canonical_hash(obj));
     }
 
     /// Hashes and inserts multiple input values into the sketch.

--- a/src/sketches/mod.rs
+++ b/src/sketches/mod.rs
@@ -95,10 +95,13 @@ pub use countminsketch_topk::CMSHeap;
 
 pub mod countsketch_topk;
 pub use countsketch_topk::CSHeap;
-pub use countsketch_topk::CountL2HH;
+pub use countsketch_topk::{CountL2HH, l2hh_cell_for_row};
 
 pub mod octo_delta;
-pub use octo_delta::{CM_PROMASK, COUNT_PROMASK, CmDelta, CountDelta, HLL_PROMASK, HllDelta};
+pub use octo_delta::{
+    CM_PROMASK, COUNT_PROMASK, CmDelta, CountDelta, DD_PROMASK, DdDelta, HLL_PROMASK, HllDelta,
+    KeyedCmDelta, KeyedCountDelta, LayeredCountDelta, MAX_PROMASK, OctoThreshold, UNIVMON_PROMASK,
+};
 
 pub mod fold_cms;
 pub use fold_cms::{FoldCMS, FoldCell, FoldEntry};

--- a/src/sketches/octo_delta.rs
+++ b/src/sketches/octo_delta.rs
@@ -39,10 +39,13 @@ pub const HLL_PROMASK: u8 = 0;
 
 /// Largest threshold a worker may be configured with.
 ///
-/// Counter storage in the compact worker sketches is one byte wide, so a
-/// counter must stay representable in `u8` right up to the promotion that
-/// clears it.
-pub const MAX_PROMASK: u32 = u8::MAX as u32;
+/// Counter storage in the compact worker sketches is one byte wide, and the
+/// Count-sketch and UnivMon workers hold *signed* counters, so a counter must
+/// stay representable in `i8` right up to the promotion that clears it. The
+/// ceiling is the same for every sketch on purpose: one shared `OctoThreshold`
+/// serves workers of different kinds, and a τ that silently meant 200 in one
+/// and 127 in another would put a dead band in the aggregator's controller.
+pub const MAX_PROMASK: u32 = i8::MAX as u32;
 
 /// Delta emitted by a CountMin child worker.
 /// Represents an accumulated unsigned count for a single cell.

--- a/src/sketches/octo_delta.rs
+++ b/src/sketches/octo_delta.rs
@@ -1,47 +1,170 @@
 //! Delta entry types for OctoSketch-style multi-threaded sketch updates.
 //!
 //! Each delta represents an accumulated counter change emitted by a child
-//! worker sketch when a local counter overflows the promotion threshold (PROMASK).
+//! worker sketch when a local counter crosses the promotion threshold τ
+//! (Algorithm 1 of the OctoSketch paper, NSDI '24).
 
-/// CountMin promotion threshold: emit delta when u8 counter >= 127.
-pub const CM_PROMASK: u8 = 0x1f;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
-/// Count sketch promotion threshold: emit delta when |i8 counter| >= 63.
-pub const COUNT_PROMASK: u8 = 0x1f;
+use crate::HeapItem;
 
-/// HLL promotion threshold: 0 means every register improvement is emitted.
+/// Default promotion threshold τ for Count-Min workers.
+pub const CM_PROMASK: u32 = 0x1f;
+
+/// Default promotion threshold τ for Count sketch workers, applied to `|counter|`.
+pub const COUNT_PROMASK: u32 = 0x1f;
+
+/// Default promotion threshold τ for DDSketch workers.
+///
+/// A bucket histogram spreads a stream over many buckets, and a bucket that
+/// never reaches τ never reaches the aggregator at all - so the sparse tail
+/// disappears rather than merely lagging. DDSketch therefore wants a much
+/// lower threshold than a Count-Min row, whose counters are dense and whose
+/// query is a minimum. Size it against the samples-per-bucket you expect.
+pub const DD_PROMASK: u32 = 4;
+
+/// Default base promotion threshold τ for UnivMon workers.
+///
+/// Higher than a plain Count sketch's because a UnivMon insert touches several
+/// layers and the aggregator does the heavy-hitter work the workers dropped,
+/// which makes it the pipeline's ceiling. Measured with
+/// `cargo run --release --example octo_throughput_probe`, the sustainable rate
+/// on a 2M-insert Zipf stream runs 0.41 M/s at τ=31 and 1.00 M/s at τ=64 for
+/// the same 0.02% gap to a single-threaded sketch, so 31 is simply dominated.
+pub const UNIVMON_PROMASK: u32 = 64;
+
+/// Default HLL promotion threshold τ: 0 promotes every register improvement.
 pub const HLL_PROMASK: u8 = 0;
+
+/// Largest threshold a worker may be configured with.
+///
+/// Counter storage in the compact worker sketches is one byte wide, so a
+/// counter must stay representable in `u8` right up to the promotion that
+/// clears it.
+pub const MAX_PROMASK: u32 = u8::MAX as u32;
 
 /// Delta emitted by a CountMin child worker.
 /// Represents an accumulated unsigned count for a single cell.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CmDelta {
     /// Row index of the updated cell.
-    pub row: u16,
+    pub row: u32,
     /// Column index of the updated cell.
-    pub col: u16,
+    pub col: u32,
     /// Accumulated delta for the cell.
-    pub value: u8,
+    pub value: u32,
 }
 
 /// Delta emitted by a Count sketch child worker.
 /// Represents a signed accumulated count for a single cell.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CountDelta {
     /// Row index of the updated cell.
-    pub row: u16,
+    pub row: u32,
     /// Column index of the updated cell.
-    pub col: u16,
+    pub col: u32,
     /// Signed accumulated delta for the cell.
-    pub value: i8,
+    pub value: i32,
 }
 
 /// Delta emitted by an HLL child worker.
 /// Represents a register improvement (max-register semantics).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HllDelta {
     /// Register position to update.
-    pub pos: u16,
+    pub pos: u32,
     /// New register value.
     pub value: u8,
+}
+
+/// Delta emitted by a DDSketch child worker for one bucket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DdDelta {
+    /// Absolute bucket index, as used by `DDSketch::store_offset`.
+    pub index: i32,
+    /// Accumulated count for the bucket.
+    pub value: u64,
+}
+
+/// A `CmDelta` carrying the flow key that produced it.
+///
+/// The paper's worker-to-aggregator message is a 4-tuple `<flow key, row,
+/// column, value>`; the key lets the aggregator maintain the heavy-hitter heap
+/// that workers no longer keep (§3.2, Idea 3).
+#[derive(Clone, Debug, PartialEq)]
+pub struct KeyedCmDelta {
+    /// Flow key whose insertion triggered the promotion.
+    pub key: HeapItem,
+    /// The promoted cell update.
+    pub delta: CmDelta,
+}
+
+/// A `CountDelta` carrying the flow key that produced it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct KeyedCountDelta {
+    /// Flow key whose insertion triggered the promotion.
+    pub key: HeapItem,
+    /// The promoted cell update.
+    pub delta: CountDelta,
+}
+
+/// A `CountDelta` tagged with the UnivMon pyramid layer it belongs to.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LayeredCountDelta {
+    /// Pyramid layer index.
+    pub layer: u32,
+    /// Flow key whose insertion triggered the promotion.
+    pub key: HeapItem,
+    /// The promoted cell update.
+    pub delta: CountDelta,
+    /// Which worker emitted this, so an aggregator can keep per-worker totals.
+    pub worker_id: u32,
+    /// Total weight the emitting worker has seen so far.
+    ///
+    /// UnivMon divides by this in its g-sum queries, and it cannot be recovered
+    /// from thresholded counter deltas. Riding along on a message the worker is
+    /// already sending keeps the aggregator's copy current without adding one.
+    pub weight_total: u64,
+}
+
+/// The promotion threshold τ, shared by every worker and adjustable at runtime.
+///
+/// The paper keeps τ in one atomic that the aggregator raises or lowers to
+/// match its receive rate against the workers' send rate (§4.3).
+#[derive(Clone, Debug)]
+pub struct OctoThreshold(Arc<AtomicU32>);
+
+impl OctoThreshold {
+    /// Creates a shared threshold, clamped to `1..=MAX_PROMASK`.
+    pub fn new(tau: u32) -> Self {
+        Self(Arc::new(AtomicU32::new(tau.clamp(1, MAX_PROMASK))))
+    }
+
+    /// Reads the current threshold.
+    #[inline(always)]
+    pub fn get(&self) -> u32 {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    /// Replaces the threshold, clamped to `1..=MAX_PROMASK`.
+    pub fn set(&self, tau: u32) {
+        self.0.store(tau.clamp(1, MAX_PROMASK), Ordering::Relaxed);
+    }
+
+    /// Adds `step` to the threshold, saturating at `MAX_PROMASK`.
+    pub fn increase(&self, step: u32) {
+        self.set(self.get().saturating_add(step));
+    }
+
+    /// Subtracts `step` from the threshold, saturating at 1.
+    pub fn decrease(&self, step: u32) {
+        self.set(self.get().saturating_sub(step).max(1));
+    }
+}
+
+impl Default for OctoThreshold {
+    fn default() -> Self {
+        Self::new(CM_PROMASK)
+    }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,6 +13,7 @@ same conformance batteries before landing — copy an adapter from
 | `common/conformance.rs` | Capability traits + standard conformance batteries |
 | `conformance_kit.rs` | Reference adapters: established sketches running through the kit (copy these) |
 | `e2e_frequency.rs` / `e2e_cardinality.rs` / `e2e_quantiles.rs` / `e2e_frameworks.rs` | Deep per-family suites with hand-tuned tolerances |
+| `e2e_octo.rs` | OctoSketch delta-promotion invariants and the `octo-runtime` pipeline, checked against single-threaded replays |
 | `e2e_experimental.rs` | Same for `feature = "experimental"` sketches |
 | `bug_verification.rs` | Regression tests for fixed wrong-query-results bugs |
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ same conformance batteries before landing — copy an adapter from
 | `common/conformance.rs` | Capability traits + standard conformance batteries |
 | `conformance_kit.rs` | Reference adapters: established sketches running through the kit (copy these) |
 | `e2e_frequency.rs` / `e2e_cardinality.rs` / `e2e_quantiles.rs` / `e2e_frameworks.rs` | Deep per-family suites with hand-tuned tolerances |
-| `e2e_octo.rs` | OctoSketch delta-promotion invariants and the `octo-runtime` pipeline, checked against single-threaded replays |
+| `e2e_octo.rs` | OctoSketch delta-promotion invariants, the `octo-runtime` pipeline, and conformance to the paper's Theorems 1-4 and its sketch-merge baseline |
 | `e2e_experimental.rs` | Same for `feature = "experimental"` sketches |
 | `bug_verification.rs` | Regression tests for fixed wrong-query-results bugs |
 

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -20,9 +20,10 @@
 mod common;
 
 use asap_sketchlib::{
-    CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin, DataInput, ErtlMLE,
-    FastPath, HLL_PROMASK, HllDelta, HyperLogLog, HyperLogLogP12, HyperLogLogP16, RegularPath,
-    Vector2D,
+    CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin, DDSketch, DataInput,
+    DdWorkerSketch, ErtlMLE, FastPath, HLL_PROMASK, HllDelta, HyperLogLog, HyperLogLogP12,
+    HyperLogLogP16, OctoAggregator, OctoThreshold, OctoWorker, RegularPath, UnivMon,
+    UnivMonOctoAggregator, UnivMonOctoWorker, Vector2D, hash64_seeded,
 };
 use common::{FreqTruth, zipf_u64};
 use rand::SeedableRng;
@@ -104,20 +105,32 @@ fn cs_cells(sketch: &Cs) -> Vec<i32> {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn cm_emit_path_leaves_the_child_identical_to_a_plain_insert() {
+fn cm_promotion_is_lossless_modulo_the_child_residual() {
     let stream = keys(20_000, 512, 9_101);
-    let (child, _) = cm_child_run(&stream, ROWS, COLS);
+    let (child, deltas) = cm_child_run(&stream, ROWS, COLS);
 
+    let mut parent = Cm::with_dimensions(ROWS, COLS);
+    for d in &deltas {
+        parent.apply_delta(*d);
+    }
     let mut reference = Cm::with_dimensions(ROWS, COLS);
     for k in &stream {
         reference.insert(&DataInput::U64(*k));
     }
 
-    assert_eq!(
-        cm_cells(&child),
-        cm_cells(&reference),
-        "emitting deltas must not perturb the child's own counters"
-    );
+    // Algorithm 1 clears the counter it promotes, so what the child still
+    // holds plus what the parent received must reconstruct a single pass.
+    let (child_cells, parent_cells, ref_cells) =
+        (cm_cells(&child), cm_cells(&parent), cm_cells(&reference));
+    for (i, ((&c, &p), &r)) in child_cells
+        .iter()
+        .zip(parent_cells.iter())
+        .zip(ref_cells.iter())
+        .enumerate()
+    {
+        assert_eq!(p + c, r, "cell {i}: promoted {p} plus residual {c} != {r}");
+        assert!(c <= MAX_CELL_RESIDUAL, "cell {i}: residual {c} un-promoted");
+    }
 }
 
 #[test]
@@ -134,30 +147,32 @@ fn cm_deltas_are_well_formed_and_carry_exactly_one_promotion() {
 }
 
 #[test]
-fn cm_parent_holds_the_promoted_multiple_of_every_child_cell() {
+fn cm_parent_holds_every_completed_promotion() {
     let stream = keys(30_000, 512, 9_103);
-    let (child, deltas) = cm_child_run(&stream, ROWS, COLS);
+    let (_, deltas) = cm_child_run(&stream, ROWS, COLS);
 
     let mut parent = Cm::with_dimensions(ROWS, COLS);
     for d in &deltas {
         parent.apply_delta(*d);
     }
 
-    let (child_cells, parent_cells) = (cm_cells(&child), cm_cells(&parent));
+    let mut reference = Cm::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
     let mask = CM_PROMASK as i32;
+    let (parent_cells, ref_cells) = (cm_cells(&parent), cm_cells(&reference));
     let mut worst_residual = 0;
-    for (i, (&c, &p)) in child_cells.iter().zip(parent_cells.iter()).enumerate() {
+    for (i, (&p, &r)) in parent_cells.iter().zip(ref_cells.iter()).enumerate() {
         assert_eq!(
             p,
-            mask * (c / mask),
-            "cell {i}: parent must hold every completed promotion of child count {c}"
+            mask * (r / mask),
+            "cell {i}: parent must hold every completed promotion of {r}"
         );
-        worst_residual = worst_residual.max(c - p);
+        worst_residual = worst_residual.max(r - p);
     }
-    assert!(
-        worst_residual <= MAX_CELL_RESIDUAL,
-        "residual {worst_residual} exceeds one promotion window"
-    );
+    assert!(worst_residual <= MAX_CELL_RESIDUAL);
     assert!(
         worst_residual > 0,
         "a skewed stream should leave some un-promoted remainder"
@@ -167,18 +182,22 @@ fn cm_parent_holds_the_promoted_multiple_of_every_child_cell() {
 #[test]
 fn cm_octo_estimate_trails_the_single_thread_estimate_by_under_one_promotion() {
     let stream = keys(40_000, 256, 9_104);
-    let (child, deltas) = cm_child_run(&stream, ROWS, COLS);
+    let (_, deltas) = cm_child_run(&stream, ROWS, COLS);
 
     let mut parent = Cm::with_dimensions(ROWS, COLS);
     for d in &deltas {
         parent.apply_delta(*d);
     }
+    let mut reference = Cm::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
 
-    // Per row the parent lags by `count mod mask`, so the row-wise minimum
+    // Per row the parent lags by `count mod tau`, so the row-wise minimum
     // lags by strictly less than one promotion window and never overshoots.
     for k in 0u64..256 {
         let key = DataInput::U64(k);
-        let single = child.estimate(&key);
+        let single = reference.estimate(&key);
         let octo = parent.estimate(&key);
         assert!(
             octo <= single,
@@ -212,22 +231,29 @@ fn cm_fast_path_promotes_on_the_same_schedule_as_the_regular_path() {
     // The fast path derives all columns from one hash, so its collision
     // pattern - and therefore its promotion count - differs from the regular
     // path. Only the per-cell promotion rule is shared.
-    let mask = CM_PROMASK as i32;
+    let mut reference = CmFast::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
     for r in 0..ROWS {
         for c in 0..COLS {
-            let child_cell = fast_child.as_storage().query_one_counter(r, c);
-            let parent_cell = fast_parent.as_storage().query_one_counter(r, c);
-            assert_eq!(parent_cell, mask * (child_cell / mask), "cell ({r},{c})");
+            assert_eq!(
+                fast_parent.as_storage().query_one_counter(r, c)
+                    + fast_child.as_storage().query_one_counter(r, c),
+                reference.as_storage().query_one_counter(r, c),
+                "cell ({r},{c})"
+            );
         }
     }
 }
 
 #[test]
-fn cm_delta_addressing_holds_at_the_widest_supported_geometry() {
-    // `CmDelta` addresses cells with u16 row/col, so 65_536 columns is the
-    // widest geometry the promotion protocol can carry (max index 65_535).
+fn cm_delta_addressing_survives_columns_past_the_old_u16_ceiling() {
+    // Regression: `CmDelta` used to address cells with u16 row/col, so any
+    // geometry wider than 65_536 columns silently wrapped deltas onto the
+    // wrong cell. The fields are u32, so a wider sketch must stay exact.
     let rows = 3;
-    let cols = u16::MAX as usize + 1;
+    let cols = 100_000;
     let stream = keys(60_000, 4_096, 9_108);
 
     let mut child = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
@@ -236,14 +262,17 @@ fn cm_delta_addressing_holds_at_the_widest_supported_geometry() {
         child.insert_emit_delta(&DataInput::U64(*k), &mut |d| parent.apply_delta(d));
     }
 
-    let mask = CM_PROMASK as i32;
+    let mut reference = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
     for r in 0..rows {
         for c in 0..cols {
-            let child_cell = child.as_storage().query_one_counter(r, c);
             assert_eq!(
-                parent.as_storage().query_one_counter(r, c),
-                mask * (child_cell / mask),
-                "cell ({r},{c}) mis-addressed at the u16 column boundary"
+                parent.as_storage().query_one_counter(r, c)
+                    + child.as_storage().query_one_counter(r, c),
+                reference.as_storage().query_one_counter(r, c),
+                "cell ({r},{c}) mis-addressed past the old u16 ceiling"
             );
         }
     }
@@ -299,10 +328,9 @@ fn cm_sharded_children_conserve_counts_against_a_single_pass() {
     for r in 0..ROWS {
         for c in 0..COLS {
             let promoted = parent.as_storage().query_one_counter(r, c);
-            let mask = CM_PROMASK as i32;
             let residual: i32 = children
                 .iter()
-                .map(|ch| ch.as_storage().query_one_counter(r, c) % mask)
+                .map(|ch| ch.as_storage().query_one_counter(r, c))
                 .sum();
             assert_eq!(
                 promoted + residual,
@@ -674,7 +702,8 @@ mod runtime {
     use super::*;
     use asap_sketchlib::{
         CmOctoAggregator, CmOctoWorker, CountOctoAggregator, CountOctoWorker, HllOctoAggregator,
-        HllOctoWorker, OctoAggregator, OctoConfig, OctoRuntime, OctoWorker, run_octo,
+        HllOctoWorker, OctoAggregator, OctoConfig, OctoPartition, OctoRuntime, OctoWorker,
+        run_octo,
     };
 
     fn config(num_workers: usize) -> OctoConfig {
@@ -683,6 +712,7 @@ mod runtime {
             // CI runners have fewer cores than the widest configuration here.
             pin_cores: false,
             queue_capacity: 4096,
+            ..OctoConfig::default()
         }
     }
 
@@ -700,7 +730,7 @@ mod runtime {
     }
 
     fn cm_replay(inputs: &[DataInput<'_>], workers: usize, rows: usize, cols: usize) -> Cm {
-        let mut replay = OctoCm::new(workers, rows, cols);
+        let mut replay = OctoCm::new(workers, rows, cols, Route::HashByKey);
         for (i, input) in inputs.iter().enumerate() {
             replay.insert(i, input);
         }
@@ -708,7 +738,7 @@ mod runtime {
     }
 
     fn cs_replay(inputs: &[DataInput<'_>], workers: usize, rows: usize, cols: usize) -> Cs {
-        let mut replay = OctoCs::new(workers, rows, cols);
+        let mut replay = OctoCs::new(workers, rows, cols, Route::HashByKey);
         for (i, input) in inputs.iter().enumerate() {
             replay.insert(i, input);
         }
@@ -845,6 +875,7 @@ mod runtime {
             num_workers: 0,
             pin_cores: false,
             queue_capacity: 0,
+            ..OctoConfig::default()
         };
         let got = run_octo(
             &inputs,
@@ -875,6 +906,7 @@ mod runtime {
             num_workers: 4,
             pin_cores: false,
             queue_capacity: 1,
+            ..OctoConfig::default()
         };
         let got = run_octo(
             &inputs,
@@ -983,9 +1015,13 @@ mod runtime {
         let n = 10_001u64;
         let inputs = inputs_from(&(0..n).collect::<Vec<_>>());
 
+        let cfg = OctoConfig {
+            partition: OctoPartition::RoundRobin,
+            ..config(workers)
+        };
         let result = run_octo(
             &inputs,
-            &config(workers),
+            &cfg,
             |worker_id| SumWorker { worker_id, seen: 0 },
             || SumAggregator {
                 per_worker: vec![0; workers],
@@ -1116,7 +1152,7 @@ mod runtime {
         // may reach. `run_octo` dispatches round-robin, so every key reaches
         // every worker and k' = num_workers - the worst case of that bound.
         let epsilon_n = (std::f64::consts::E / cols as f64) * truth.total() as f64;
-        let floor = 4.0 * MAX_CELL_RESIDUAL as f64;
+        let floor = TAU as f64;
         for k in 0u64..4_096 {
             let exact = truth.get(k as i64) as f64;
             let est = parent.estimate(&DataInput::U64(k)) as f64;
@@ -1179,8 +1215,7 @@ mod runtime {
 
         // Count-Sketch error is ±‖f‖₂/√cols w.h.p.; per OctoSketch Theorem 1
         // the promotion protocol adds k'·τ, and round-robin makes k' = workers.
-        let tolerance =
-            3.0 * truth.l2_norm() / (cols as f64).sqrt() + 4.0 * MAX_CELL_RESIDUAL as f64;
+        let tolerance = 3.0 * truth.l2_norm() / (cols as f64).sqrt() + TAU as f64;
         let mut violations = Vec::new();
         for (key, exact) in truth.top_k(64) {
             let est = parent.estimate(&DataInput::U64(key as u64));
@@ -1203,27 +1238,55 @@ mod runtime {
 // Replays: OctoSketch delta promotion vs. the periodic sketch-merge baseline
 // ---------------------------------------------------------------------------
 
+/// How a replay routes an input to a worker, mirroring `OctoPartition`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Route {
+    /// One flow, one worker: the paper's setting, k' = 1.
+    HashByKey,
+    /// Every flow reaches every worker: k' = k, the worst case of each bound.
+    RoundRobin,
+}
+
+impl Route {
+    fn worker(self, index: usize, key: &DataInput, workers: usize) -> usize {
+        match self {
+            Route::RoundRobin => index % workers,
+            Route::HashByKey => (hash64_seeded(0, key) % workers as u64) as usize,
+        }
+    }
+
+    /// k' in the paper's bounds: the number of workers one flow may reach.
+    fn k_prime(self, workers: usize) -> usize {
+        match self {
+            Route::RoundRobin => workers,
+            Route::HashByKey => 1,
+        }
+    }
+}
+
 /// OctoSketch: workers promote single counters once they cross τ.
 struct OctoCm {
     children: Vec<Cm>,
     parent: Cm,
+    route: Route,
     /// Counters shipped to the aggregator, the unit Theorem 2 counts in.
     sent_counters: usize,
 }
 
 impl OctoCm {
-    fn new(workers: usize, rows: usize, cols: usize) -> Self {
+    fn new(workers: usize, rows: usize, cols: usize, route: Route) -> Self {
         Self {
             children: (0..workers)
                 .map(|_| Cm::with_dimensions(rows, cols))
                 .collect(),
             parent: Cm::with_dimensions(rows, cols),
+            route,
             sent_counters: 0,
         }
     }
 
     fn insert(&mut self, index: usize, key: &DataInput) {
-        let worker = index % self.children.len();
+        let worker = self.route.worker(index, key, self.children.len());
         let mut promoted = Vec::new();
         self.children[worker].insert_emit_delta(key, &mut |d| promoted.push(d));
         self.sent_counters += promoted.len();
@@ -1242,11 +1305,12 @@ struct MergeCm {
     period: usize,
     rows: usize,
     cols: usize,
+    route: Route,
     sent_counters: usize,
 }
 
 impl MergeCm {
-    fn new(workers: usize, rows: usize, cols: usize, period: usize) -> Self {
+    fn new(workers: usize, rows: usize, cols: usize, period: usize, route: Route) -> Self {
         Self {
             children: (0..workers)
                 .map(|_| Cm::with_dimensions(rows, cols))
@@ -1256,12 +1320,13 @@ impl MergeCm {
             period,
             rows,
             cols,
+            route,
             sent_counters: 0,
         }
     }
 
     fn insert(&mut self, index: usize, key: &DataInput) {
-        let worker = index % self.children.len();
+        let worker = self.route.worker(index, key, self.children.len());
         self.children[worker].insert(key);
         self.seen[worker] += 1;
         if self.seen[worker] % self.period == 0 {
@@ -1272,26 +1337,31 @@ impl MergeCm {
     }
 }
 
-/// Count-sketch flavour of `OctoCm`; the worker zeroes the counter on promotion.
+/// Count-sketch flavour of `OctoCm`.
 struct OctoCs {
     children: Vec<Cs>,
     parent: Cs,
+    route: Route,
+    sent_counters: usize,
 }
 
 impl OctoCs {
-    fn new(workers: usize, rows: usize, cols: usize) -> Self {
+    fn new(workers: usize, rows: usize, cols: usize, route: Route) -> Self {
         Self {
             children: (0..workers)
                 .map(|_| Cs::with_dimensions(rows, cols))
                 .collect(),
             parent: Cs::with_dimensions(rows, cols),
+            route,
+            sent_counters: 0,
         }
     }
 
     fn insert(&mut self, index: usize, key: &DataInput) {
-        let worker = index % self.children.len();
+        let worker = self.route.worker(index, key, self.children.len());
         let mut promoted = Vec::new();
         self.children[worker].insert_emit_delta(key, &mut |d| promoted.push(d));
+        self.sent_counters += promoted.len();
         for d in promoted {
             self.parent.apply_delta(d);
         }
@@ -1311,55 +1381,76 @@ fn theorem_1_bounds_the_count_min_error() {
     let workers = 4usize;
     let epsilon = 2.0 / l as f64;
     let delta = 2f64.powi(-(d as i32));
-    let k_prime_tau = (workers as i32 * TAU) as f64;
 
     let stream = zipf_u64(400_000, 8_192, 1.1, 11_001);
     let mut truth = FreqTruth::default();
-    let mut octo = OctoCm::new(workers, d, l);
-    for (i, key) in stream.iter().enumerate() {
+    for key in &stream {
         truth.observe(*key as i64);
-        octo.insert(i, &DataInput::U64(*key));
     }
-
-    let l1 = truth.total() as f64;
-    assert!(
-        l1 > k_prime_tau / epsilon,
-        "theorem precondition L1 > ε⁻¹k'τ unmet: L1 = {l1}, ε⁻¹k'τ = {}",
-        k_prime_tau / epsilon
-    );
-
-    let band = epsilon * l1;
-    let mut violations = 0usize;
-    let mut worst_deficit = 0.0f64;
-    let mut worst_excess = 0.0f64;
-    let pairs = truth.pairs();
-    for (key, exact) in &pairs {
-        let est = octo.parent.estimate(&DataInput::U64(*key as u64)) as f64;
-        let exact = *exact as f64;
-        if (est - exact).abs() > band {
-            violations += 1;
+    let mut measured: Vec<(Route, f64)> = Vec::new();
+    for route in [Route::HashByKey, Route::RoundRobin] {
+        let k_prime_tau = (route.k_prime(workers) as i32 * TAU) as f64;
+        // A counter is shared by every flow that hashes into it, and each worker
+        // may hold back up to tau of its own share, so the provable per-counter
+        // gap is k*tau whatever the partition. The paper's k'*tau bounds only the
+        // queried flow's own held-back count.
+        let counter_ceiling = (workers as i32 * TAU) as f64;
+        let mut octo = OctoCm::new(workers, d, l, route);
+        for (i, key) in stream.iter().enumerate() {
+            octo.insert(i, &DataInput::U64(*key));
         }
-        worst_deficit = worst_deficit.max(exact - est);
-        worst_excess = worst_excess.max(est - exact);
+
+        let l1 = truth.total() as f64;
+        assert!(
+            l1 > k_prime_tau / epsilon,
+            "theorem precondition L1 > ε⁻¹k'τ unmet: L1 = {l1}, ε⁻¹k'τ = {}",
+            k_prime_tau / epsilon
+        );
+
+        let band = epsilon * l1;
+        let mut violations = 0usize;
+        let mut worst_deficit = 0.0f64;
+        let mut worst_excess = 0.0f64;
+        let pairs = truth.pairs();
+        for (key, exact) in &pairs {
+            let est = octo.parent.estimate(&DataInput::U64(*key as u64)) as f64;
+            let exact = *exact as f64;
+            if (est - exact).abs() > band {
+                violations += 1;
+            }
+            worst_deficit = worst_deficit.max(exact - est);
+            worst_excess = worst_excess.max(est - exact);
+        }
+
+        // The proof's deterministic half: f̂ ≤ f̂' and |f̂' − f̂| < k'τ, and Count-Min
+        // never underestimates, so f(e) − k'τ < f̂(e) for *every* key, not merely
+        // with probability 1 − δ.
+        assert!(
+            worst_deficit < counter_ceiling,
+            "worst underestimate {worst_deficit} reached the k*tau = {counter_ceiling} ceiling"
+        );
+        measured.push((route, worst_deficit));
+
+        let rate = violations as f64 / pairs.len() as f64;
+        println!(
+            "Theorem 1 [{route:?}]: eps={epsilon:.2e} delta={delta:.4} eps*L1={band:.1} \
+         k'tau={k_prime_tau} violations={rate:.5} worst_deficit={worst_deficit} \
+         worst_excess={worst_excess}"
+        );
+        assert!(
+            rate < delta,
+            "{route:?}: violation rate {rate:.5} exceeded δ = {delta:.5} over {} keys",
+            pairs.len()
+        );
     }
 
-    // The proof's deterministic half: f̂ ≤ f̂' and |f̂' − f̂| < k'τ, and Count-Min
-    // never underestimates, so f(e) − k'τ < f̂(e) for *every* key, not merely
-    // with probability 1 − δ.
+    // Hash partitioning keeps a flow's whole count on one worker, so it should
+    // never trail further behind than round-robin does.
+    let hashed = measured[0].1;
+    let round_robin = measured[1].1;
     assert!(
-        worst_deficit < k_prime_tau,
-        "worst underestimate {worst_deficit} reached the k'τ = {k_prime_tau} ceiling"
-    );
-
-    let rate = violations as f64 / pairs.len() as f64;
-    println!(
-        "Theorem 1: eps={epsilon:.2e} delta={delta:.4} eps*L1={band:.1} k'tau={k_prime_tau} \
-         violations={rate:.5} worst_deficit={worst_deficit} worst_excess={worst_excess}"
-    );
-    assert!(
-        rate < delta,
-        "violation rate {rate:.5} exceeded δ = {delta:.5} over {} keys",
-        pairs.len()
+        hashed <= round_robin,
+        "hash partitioning lagged more than round-robin: {hashed} vs {round_robin}"
     );
 }
 
@@ -1380,53 +1471,68 @@ fn theorem_3_bounds_the_count_sketch_error() {
     let workers = 4usize;
     let epsilon = (8.0 / l as f64).sqrt();
     let delta = 2f64.powi(-(d as i32));
-    let k_prime_tau = (workers as i32 * TAU) as f64;
 
     let stream = zipf_u64(400_000, 8_192, 1.1, 11_003);
     let mut truth = FreqTruth::default();
-    let mut octo = OctoCs::new(workers, d, l);
     let mut single_core = Cs::with_dimensions(d, l);
-    for (i, key) in stream.iter().enumerate() {
+    for key in &stream {
         truth.observe(*key as i64);
-        octo.insert(i, &DataInput::U64(*key));
         single_core.insert(&DataInput::U64(*key));
     }
-
-    let l2 = truth.l2_norm();
-    assert!(
-        l2 > 2.0 * k_prime_tau / epsilon,
-        "theorem precondition L2 > 2ε⁻¹k'τ unmet: L2 = {l2}, 2ε⁻¹k'τ = {}",
-        2.0 * k_prime_tau / epsilon
-    );
-
-    let band = epsilon * l2;
-    let mut violations = 0usize;
-    let mut worst_octo_gap = 0.0f64;
-    let pairs = truth.pairs();
-    for (key, exact) in &pairs {
-        let input = DataInput::U64(*key as u64);
-        let est = octo.parent.estimate(&input);
-        if (est - *exact as f64).abs() > band {
-            violations += 1;
+    let mut measured: Vec<(Route, f64)> = Vec::new();
+    for route in [Route::HashByKey, Route::RoundRobin] {
+        let k_prime_tau = (route.k_prime(workers) as i32 * TAU) as f64;
+        // See Theorem 1: the per-counter gap ceiling is k*tau, not k'*tau.
+        let counter_ceiling = (workers as i32 * TAU) as f64;
+        let mut octo = OctoCs::new(workers, d, l, route);
+        for (i, key) in stream.iter().enumerate() {
+            octo.insert(i, &DataInput::U64(*key));
         }
-        // The proof's deterministic half: |f̂'(e) − f̂(e)| < k'τ.
-        worst_octo_gap = worst_octo_gap.max((single_core.estimate(&input) - est).abs());
+
+        let l2 = truth.l2_norm();
+        assert!(
+            l2 > 2.0 * k_prime_tau / epsilon,
+            "theorem precondition L2 > 2ε⁻¹k'τ unmet: L2 = {l2}, 2ε⁻¹k'τ = {}",
+            2.0 * k_prime_tau / epsilon
+        );
+
+        let band = epsilon * l2;
+        let mut violations = 0usize;
+        let mut worst_octo_gap = 0.0f64;
+        let pairs = truth.pairs();
+        for (key, exact) in &pairs {
+            let input = DataInput::U64(*key as u64);
+            let est = octo.parent.estimate(&input);
+            if (est - *exact as f64).abs() > band {
+                violations += 1;
+            }
+            // The proof's deterministic half: |f̂'(e) − f̂(e)| < k'τ.
+            worst_octo_gap = worst_octo_gap.max((single_core.estimate(&input) - est).abs());
+        }
+
+        assert!(
+            worst_octo_gap < counter_ceiling,
+            "gap to the single-core sketch {worst_octo_gap} reached the k*tau = {counter_ceiling} ceiling"
+        );
+        measured.push((route, worst_octo_gap));
+
+        let rate = violations as f64 / pairs.len() as f64;
+        println!(
+            "Theorem 3 [{route:?}]: eps={epsilon:.4} delta={delta:.4} eps*L2={band:.1} \
+         k'tau={k_prime_tau} violations={rate:.5} worst_gap_to_single_core={worst_octo_gap}"
+        );
+        assert!(
+            rate < delta,
+            "{route:?}: violation rate {rate:.5} exceeded δ = {delta:.5} over {} keys",
+            pairs.len()
+        );
     }
 
+    let hashed = measured[0].1;
+    let round_robin = measured[1].1;
     assert!(
-        worst_octo_gap < k_prime_tau,
-        "gap to the single-core sketch {worst_octo_gap} reached the k'τ = {k_prime_tau} ceiling"
-    );
-
-    let rate = violations as f64 / pairs.len() as f64;
-    println!(
-        "Theorem 3: eps={epsilon:.4} delta={delta:.4} eps*L2={band:.1} k'tau={k_prime_tau} \
-         violations={rate:.5} worst_gap_to_single_core={worst_octo_gap}"
-    );
-    assert!(
-        rate < delta,
-        "violation rate {rate:.5} exceeded δ = {delta:.5} over {} keys",
-        pairs.len()
+        hashed <= round_robin,
+        "hash partitioning lagged more than round-robin: {hashed} vs {round_robin}"
     );
 }
 
@@ -1494,12 +1600,15 @@ fn theorem_2_delta_promotion_sends_l_times_fewer_counters_for_the_same_goal() {
     let d = 3usize;
     let l = 1_024usize;
     let workers = 4usize;
+    // A counter is shared across workers whatever the partition, so the goal a
+    // shipped tau solves for is k*tau, and sketch-merge must match it by
+    // shipping every tau items per worker.
     let accuracy_goal = (workers as i32 * TAU) as f64;
     let merge_period = TAU as usize;
 
     let stream = zipf_u64(40_000, 2_048, 1.1, 11_005);
-    let mut octo = OctoCm::new(workers, d, l);
-    let mut merge = MergeCm::new(workers, d, l, merge_period);
+    let mut octo = OctoCm::new(workers, d, l, Route::HashByKey);
+    let mut merge = MergeCm::new(workers, d, l, merge_period, Route::HashByKey);
     let mut single_core = Cm::with_dimensions(d, l);
     for (i, key) in stream.iter().enumerate() {
         let input = DataInput::U64(*key);
@@ -1576,22 +1685,26 @@ fn delta_promotion_beats_sketch_merge_on_online_accuracy() {
     let watched: Vec<i64> = final_truth.top_k(32).into_iter().map(|(k, _)| k).collect();
 
     // Sizing pass: what does delta promotion spend over this stream?
-    let mut probe = OctoCm::new(workers, d, l);
+    let mut probe = OctoCm::new(workers, d, l, Route::HashByKey);
     for (i, key) in stream.iter().enumerate() {
         probe.insert(i, &DataInput::U64(*key));
     }
     let mut merges: Vec<MergeCm> = budget_multiples
         .iter()
         .map(|mult| {
-            let merges_per_worker = ((mult * probe.sent_counters) / (d * l))
-                .div_ceil(workers)
-                .max(1);
-            MergeCm::new(workers, d, l, (n / workers) / merges_per_worker)
+            let merges_per_worker = ((mult * probe.sent_counters) as f64 / (d * l * workers) as f64)
+                .ceil()
+                .max(1.0) as usize;
+            // Divide by one more than the merge count so boundaries land
+            // mid-stream: a period equal to a worker's whole share would make
+            // it a coin flip whether that worker ever merges at all.
+            let period = ((n / workers) / (merges_per_worker + 1)).max(1);
+            MergeCm::new(workers, d, l, period, Route::HashByKey)
         })
         .collect();
 
     let mut truth = FreqTruth::default();
-    let mut octo = OctoCm::new(workers, d, l);
+    let mut octo = OctoCm::new(workers, d, l, Route::HashByKey);
     let mut single_core = Cm::with_dimensions(d, l);
     let mut octo_error = 0.0f64;
     let mut ideal_error = 0.0f64;
@@ -1644,8 +1757,8 @@ fn delta_promotion_beats_sketch_merge_on_online_accuracy() {
             merge.sent_counters > octo.sent_counters,
             "the baseline must not be starved of budget for this comparison to mean anything"
         );
-        // Empirical and deliberately loose: measured 9.3x at parity - within
-        // noise of the paper's 9.32x for Count-Min - and 2.8x at 10x budget.
+        // Empirical and deliberately loose: measured 14.0x at parity and 5.4x
+        // when the baseline is handed ten times the budget.
         assert!(
             merge_mae > octo_mae * 2.0,
             "delta promotion should stay well ahead at {mult}x budget: \
@@ -1655,13 +1768,13 @@ fn delta_promotion_beats_sketch_merge_on_online_accuracy() {
 
     let parity_mae = merge_error[0] / samples as f64;
     assert!(
-        parity_mae > octo_mae * 5.0,
+        parity_mae > octo_mae * 8.0,
         "at equal communication budget the gap should be large: \
          octo={octo_mae:.1} vs merge={parity_mae:.1}"
     );
     assert!(
-        octo_mae <= ideal_mae + (workers as i32 * TAU) as f64,
-        "octo online error {octo_mae:.1} drifted more than k'τ from ideal {ideal_mae:.1}"
+        octo_mae <= ideal_mae + TAU as f64,
+        "octo online error {octo_mae:.1} drifted more than tau from ideal {ideal_mae:.1}"
     );
 }
 
@@ -1689,10 +1802,10 @@ fn sketch_merge_staleness_grows_with_the_merge_period_while_promotion_does_not()
 
     let periods = [500usize, 1_000, 2_000, 4_000];
     let mut truth = FreqTruth::default();
-    let mut octo = OctoCm::new(workers, d, l);
+    let mut octo = OctoCm::new(workers, d, l, Route::HashByKey);
     let mut merges: Vec<MergeCm> = periods
         .iter()
-        .map(|p| MergeCm::new(workers, d, l, *p))
+        .map(|p| MergeCm::new(workers, d, l, *p, Route::HashByKey))
         .collect();
     let mut octo_deficit = 0.0f64;
     let mut merge_deficit = vec![0.0f64; periods.len()];
@@ -1727,8 +1840,8 @@ fn sketch_merge_staleness_grows_with_the_merge_period_while_promotion_does_not()
     );
 
     assert!(
-        octo_mean <= (workers as i32 * TAU) as f64,
-        "octo mean deficit {octo_mean:.1} exceeded k'τ"
+        octo_mean <= TAU as f64,
+        "octo mean deficit {octo_mean:.1} exceeded tau"
     );
     for (window, pair) in merge_means.windows(2).zip(periods.windows(2)) {
         assert!(
@@ -1744,5 +1857,705 @@ fn sketch_merge_staleness_grows_with_the_merge_period_while_promotion_does_not()
     assert!(
         merge_means[periods.len() - 1] > octo_mean * 3.0,
         "expected the widest merge period to be far staler than delta promotion"
+    );
+}
+
+// ===========================================================================
+// Online accuracy per sketch: delta promotion vs periodic sketch-merge
+// ===========================================================================
+//
+// Correctness is settled by the conservation identities above. What these
+// measure is the paper's actual claim: the error a query sees *while the
+// stream is still running*. Every comparison hands sketch-merge at least as
+// much communication as delta promotion spent, then queries both at points
+// that do not line up with a merge boundary.
+
+/// One row of the comparison: mean error at query time under each scheme.
+struct OnlineComparison {
+    ideal: f64,
+    octo: f64,
+    merge_at_parity: f64,
+    merge_at_ten_x: f64,
+    octo_counters: usize,
+    parity_counters: usize,
+    ten_x_counters: usize,
+}
+
+impl OnlineComparison {
+    fn report(&self, label: &str) {
+        println!(
+            "{label:<10} ideal={:.4} octo={:.4} merge@{:.1}x={:.4} merge@{:.1}x={:.4} \
+             (octo sent {} counters)",
+            self.ideal,
+            self.octo,
+            self.parity_counters as f64 / self.octo_counters.max(1) as f64,
+            self.merge_at_parity,
+            self.ten_x_counters as f64 / self.octo_counters.max(1) as f64,
+            self.merge_at_ten_x,
+            self.octo_counters,
+        );
+    }
+
+    /// Both baselines must be at least as expensive as the scheme they lose to.
+    fn assert_baselines_were_funded(&self) {
+        assert!(
+            self.parity_counters >= self.octo_counters,
+            "parity baseline was starved: {} < {}",
+            self.parity_counters,
+            self.octo_counters
+        );
+        assert!(self.ten_x_counters > self.parity_counters);
+    }
+}
+
+/// Merge periods that spend roughly `1x` and `10x` the given counter budget.
+fn merge_periods(
+    octo_counters: usize,
+    sketch_counters: usize,
+    per_worker: usize,
+) -> (usize, usize) {
+    let period_for = |budget: usize| {
+        let merges = (budget as f64 / sketch_counters as f64).ceil().max(1.0) as usize;
+        (per_worker / (merges + 1)).max(1)
+    };
+    (period_for(octo_counters), period_for(10 * octo_counters))
+}
+
+// --------------------------------------------------------------- Count sketch
+
+struct MergeCs {
+    children: Vec<Cs>,
+    seen: Vec<usize>,
+    parent: Cs,
+    period: usize,
+    rows: usize,
+    cols: usize,
+    sent_counters: usize,
+}
+
+impl MergeCs {
+    fn new(workers: usize, rows: usize, cols: usize, period: usize) -> Self {
+        Self {
+            children: (0..workers)
+                .map(|_| Cs::with_dimensions(rows, cols))
+                .collect(),
+            seen: vec![0; workers],
+            parent: Cs::with_dimensions(rows, cols),
+            period,
+            rows,
+            cols,
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = Route::HashByKey.worker(index, key, self.children.len());
+        self.children[worker].insert(key);
+        self.seen[worker] += 1;
+        if self.seen[worker] % self.period == 0 {
+            self.parent.merge(&self.children[worker]);
+            self.children[worker] = Cs::with_dimensions(self.rows, self.cols);
+            self.sent_counters += self.rows * self.cols;
+        }
+    }
+}
+
+#[test]
+fn count_sketch_online_accuracy_beats_sketch_merge() {
+    let (d, l, workers, n) = (5usize, 1_024usize, 4usize, 60_000usize);
+    let stream = zipf_u64(n, 4_096, 1.1, 12_001);
+    let mut truth = FreqTruth::default();
+    for key in &stream {
+        truth.observe(*key as i64);
+    }
+    let watched: Vec<i64> = truth.top_k(32).into_iter().map(|(k, _)| k).collect();
+
+    // Sizing pass: what does delta promotion spend over this stream?
+    let mut probe = OctoCs::new(workers, d, l, Route::HashByKey);
+    for (i, key) in stream.iter().enumerate() {
+        probe.insert(i, &DataInput::U64(*key));
+    }
+    let octo_counters = probe.sent_counters;
+    let (parity_period, ten_x_period) = merge_periods(octo_counters, d * l, n / workers);
+
+    let mut running = FreqTruth::default();
+    let mut octo = OctoCs::new(workers, d, l, Route::HashByKey);
+    let mut ideal = Cs::with_dimensions(d, l);
+    let mut parity = MergeCs::new(workers, d, l, parity_period);
+    let mut ten_x = MergeCs::new(workers, d, l, ten_x_period);
+    let (mut e_ideal, mut e_octo, mut e_parity, mut e_ten) = (0.0, 0.0, 0.0, 0.0);
+    let mut samples = 0usize;
+    let stride = n / 8;
+
+    for (i, key) in stream.iter().enumerate() {
+        let input = DataInput::U64(*key);
+        running.observe(*key as i64);
+        octo.insert(i, &input);
+        ideal.insert(&input);
+        parity.insert(i, &input);
+        ten_x.insert(i, &input);
+        if i > 0 && i % stride == stride / 3 {
+            for probe_key in &watched {
+                let probe_input = DataInput::U64(*probe_key as u64);
+                let exact = running.get(*probe_key) as f64;
+                e_ideal += (ideal.estimate(&probe_input) - exact).abs();
+                e_octo += (octo.parent.estimate(&probe_input) - exact).abs();
+                e_parity += (parity.parent.estimate(&probe_input) - exact).abs();
+                e_ten += (ten_x.parent.estimate(&probe_input) - exact).abs();
+                samples += 1;
+            }
+        }
+    }
+
+    let scale = samples as f64;
+    let comparison = OnlineComparison {
+        ideal: e_ideal / scale,
+        octo: e_octo / scale,
+        merge_at_parity: e_parity / scale,
+        merge_at_ten_x: e_ten / scale,
+        octo_counters,
+        parity_counters: parity.sent_counters,
+        ten_x_counters: ten_x.sent_counters,
+    };
+    comparison.report("Count");
+    comparison.assert_baselines_were_funded();
+    assert!(comparison.octo < comparison.merge_at_parity / 2.0);
+    assert!(comparison.octo < comparison.merge_at_ten_x);
+}
+
+// ---------------------------------------------------------------- HyperLogLog
+
+struct OctoHll {
+    children: Vec<HyperLogLog<Classic>>,
+    parent: HyperLogLog<Classic>,
+    sent_counters: usize,
+}
+
+impl OctoHll {
+    fn new(workers: usize) -> Self {
+        Self {
+            children: (0..workers).map(|_| HyperLogLog::default()).collect(),
+            parent: HyperLogLog::default(),
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = Route::HashByKey.worker(index, key, self.children.len());
+        let mut promoted = Vec::new();
+        self.children[worker].insert_emit_delta(key, &mut |d| promoted.push(d));
+        self.sent_counters += promoted.len();
+        for d in promoted {
+            self.parent.apply_delta(d);
+        }
+    }
+}
+
+struct MergeHll {
+    children: Vec<HyperLogLog<Classic>>,
+    seen: Vec<usize>,
+    parent: HyperLogLog<Classic>,
+    period: usize,
+    sent_counters: usize,
+}
+
+impl MergeHll {
+    fn new(workers: usize, period: usize) -> Self {
+        Self {
+            children: (0..workers).map(|_| HyperLogLog::default()).collect(),
+            seen: vec![0; workers],
+            parent: HyperLogLog::default(),
+            period,
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = Route::HashByKey.worker(index, key, self.children.len());
+        self.children[worker].insert(key);
+        self.seen[worker] += 1;
+        if self.seen[worker] % self.period == 0 {
+            // A max-merge does not clear the worker: its registers stay valid.
+            self.parent.merge(&self.children[worker]);
+            self.sent_counters += self.children[worker].registers_as_slice().len();
+        }
+    }
+}
+
+#[test]
+fn hyperloglog_online_accuracy_beats_sketch_merge() {
+    let (workers, n) = (4usize, 200_000usize);
+    let stream: Vec<u64> = (0..n as u64).collect();
+    let registers = HyperLogLog::<Classic>::default().registers_as_slice().len();
+
+    let mut probe = OctoHll::new(workers);
+    for (i, key) in stream.iter().enumerate() {
+        probe.insert(i, &DataInput::U64(*key));
+    }
+    let octo_counters = probe.sent_counters;
+    let (parity_period, ten_x_period) = merge_periods(octo_counters, registers, n / workers);
+
+    let mut octo = OctoHll::new(workers);
+    let mut ideal = HyperLogLog::<Classic>::default();
+    let mut parity = MergeHll::new(workers, parity_period);
+    let mut ten_x = MergeHll::new(workers, ten_x_period);
+    let (mut e_ideal, mut e_octo, mut e_parity, mut e_ten) = (0.0, 0.0, 0.0, 0.0);
+    let mut samples = 0usize;
+    let stride = n / 8;
+
+    for (i, key) in stream.iter().enumerate() {
+        let input = DataInput::U64(*key);
+        octo.insert(i, &input);
+        ideal.insert(&input);
+        parity.insert(i, &input);
+        ten_x.insert(i, &input);
+        if i > 0 && i % stride == stride / 3 {
+            // Every key so far is distinct, so the exact cardinality is i + 1.
+            let exact = (i + 1) as f64;
+            let rel = |estimate: usize| (estimate as f64 - exact).abs() / exact;
+            e_ideal += rel(ideal.estimate());
+            e_octo += rel(octo.parent.estimate());
+            e_parity += rel(parity.parent.estimate());
+            e_ten += rel(ten_x.parent.estimate());
+            samples += 1;
+        }
+    }
+
+    let scale = samples as f64;
+    let comparison = OnlineComparison {
+        ideal: e_ideal / scale,
+        octo: e_octo / scale,
+        merge_at_parity: e_parity / scale,
+        merge_at_ten_x: e_ten / scale,
+        octo_counters,
+        parity_counters: parity.sent_counters,
+        ten_x_counters: ten_x.sent_counters,
+    };
+    comparison.report("HLL");
+    comparison.assert_baselines_were_funded();
+    // Max-register promotion loses nothing, so the parent is the ideal sketch
+    // at every query point - not merely close to it.
+    assert_eq!(
+        comparison.octo, comparison.ideal,
+        "delta promotion must leave HLL exactly ideal online"
+    );
+    assert!(comparison.octo < comparison.merge_at_parity);
+    assert!(comparison.octo < comparison.merge_at_ten_x);
+}
+
+// -------------------------------------------------------------------- DDSketch
+
+struct OctoDd {
+    children: Vec<DdWorkerSketch>,
+    parent: DDSketch,
+    sent_counters: usize,
+}
+
+impl OctoDd {
+    fn new(workers: usize, alpha: f64) -> Self {
+        Self {
+            children: (0..workers).map(|_| DdWorkerSketch::new(alpha)).collect(),
+            parent: DDSketch::new(alpha),
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, value: f64, threshold: u32) {
+        let key = DataInput::F64(value);
+        let worker = Route::HashByKey.worker(index, &key, self.children.len());
+        let mut promoted = Vec::new();
+        self.children[worker].add_emit_delta(value, threshold, &mut |d| promoted.push(d));
+        self.sent_counters += promoted.len();
+        for d in promoted {
+            self.parent.apply_delta(d);
+        }
+    }
+}
+
+struct MergeDd {
+    children: Vec<DDSketch>,
+    seen: Vec<usize>,
+    parent: DDSketch,
+    period: usize,
+    alpha: f64,
+    sent_counters: usize,
+}
+
+impl MergeDd {
+    fn new(workers: usize, alpha: f64, period: usize) -> Self {
+        Self {
+            children: (0..workers).map(|_| DDSketch::new(alpha)).collect(),
+            seen: vec![0; workers],
+            parent: DDSketch::new(alpha),
+            period,
+            alpha,
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, value: f64) {
+        let worker = Route::HashByKey.worker(index, &DataInput::F64(value), self.children.len());
+        self.children[worker].add(&value);
+        self.seen[worker] += 1;
+        if self.seen[worker] % self.period == 0 {
+            self.sent_counters += self.children[worker].store_counts().len();
+            self.parent
+                .merge(&self.children[worker])
+                .expect("same alpha");
+            self.children[worker] = DDSketch::new(self.alpha);
+        }
+    }
+}
+
+/// Runs the DDSketch comparison over one value stream at one threshold.
+fn ddsketch_online_comparison(
+    label: &str,
+    values: &[f64],
+    alpha: f64,
+    threshold: u32,
+) -> OnlineComparison {
+    let workers = 4usize;
+    let n = values.len();
+
+    let mut sizing = DDSketch::new(alpha);
+    for v in values {
+        sizing.add(v);
+    }
+    let sketch_counters = sizing.store_counts().len();
+
+    let mut probe = OctoDd::new(workers, alpha);
+    for (i, v) in values.iter().enumerate() {
+        probe.insert(i, *v, threshold);
+    }
+    let octo_counters = probe.sent_counters;
+    let (parity_period, ten_x_period) = merge_periods(octo_counters, sketch_counters, n / workers);
+
+    let mut octo = OctoDd::new(workers, alpha);
+    let mut ideal = DDSketch::new(alpha);
+    let mut parity = MergeDd::new(workers, alpha, parity_period);
+    let mut ten_x = MergeDd::new(workers, alpha, ten_x_period);
+    let mut seen: Vec<f64> = Vec::with_capacity(n);
+    let (mut e_ideal, mut e_octo, mut e_parity, mut e_ten) = (0.0, 0.0, 0.0, 0.0);
+    let mut samples = 0usize;
+    let stride = n / 8;
+
+    for (i, v) in values.iter().enumerate() {
+        octo.insert(i, *v, threshold);
+        ideal.add(v);
+        parity.insert(i, *v);
+        ten_x.insert(i, *v);
+        seen.push(*v);
+        if i > 0 && i % stride == stride / 3 {
+            let mut sorted = seen.clone();
+            sorted.sort_by(f64::total_cmp);
+            for q in [0.1, 0.5, 0.9] {
+                let exact = sorted[((sorted.len() - 1) as f64 * q) as usize];
+                let rel = |sketch: &DDSketch| {
+                    sketch
+                        .get_value_at_quantile(q)
+                        .map(|got| (got - exact).abs() / exact)
+                        .unwrap_or(1.0)
+                };
+                e_ideal += rel(&ideal);
+                e_octo += rel(&octo.parent);
+                e_parity += rel(&parity.parent);
+                e_ten += rel(&ten_x.parent);
+                samples += 1;
+            }
+        }
+    }
+
+    let scale = samples as f64;
+    let comparison = OnlineComparison {
+        ideal: e_ideal / scale,
+        octo: e_octo / scale,
+        merge_at_parity: e_parity / scale,
+        merge_at_ten_x: e_ten / scale,
+        octo_counters,
+        parity_counters: parity.sent_counters,
+        ten_x_counters: ten_x.sent_counters,
+    };
+    comparison.report(label);
+    comparison
+}
+
+#[test]
+fn ddsketch_delta_promotion_trades_quantile_accuracy_for_messages() {
+    // DDSketch is the one integrated sketch where delta promotion does not pay
+    // off, and this pins the reason. A Count-Min counter that lags is still
+    // counted, just low; a DDSketch bucket that never reaches the threshold is
+    // absent from the parent entirely, and a quantile is exactly a statement
+    // about where the mass sits. Sparse buckets are also the common case: a
+    // logarithmic histogram over a skewed stream has many of them.
+    let (n, alpha) = (200_000usize, 0.01f64);
+    let values = common::exponential_f64(n, 0.05, 12_101)
+        .into_iter()
+        .map(|v| v.max(1e-3))
+        .collect::<Vec<f64>>();
+
+    let mut sweep: Vec<(u32, f64, usize)> = Vec::new();
+    for threshold in [1u32, 2, 4, 8] {
+        let result =
+            ddsketch_online_comparison(&format!("DDS/tau={threshold}"), &values, alpha, threshold);
+        sweep.push((threshold, result.octo, result.octo_counters));
+    }
+
+    // A threshold of 1 promotes every sample, so the parent is the ideal
+    // sketch - at the cost of one message per sample.
+    let (_, exact_error, exact_counters) = sweep[0];
+    assert_eq!(exact_counters, n, "tau=1 must promote every sample");
+    let ideal_error = ddsketch_online_comparison("DDS/ideal-ref", &values, alpha, 1).ideal;
+    assert!(
+        (exact_error - ideal_error).abs() < 1e-12,
+        "tau=1 must leave the parent exactly ideal: {exact_error} vs {ideal_error}"
+    );
+
+    // Above that, every step up buys fewer messages and costs accuracy.
+    for pair in sweep.windows(2) {
+        let (lo_tau, lo_error, lo_counters) = pair[0];
+        let (hi_tau, hi_error, hi_counters) = pair[1];
+        assert!(
+            hi_counters < lo_counters,
+            "tau {hi_tau} should send fewer counters than {lo_tau}: {hi_counters} vs {lo_counters}"
+        );
+        assert!(
+            hi_error >= lo_error,
+            "tau {hi_tau} should not be more accurate than {lo_tau}: {hi_error} vs {lo_error}"
+        );
+    }
+}
+
+// --------------------------------------------------------------------- UnivMon
+
+struct OctoUniv {
+    workers: Vec<UnivMonOctoWorker>,
+    aggregator: UnivMonOctoAggregator,
+    sent_counters: usize,
+}
+
+impl OctoUniv {
+    fn new(workers: usize, heap: usize, rows: usize, cols: usize, layers: usize, tau: u32) -> Self {
+        let threshold = OctoThreshold::new(tau);
+        Self {
+            workers: (0..workers)
+                .map(|id| {
+                    UnivMonOctoWorker::with_threshold(id, rows, cols, layers, threshold.clone())
+                })
+                .collect(),
+            aggregator: UnivMonOctoAggregator::new(heap, rows, cols, layers, tau),
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = Route::HashByKey.worker(index, key, self.workers.len());
+        let mut promoted = Vec::new();
+        self.workers[worker].process(key, &mut |d| promoted.push(d));
+        self.sent_counters += promoted.len();
+        for delta in promoted {
+            self.aggregator.apply(delta);
+        }
+    }
+}
+
+struct MergeUniv {
+    children: Vec<UnivMon>,
+    seen: Vec<usize>,
+    parent: UnivMon,
+    period: usize,
+    dims: (usize, usize, usize, usize),
+    sent_counters: usize,
+}
+
+impl MergeUniv {
+    fn new(
+        workers: usize,
+        heap: usize,
+        rows: usize,
+        cols: usize,
+        layers: usize,
+        period: usize,
+    ) -> Self {
+        Self {
+            children: (0..workers)
+                .map(|_| UnivMon::init_univmon(heap, rows, cols, layers))
+                .collect(),
+            seen: vec![0; workers],
+            parent: UnivMon::init_univmon(heap, rows, cols, layers),
+            period,
+            dims: (heap, rows, cols, layers),
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = Route::HashByKey.worker(index, key, self.children.len());
+        self.children[worker].insert(key, 1);
+        self.seen[worker] += 1;
+        if self.seen[worker] % self.period == 0 {
+            let (heap, rows, cols, layers) = self.dims;
+            self.parent.merge(&self.children[worker]);
+            self.children[worker] = UnivMon::init_univmon(heap, rows, cols, layers);
+            self.sent_counters += rows * cols * layers;
+        }
+    }
+}
+
+#[test]
+fn univmon_online_accuracy_beats_sketch_merge() {
+    // UnivMon's recursive estimator needs about log2(distinct) sampling layers
+    // before the deepest sampled substream fits the heap. This stream carries
+    // ~3.5k distinct keys, so 12 layers; too few and the sketch's own error
+    // swamps anything a distribution scheme does to it.
+    let (workers, heap, rows, cols, layers) = (4usize, 64usize, 5usize, 1_024usize, 12usize);
+    let n = 60_000usize;
+    let tau = COUNT_PROMASK;
+    let stream = zipf_u64(n, 4_096, 1.1, 12_201);
+
+    let mut probe = OctoUniv::new(workers, heap, rows, cols, layers, tau);
+    for (i, key) in stream.iter().enumerate() {
+        probe.insert(i, &DataInput::U64(*key));
+    }
+    let octo_counters = probe.sent_counters;
+    let (parity_period, ten_x_period) =
+        merge_periods(octo_counters, rows * cols * layers, n / workers);
+
+    let mut truth = FreqTruth::default();
+    let mut octo = OctoUniv::new(workers, heap, rows, cols, layers, tau);
+    let mut ideal = UnivMon::init_univmon(heap, rows, cols, layers);
+    let mut parity = MergeUniv::new(workers, heap, rows, cols, layers, parity_period);
+    let mut ten_x = MergeUniv::new(workers, heap, rows, cols, layers, ten_x_period);
+
+    let (mut e_ideal, mut e_octo, mut e_parity, mut e_ten) = (0.0, 0.0, 0.0, 0.0);
+    let mut samples = 0usize;
+    let stride = n / 8;
+
+    for (i, key) in stream.iter().enumerate() {
+        let input = DataInput::U64(*key);
+        truth.observe(*key as i64);
+        octo.insert(i, &input);
+        ideal.insert(&input, 1);
+        parity.insert(i, &input);
+        ten_x.insert(i, &input);
+        if i > 0 && i % stride == stride / 3 {
+            // UnivMon's headline queries are g-sums over the whole stream:
+            // distinct-count and Shannon entropy. Both are compared against the
+            // single-core sketch rather than against exact truth, which is the
+            // paper's Definition 1: what is being measured here is the gap a
+            // distributed scheme opens up, not UnivMon's own approximation
+            // error, which at these dimensions dwarfs it.
+            let (ideal_card, ideal_entropy) = (ideal.calc_card(), ideal.calc_entropy());
+            let gap_to_ideal = |sketch: &UnivMon| {
+                let card = (sketch.calc_card() - ideal_card).abs() / ideal_card.abs().max(1.0);
+                let entropy =
+                    (sketch.calc_entropy() - ideal_entropy).abs() / ideal_entropy.abs().max(1e-9);
+                (card + entropy) / 2.0
+            };
+            let exact_card = truth.distinct() as f64;
+            let exact_entropy = truth.entropy(true);
+            e_ideal += ((ideal_card - exact_card).abs() / exact_card
+                + (ideal_entropy - exact_entropy).abs() / exact_entropy.abs())
+                / 2.0;
+            e_octo += gap_to_ideal(&octo.aggregator.sketch);
+            e_parity += gap_to_ideal(&parity.parent);
+            e_ten += gap_to_ideal(&ten_x.parent);
+            samples += 1;
+        }
+    }
+
+    let scale = samples as f64;
+    let comparison = OnlineComparison {
+        ideal: e_ideal / scale,
+        octo: e_octo / scale,
+        merge_at_parity: e_parity / scale,
+        merge_at_ten_x: e_ten / scale,
+        octo_counters,
+        parity_counters: parity.sent_counters,
+        ten_x_counters: ten_x.sent_counters,
+    };
+    // `ideal` here is UnivMon's own error against exact truth, for context;
+    // the other three are gaps to that ideal, per Definition 1.
+    comparison.report("UnivMon");
+    comparison.assert_baselines_were_funded();
+    assert!(
+        comparison.octo < comparison.merge_at_parity / 2.0,
+        "delta promotion should track the single-core answer at least twice as closely \
+         at comparable budget: octo={:.4} merge={:.4}",
+        comparison.octo,
+        comparison.merge_at_parity
+    );
+    // Sketch-merge does close the gap - it just has to buy its way there. On
+    // this workload it needs an order of magnitude more traffic before it
+    // matches delta promotion, which is Theorem 2 showing up as a measurement.
+    assert!(
+        comparison.merge_at_ten_x < comparison.merge_at_parity,
+        "more budget must help the baseline"
+    );
+    assert!(
+        comparison.ten_x_counters as f64 / comparison.octo_counters as f64 > 10.0,
+        "the catch-up budget should be an order of magnitude larger"
+    );
+}
+
+#[test]
+fn univmon_heavy_hitter_recall_beats_sketch_merge() {
+    let (workers, heap, rows, cols, layers) = (4usize, 64usize, 5usize, 1_024usize, 12usize);
+    let n = 60_000usize;
+    let tau = COUNT_PROMASK;
+    let stream = zipf_u64(n, 4_096, 1.1, 12_203);
+
+    let mut truth = FreqTruth::default();
+    for key in &stream {
+        truth.observe(*key as i64);
+    }
+    let hottest: Vec<i64> = truth.top_k(16).into_iter().map(|(k, _)| k).collect();
+
+    let mut probe = OctoUniv::new(workers, heap, rows, cols, layers, tau);
+    for (i, key) in stream.iter().enumerate() {
+        probe.insert(i, &DataInput::U64(*key));
+    }
+    let (parity_period, _) = merge_periods(probe.sent_counters, rows * cols * layers, n / workers);
+
+    let mut octo = OctoUniv::new(workers, heap, rows, cols, layers, tau);
+    let mut parity = MergeUniv::new(workers, heap, rows, cols, layers, parity_period);
+    let (mut octo_recall, mut merge_recall) = (0.0, 0.0);
+    let mut samples = 0usize;
+    let stride = n / 8;
+
+    for (i, key) in stream.iter().enumerate() {
+        let input = DataInput::U64(*key);
+        octo.insert(i, &input);
+        parity.insert(i, &input);
+        if i > 0 && i % stride == stride / 3 {
+            let found = |sketch: &UnivMon| {
+                hottest
+                    .iter()
+                    .filter(|k| {
+                        sketch.hh_layers[0]
+                            .find(&DataInput::U64(**k as u64))
+                            .is_some()
+                    })
+                    .count() as f64
+                    / hottest.len() as f64
+            };
+            octo_recall += found(&octo.aggregator.sketch);
+            merge_recall += found(&parity.parent);
+            samples += 1;
+        }
+    }
+
+    let (octo_recall, merge_recall) = (octo_recall / samples as f64, merge_recall / samples as f64);
+    println!(
+        "UnivMon top-16 recall at layer 0: octo={octo_recall:.3} merge={merge_recall:.3} \
+         (merge spent {}x octo's counters)",
+        parity.sent_counters / probe.sent_counters.max(1)
+    );
+    assert!(
+        octo_recall >= merge_recall,
+        "the aggregator's heap should not trail sketch-merge: {octo_recall:.3} vs {merge_recall:.3}"
+    );
+    assert!(
+        octo_recall > 0.9,
+        "heavy hitters should be found nearly always, got {octo_recall:.3}"
     );
 }

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -23,10 +23,11 @@
 mod common;
 
 use asap_sketchlib::{
-    CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin, DDSketch, DataInput,
-    DdWorkerSketch, ErtlMLE, FastPath, HLL_PROMASK, HllDelta, HyperLogLog, HyperLogLogP12,
-    HyperLogLogP16, OctoAggregator, OctoThreshold, OctoWorker, RegularPath, UnivMon,
-    UnivMonOctoAggregator, UnivMonOctoWorker, Vector2D, hash64_seeded,
+    CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin, DD_PROMASK, DDSketch,
+    DataInput, DdWorkerSketch, ErtlMLE, FastPath, HLL_PROMASK, HllDelta, HyperLogLog,
+    HyperLogLogP12, HyperLogLogP16, OctoAggregator, OctoPlan, OctoThreshold, OctoWorker,
+    RegularPath, UnivMon, UnivMonOctoAggregator, UnivMonOctoPlan, UnivMonOctoWorker, Vector2D,
+    hash64_seeded,
 };
 use common::{FreqTruth, zipf_u64};
 use rand::SeedableRng;
@@ -714,9 +715,9 @@ fn hll_cardinality_survives_the_delta_round_trip_exactly() {
 mod runtime {
     use super::*;
     use asap_sketchlib::{
-        CmOctoAggregator, CmOctoWorker, CountOctoAggregator, CountOctoWorker, HllOctoAggregator,
-        HllOctoWorker, OctoAggregator, OctoConfig, OctoPartition, OctoRuntime, OctoWorker,
-        run_octo,
+        CmOctoAggregator, CmOctoPlan, CmTopKOctoAggregator, CmTopKOctoPlan, CountOctoAggregator,
+        CountOctoPlan, DdOctoAggregator, DdOctoPlan, HllOctoAggregator, HllOctoPlan,
+        OctoAggregator, OctoConfig, OctoPartition, OctoPlan, OctoRuntime, OctoWorker, run_octo,
     };
 
     fn config(num_workers: usize) -> OctoConfig {
@@ -733,7 +734,7 @@ mod runtime {
         run_octo(
             inputs,
             &config(workers),
-            |_| CmOctoWorker::new(rows, cols),
+            CmOctoPlan::new(rows, cols),
             || CmOctoAggregator {
                 sketch: Cm::with_dimensions(rows, cols),
             },
@@ -780,7 +781,7 @@ mod runtime {
             let got = run_octo(
                 &inputs,
                 &config(workers),
-                |_| CountOctoWorker::new(ROWS, COLS),
+                CountOctoPlan::new(ROWS, COLS),
                 || CountOctoAggregator {
                     sketch: Cs::with_dimensions(ROWS, COLS),
                 },
@@ -804,14 +805,11 @@ mod runtime {
         }
 
         for workers in [1usize, 2, 3, 4, 8] {
-            let got = run_octo(
-                &inputs,
-                &config(workers),
-                |_| HllOctoWorker::new(),
-                || HllOctoAggregator {
+            let got = run_octo(&inputs, &config(workers), HllOctoPlan::new(), || {
+                HllOctoAggregator {
                     sketch: HyperLogLog::<Classic>::default(),
-                },
-            )
+                }
+            })
             .parent
             .sketch;
             assert_eq!(
@@ -820,6 +818,49 @@ mod runtime {
                 "{workers} workers: HLL promotion must carry no partition penalty"
             );
         }
+    }
+
+    #[test]
+    fn run_octo_ddsketch_matches_a_single_threaded_replay() {
+        // Bucket deltas are additive, so the parent is a pure function of the
+        // partition and thread interleaving cannot change it.
+        let alpha = 0.01;
+        let values: Vec<f64> = (1..=40_000u64)
+            .map(|i| 1.0 + (i as f64 * 7.0) % 999.0)
+            .collect();
+        let inputs: Vec<DataInput<'_>> = values.iter().map(|v| DataInput::F64(*v)).collect();
+        let workers = 4usize;
+
+        let got = run_octo(&inputs, &config(workers), DdOctoPlan::new(alpha), || {
+            DdOctoAggregator::new(alpha)
+        })
+        .parent
+        .sketch;
+
+        let mut replay = OctoDd::new(workers, alpha);
+        for (i, value) in values.iter().enumerate() {
+            replay.insert(i, *value, DD_PROMASK);
+        }
+        // `run_octo` flushes when the stream ends, so the replay must too.
+        let mut children = std::mem::take(&mut replay.children);
+        for child in children.iter_mut() {
+            child.flush(&mut |d| replay.parent.apply_delta(d));
+        }
+
+        // The dense store grows in chunks anchored on whichever bucket is
+        // touched first, so its offset and array length depend on delta arrival
+        // order. What must match is the logical bucket-to-count mapping.
+        let buckets = |sketch: &DDSketch| -> Vec<(i32, u64)> {
+            sketch
+                .store_counts()
+                .iter()
+                .enumerate()
+                .filter(|(_, count)| **count != 0)
+                .map(|(i, count)| (sketch.store_offset() + i as i32, *count))
+                .collect()
+        };
+        assert_eq!(got.get_count(), replay.parent.get_count());
+        assert_eq!(buckets(&got), buckets(&replay.parent));
     }
 
     #[test]
@@ -839,13 +880,11 @@ mod runtime {
         let inputs = inputs_from(&keys(30_000, 512, 9_404));
         let batch = cm_runtime(&inputs, 4, ROWS, COLS);
 
-        let mut runtime = OctoRuntime::new(
-            &config(4),
-            |_| CmOctoWorker::new(ROWS, COLS),
-            || CmOctoAggregator {
+        let mut runtime = OctoRuntime::new(&config(4), CmOctoPlan::new(ROWS, COLS), || {
+            CmOctoAggregator {
                 sketch: Cm::with_dimensions(ROWS, COLS),
-            },
-        );
+            }
+        });
         for input in &inputs {
             runtime.insert(input.clone());
         }
@@ -858,24 +897,20 @@ mod runtime {
     fn insert_batch_matches_element_wise_inserts() {
         let inputs = inputs_from(&keys(20_000, 512, 9_405));
 
-        let mut one_by_one = OctoRuntime::new(
-            &config(3),
-            |_| CmOctoWorker::new(ROWS, COLS),
-            || CmOctoAggregator {
+        let mut one_by_one = OctoRuntime::new(&config(3), CmOctoPlan::new(ROWS, COLS), || {
+            CmOctoAggregator {
                 sketch: Cm::with_dimensions(ROWS, COLS),
-            },
-        );
+            }
+        });
         for input in &inputs {
             one_by_one.insert(input.clone());
         }
 
-        let mut batched = OctoRuntime::new(
-            &config(3),
-            |_| CmOctoWorker::new(ROWS, COLS),
-            || CmOctoAggregator {
+        let mut batched = OctoRuntime::new(&config(3), CmOctoPlan::new(ROWS, COLS), || {
+            CmOctoAggregator {
                 sketch: Cm::with_dimensions(ROWS, COLS),
-            },
-        );
+            }
+        });
         batched.insert_batch(&inputs);
 
         assert_eq!(
@@ -893,14 +928,9 @@ mod runtime {
             queue_capacity: 0,
             ..OctoConfig::default()
         };
-        let got = run_octo(
-            &inputs,
-            &cfg,
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
-        )
+        let got = run_octo(&inputs, &cfg, HllOctoPlan::new(), || HllOctoAggregator {
+            sketch: HyperLogLog::<Classic>::default(),
+        })
         .parent
         .sketch;
 
@@ -924,14 +954,9 @@ mod runtime {
             queue_capacity: 1,
             ..OctoConfig::default()
         };
-        let got = run_octo(
-            &inputs,
-            &cfg,
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
-        )
+        let got = run_octo(&inputs, &cfg, HllOctoPlan::new(), || HllOctoAggregator {
+            sketch: HyperLogLog::<Classic>::default(),
+        })
         .parent
         .sketch;
 
@@ -943,42 +968,72 @@ mod runtime {
     }
 
     #[test]
-    fn borrowed_string_inputs_survive_the_cross_thread_transport() {
-        let owned: Vec<String> = (0..5_000).map(|i| format!("session-{i:05}")).collect();
-        let inputs: Vec<DataInput<'_>> = owned.iter().map(|s| DataInput::Str(s)).collect();
-
-        let got = run_octo(
-            &inputs,
-            &config(4),
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
-                sketch: HyperLogLog::<Classic>::default(),
-            },
-        )
-        .parent
-        .sketch;
+    fn a_borrowed_key_may_be_dropped_the_moment_insert_returns() {
+        // The point of a borrowed key is that its owner does not have to
+        // outlive the sketch. `insert` hashes for partitioning and prepares the
+        // payload on this thread, so nothing borrowed crosses to a worker and
+        // the string below is free the instant the call returns.
+        //
+        // This used to be a use-after-free: `insert` transmuted the input to
+        // 'static and queued it, so workers hashed freed heap.
+        let n = 20_000u64;
+        let mut runtime = OctoRuntime::new(&config(4), HllOctoPlan::new(), HllOctoAggregator::new);
+        for i in 0..n {
+            let owned = format!("session-{i:020}");
+            runtime.insert(DataInput::Str(&owned));
+            drop(owned);
+        }
+        let got = runtime.finish().parent.sketch;
 
         let mut reference = HyperLogLog::<Classic>::default();
-        for input in &inputs {
-            reference.insert(input);
+        for i in 0..n {
+            reference.insert(&DataInput::Str(&format!("session-{i:020}")));
         }
         assert_eq!(
             got.registers_as_slice(),
             reference.registers_as_slice(),
-            "borrowed &str payloads must reach the workers intact"
+            "a key freed right after insert must still have been hashed correctly"
         );
     }
 
     #[test]
+    fn a_borrowed_key_reaches_a_keyed_aggregator_by_value() {
+        // A worker that stores keys copies at preparation, which is the one
+        // place a copy is unavoidable - and it happens on this thread, so the
+        // borrow still ends at the call.
+        let (rows, cols, top_k) = (4usize, 2048usize, 8usize);
+        let mut runtime = OctoRuntime::new(&config(4), CmTopKOctoPlan::new(rows, cols), || {
+            CmTopKOctoAggregator::new(rows, cols, top_k)
+        });
+        for _ in 0..4_000 {
+            for hot in 0..3usize {
+                let owned = format!("hot-{hot}");
+                runtime.insert(DataInput::Str(&owned));
+                drop(owned);
+            }
+        }
+        let result = runtime.finish();
+        for hot in 0..3usize {
+            let key = format!("hot-{hot}");
+            assert!(
+                result
+                    .parent
+                    .sketch
+                    .heap()
+                    .find(&DataInput::Str(&key))
+                    .is_some(),
+                "heavy hitter {key} missing from the aggregator heap"
+            );
+        }
+    }
+
+    #[test]
     fn an_empty_stream_finishes_with_a_pristine_parent() {
-        let got = run_octo(
-            &[],
-            &config(4),
-            |_| CmOctoWorker::new(ROWS, COLS),
-            || CmOctoAggregator {
+        let got = run_octo(&[], &config(4), CmOctoPlan::new(ROWS, COLS), || {
+            CmOctoAggregator {
                 sketch: Cm::with_dimensions(ROWS, COLS),
-            },
-        )
+            }
+        })
         .parent
         .sketch;
         assert!(cm_cells(&got).iter().all(|&c| c == 0));
@@ -1000,8 +1055,9 @@ mod runtime {
 
     impl OctoWorker for SumWorker {
         type Delta = SumDelta;
+        type Payload = ();
 
-        fn process<F>(&mut self, _input: &DataInput, emit: &mut F)
+        fn process<F>(&mut self, _payload: &(), emit: &mut F)
         where
             F: FnMut(Self::Delta),
         {
@@ -1011,6 +1067,18 @@ mod runtime {
                 keys_seen: 1,
             });
         }
+    }
+
+    struct SumPlan;
+
+    impl OctoPlan for SumPlan {
+        type Worker = SumWorker;
+
+        fn worker(&self, worker_id: usize) -> Self::Worker {
+            SumWorker { worker_id, seen: 0 }
+        }
+
+        fn prepare(&self, _input: &DataInput<'_>) {}
     }
 
     struct SumAggregator {
@@ -1035,14 +1103,9 @@ mod runtime {
             partition: OctoPartition::RoundRobin,
             ..config(workers)
         };
-        let result = run_octo(
-            &inputs,
-            &cfg,
-            |worker_id| SumWorker { worker_id, seen: 0 },
-            || SumAggregator {
-                per_worker: vec![0; workers],
-            },
-        );
+        let result = run_octo(&inputs, &cfg, SumPlan, || SumAggregator {
+            per_worker: vec![0; workers],
+        });
 
         assert_eq!(
             result.parent.per_worker.iter().sum::<u64>(),
@@ -1061,13 +1124,9 @@ mod runtime {
     fn the_read_handle_observes_a_monotone_prefix_of_the_final_state() {
         let workers = 2;
         let n = 4_000u64;
-        let mut runtime = OctoRuntime::new(
-            &config(workers),
-            |worker_id| SumWorker { worker_id, seen: 0 },
-            || SumAggregator {
-                per_worker: vec![0; workers],
-            },
-        );
+        let mut runtime = OctoRuntime::new(&config(workers), SumPlan, || SumAggregator {
+            per_worker: vec![0; workers],
+        });
         let reader = runtime.read_handle();
 
         assert_eq!(
@@ -1115,13 +1174,9 @@ mod runtime {
     #[should_panic(expected = "Octo runtime has been finished")]
     fn reading_through_a_stale_handle_panics() {
         let workers = 2;
-        let runtime = OctoRuntime::new(
-            &config(workers),
-            |worker_id| SumWorker { worker_id, seen: 0 },
-            || SumAggregator {
-                per_worker: vec![0; workers],
-            },
-        );
+        let runtime = OctoRuntime::new(&config(workers), SumPlan, || SumAggregator {
+            per_worker: vec![0; workers],
+        });
         let reader = runtime.read_handle();
         let _ = runtime.finish();
         reader.with_parent(|p| p.per_worker.len());
@@ -1131,13 +1186,9 @@ mod runtime {
     fn close_is_idempotent_and_preserves_already_queued_work() {
         let workers = 4;
         let n = 3_001u64;
-        let mut runtime = OctoRuntime::new(
-            &config(workers),
-            |worker_id| SumWorker { worker_id, seen: 0 },
-            || SumAggregator {
-                per_worker: vec![0; workers],
-            },
-        );
+        let mut runtime = OctoRuntime::new(&config(workers), SumPlan, || SumAggregator {
+            per_worker: vec![0; workers],
+        });
         for i in 0..n {
             runtime.insert(DataInput::U64(i));
         }
@@ -1156,13 +1207,9 @@ mod runtime {
     #[should_panic(expected = "cannot insert after runtime has been closed")]
     fn inserting_after_close_panics() {
         let workers = 2;
-        let mut runtime = OctoRuntime::new(
-            &config(workers),
-            |worker_id| SumWorker { worker_id, seen: 0 },
-            || SumAggregator {
-                per_worker: vec![0; workers],
-            },
-        );
+        let mut runtime = OctoRuntime::new(&config(workers), SumPlan, || SumAggregator {
+            per_worker: vec![0; workers],
+        });
         runtime.close();
         runtime.insert(DataInput::U64(1));
     }
@@ -1207,14 +1254,11 @@ mod runtime {
     fn run_octo_hll_cardinality_error_stays_within_three_sigma() {
         let truth = 200_000u64;
         let inputs = inputs_from(&(0..truth).collect::<Vec<_>>());
-        let got = run_octo(
-            &inputs,
-            &config(4),
-            |_| HllOctoWorker::new(),
-            || HllOctoAggregator {
+        let got = run_octo(&inputs, &config(4), HllOctoPlan::new(), || {
+            HllOctoAggregator {
                 sketch: HyperLogLog::<Classic>::default(),
-            },
-        )
+            }
+        })
         .parent
         .sketch;
 
@@ -1245,14 +1289,11 @@ mod runtime {
             truth.observe(*k as i64);
         }
 
-        let parent = run_octo(
-            &inputs,
-            &config(4),
-            |_| CountOctoWorker::new(rows, cols),
-            || CountOctoAggregator {
+        let parent = run_octo(&inputs, &config(4), CountOctoPlan::new(rows, cols), || {
+            CountOctoAggregator {
                 sketch: Cs::with_dimensions(rows, cols),
-            },
-        )
+            }
+        })
         .parent
         .sketch;
 
@@ -2422,6 +2463,7 @@ fn ddsketch_delta_promotion_trades_quantile_accuracy_for_messages() {
 // --------------------------------------------------------------------- UnivMon
 
 struct OctoUniv {
+    plan: UnivMonOctoPlan,
     workers: Vec<UnivMonOctoWorker>,
     aggregator: UnivMonOctoAggregator,
     sent_counters: usize,
@@ -2430,21 +2472,20 @@ struct OctoUniv {
 impl OctoUniv {
     fn new(workers: usize, heap: usize, rows: usize, cols: usize, layers: usize, tau: u32) -> Self {
         let threshold = OctoThreshold::new(tau);
+        let plan = UnivMonOctoPlan::with_threshold(rows, cols, layers, threshold.clone());
         Self {
-            workers: (0..workers)
-                .map(|id| {
-                    UnivMonOctoWorker::with_threshold(id, rows, cols, layers, threshold.clone())
-                })
-                .collect(),
-            aggregator: UnivMonOctoAggregator::new(heap, rows, cols, layers, tau),
+            workers: (0..workers).map(|id| plan.worker(id)).collect(),
+            plan,
+            aggregator: UnivMonOctoAggregator::with_threshold(heap, rows, cols, layers, threshold),
             sent_counters: 0,
         }
     }
 
     fn insert(&mut self, index: usize, key: &DataInput) {
         let worker = Route::HashByKey.worker(index, key, self.workers.len());
+        let payload = self.plan.prepare(key);
         let mut promoted = Vec::new();
-        self.workers[worker].process(key, &mut |d| promoted.push(d));
+        self.workers[worker].process(&payload, &mut |d| promoted.push(d));
         self.sent_counters += promoted.len();
         for delta in promoted {
             self.aggregator.apply(delta);

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -8,6 +8,14 @@
 //! updates (`+=` for the counter sketches, `max` for HLL registers). Thread
 //! interleaving therefore cannot change the parent, so every runtime test here
 //! asserts *exact* equality against a replay instead of a statistical band.
+//!
+//! The second half checks the implementation against the OctoSketch paper
+//! itself (NSDI '24, Zhang/Chen/Liu): whether estimates land inside Theorems
+//! 1, 3 and 4, and whether delta promotion actually beats the periodic
+//! sketch-merge baseline the paper measures against (Theorem 2, Figure 6).
+//! `run_octo` dispatches round-robin, so every key reaches every worker and
+//! the paper's k' - the number of workers a flow may pass by - equals k here,
+//! the worst case each of those bounds admits.
 
 mod common;
 
@@ -16,7 +24,7 @@ use asap_sketchlib::{
     FastPath, HLL_PROMASK, HllDelta, HyperLogLog, HyperLogLogP12, HyperLogLogP16, RegularPath,
     Vector2D,
 };
-use common::zipf_u64;
+use common::{FreqTruth, zipf_u64};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -29,10 +37,12 @@ type CsFast = Count<Vector2D<i32>, FastPath>;
 const ROWS: usize = 5;
 const COLS: usize = 2048;
 
+/// τ in the paper's notation (NSDI '24, §4.1): the worker promotion threshold.
+const TAU: i32 = CM_PROMASK as i32;
+
 /// Largest amount a single cell can lag its exact count: promotion fires at a
-/// multiple of the mask, so at most `mask - 1` un-promoted increments remain.
-/// This is τ in the OctoSketch paper's notation (NSDI '24, §4.1).
-const MAX_CELL_RESIDUAL: i32 = CM_PROMASK as i32 - 1;
+/// multiple of τ, so at most `τ - 1` un-promoted increments remain.
+const MAX_CELL_RESIDUAL: i32 = TAU - 1;
 
 fn keys(n: usize, domain: usize, seed: u64) -> Vec<u64> {
     zipf_u64(n, domain, 1.1, seed)
@@ -689,35 +699,20 @@ mod runtime {
         .sketch
     }
 
-    /// Single-threaded replay of the runtime's round-robin dispatch.
     fn cm_replay(inputs: &[DataInput<'_>], workers: usize, rows: usize, cols: usize) -> Cm {
-        let mut children: Vec<Cm> = (0..workers)
-            .map(|_| Cm::with_dimensions(rows, cols))
-            .collect();
-        let mut parent = Cm::with_dimensions(rows, cols);
+        let mut replay = OctoCm::new(workers, rows, cols);
         for (i, input) in inputs.iter().enumerate() {
-            let mut out = Vec::new();
-            children[i % workers].insert_emit_delta(input, &mut |d| out.push(d));
-            for d in out {
-                parent.apply_delta(d);
-            }
+            replay.insert(i, input);
         }
-        parent
+        replay.parent
     }
 
     fn cs_replay(inputs: &[DataInput<'_>], workers: usize, rows: usize, cols: usize) -> Cs {
-        let mut children: Vec<Cs> = (0..workers)
-            .map(|_| Cs::with_dimensions(rows, cols))
-            .collect();
-        let mut parent = Cs::with_dimensions(rows, cols);
+        let mut replay = OctoCs::new(workers, rows, cols);
         for (i, input) in inputs.iter().enumerate() {
-            let mut out = Vec::new();
-            children[i % workers].insert_emit_delta(input, &mut |d| out.push(d));
-            for d in out {
-                parent.apply_delta(d);
-            }
+            replay.insert(i, input);
         }
-        parent
+        replay.parent
     }
 
     #[test]
@@ -1108,7 +1103,7 @@ mod runtime {
         let stream = keys(200_000, 4_096, 9_501);
         let inputs = inputs_from(&stream);
 
-        let mut truth = common::FreqTruth::default();
+        let mut truth = FreqTruth::default();
         for k in &stream {
             truth.observe(*k as i64);
         }
@@ -1166,7 +1161,7 @@ mod runtime {
         let stream = keys(200_000, 2_048, 9_502);
         let inputs = inputs_from(&stream);
 
-        let mut truth = common::FreqTruth::default();
+        let mut truth = FreqTruth::default();
         for k in &stream {
             truth.observe(*k as i64);
         }
@@ -1198,4 +1193,556 @@ mod runtime {
             "count-sketch estimates outside ±{tolerance:.1}: {violations:?}"
         );
     }
+}
+
+// ===========================================================================
+// Paper conformance: OctoSketch (NSDI '24) Theorems 1-4 and its baseline
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Replays: OctoSketch delta promotion vs. the periodic sketch-merge baseline
+// ---------------------------------------------------------------------------
+
+/// OctoSketch: workers promote single counters once they cross τ.
+struct OctoCm {
+    children: Vec<Cm>,
+    parent: Cm,
+    /// Counters shipped to the aggregator, the unit Theorem 2 counts in.
+    sent_counters: usize,
+}
+
+impl OctoCm {
+    fn new(workers: usize, rows: usize, cols: usize) -> Self {
+        Self {
+            children: (0..workers)
+                .map(|_| Cm::with_dimensions(rows, cols))
+                .collect(),
+            parent: Cm::with_dimensions(rows, cols),
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = index % self.children.len();
+        let mut promoted = Vec::new();
+        self.children[worker].insert_emit_delta(key, &mut |d| promoted.push(d));
+        self.sent_counters += promoted.len();
+        for d in promoted {
+            self.parent.apply_delta(d);
+        }
+    }
+}
+
+/// Sketch-merge: each worker keeps a full sketch and ships all `rows*cols`
+/// counters every `period` items it sees, then restarts from zero.
+struct MergeCm {
+    children: Vec<Cm>,
+    seen: Vec<usize>,
+    parent: Cm,
+    period: usize,
+    rows: usize,
+    cols: usize,
+    sent_counters: usize,
+}
+
+impl MergeCm {
+    fn new(workers: usize, rows: usize, cols: usize, period: usize) -> Self {
+        Self {
+            children: (0..workers)
+                .map(|_| Cm::with_dimensions(rows, cols))
+                .collect(),
+            seen: vec![0; workers],
+            parent: Cm::with_dimensions(rows, cols),
+            period,
+            rows,
+            cols,
+            sent_counters: 0,
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = index % self.children.len();
+        self.children[worker].insert(key);
+        self.seen[worker] += 1;
+        if self.seen[worker] % self.period == 0 {
+            self.parent.merge(&self.children[worker]);
+            self.children[worker] = Cm::with_dimensions(self.rows, self.cols);
+            self.sent_counters += self.rows * self.cols;
+        }
+    }
+}
+
+/// Count-sketch flavour of `OctoCm`; the worker zeroes the counter on promotion.
+struct OctoCs {
+    children: Vec<Cs>,
+    parent: Cs,
+}
+
+impl OctoCs {
+    fn new(workers: usize, rows: usize, cols: usize) -> Self {
+        Self {
+            children: (0..workers)
+                .map(|_| Cs::with_dimensions(rows, cols))
+                .collect(),
+            parent: Cs::with_dimensions(rows, cols),
+        }
+    }
+
+    fn insert(&mut self, index: usize, key: &DataInput) {
+        let worker = index % self.children.len();
+        let mut promoted = Vec::new();
+        self.children[worker].insert_emit_delta(key, &mut |d| promoted.push(d));
+        for d in promoted {
+            self.parent.apply_delta(d);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Theorem 1: Count-Min error bound
+// ---------------------------------------------------------------------------
+
+#[test]
+fn theorem_1_bounds_the_count_min_error() {
+    // "let d = log2 δ⁻¹ and l = 2ε⁻¹. For any flow e and any traffic whose
+    //  L1 > ε⁻¹k'τ, Pr[|f̂(e) − f(e)| > εL1] < δ"
+    let d = 5usize;
+    let l = 4096usize;
+    let workers = 4usize;
+    let epsilon = 2.0 / l as f64;
+    let delta = 2f64.powi(-(d as i32));
+    let k_prime_tau = (workers as i32 * TAU) as f64;
+
+    let stream = zipf_u64(400_000, 8_192, 1.1, 11_001);
+    let mut truth = FreqTruth::default();
+    let mut octo = OctoCm::new(workers, d, l);
+    for (i, key) in stream.iter().enumerate() {
+        truth.observe(*key as i64);
+        octo.insert(i, &DataInput::U64(*key));
+    }
+
+    let l1 = truth.total() as f64;
+    assert!(
+        l1 > k_prime_tau / epsilon,
+        "theorem precondition L1 > ε⁻¹k'τ unmet: L1 = {l1}, ε⁻¹k'τ = {}",
+        k_prime_tau / epsilon
+    );
+
+    let band = epsilon * l1;
+    let mut violations = 0usize;
+    let mut worst_deficit = 0.0f64;
+    let mut worst_excess = 0.0f64;
+    let pairs = truth.pairs();
+    for (key, exact) in &pairs {
+        let est = octo.parent.estimate(&DataInput::U64(*key as u64)) as f64;
+        let exact = *exact as f64;
+        if (est - exact).abs() > band {
+            violations += 1;
+        }
+        worst_deficit = worst_deficit.max(exact - est);
+        worst_excess = worst_excess.max(est - exact);
+    }
+
+    // The proof's deterministic half: f̂ ≤ f̂' and |f̂' − f̂| < k'τ, and Count-Min
+    // never underestimates, so f(e) − k'τ < f̂(e) for *every* key, not merely
+    // with probability 1 − δ.
+    assert!(
+        worst_deficit < k_prime_tau,
+        "worst underestimate {worst_deficit} reached the k'τ = {k_prime_tau} ceiling"
+    );
+
+    let rate = violations as f64 / pairs.len() as f64;
+    println!(
+        "Theorem 1: eps={epsilon:.2e} delta={delta:.4} eps*L1={band:.1} k'tau={k_prime_tau} \
+         violations={rate:.5} worst_deficit={worst_deficit} worst_excess={worst_excess}"
+    );
+    assert!(
+        rate < delta,
+        "violation rate {rate:.5} exceeded δ = {delta:.5} over {} keys",
+        pairs.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Theorem 3: Count sketch error bound
+// ---------------------------------------------------------------------------
+
+#[test]
+fn theorem_3_bounds_the_count_sketch_error() {
+    // "let d = O(log2 δ⁻¹) and l = 8ε⁻². For any flow e and any traffic whose
+    //  L2 > 2ε⁻¹k'τ, Pr[|f̂(e) − f(e)| > εL2] < δ"
+    assert_eq!(
+        COUNT_PROMASK, CM_PROMASK,
+        "both sketches share one τ in this implementation"
+    );
+    let d = 5usize;
+    let l = 4096usize;
+    let workers = 4usize;
+    let epsilon = (8.0 / l as f64).sqrt();
+    let delta = 2f64.powi(-(d as i32));
+    let k_prime_tau = (workers as i32 * TAU) as f64;
+
+    let stream = zipf_u64(400_000, 8_192, 1.1, 11_003);
+    let mut truth = FreqTruth::default();
+    let mut octo = OctoCs::new(workers, d, l);
+    let mut single_core = Cs::with_dimensions(d, l);
+    for (i, key) in stream.iter().enumerate() {
+        truth.observe(*key as i64);
+        octo.insert(i, &DataInput::U64(*key));
+        single_core.insert(&DataInput::U64(*key));
+    }
+
+    let l2 = truth.l2_norm();
+    assert!(
+        l2 > 2.0 * k_prime_tau / epsilon,
+        "theorem precondition L2 > 2ε⁻¹k'τ unmet: L2 = {l2}, 2ε⁻¹k'τ = {}",
+        2.0 * k_prime_tau / epsilon
+    );
+
+    let band = epsilon * l2;
+    let mut violations = 0usize;
+    let mut worst_octo_gap = 0.0f64;
+    let pairs = truth.pairs();
+    for (key, exact) in &pairs {
+        let input = DataInput::U64(*key as u64);
+        let est = octo.parent.estimate(&input);
+        if (est - *exact as f64).abs() > band {
+            violations += 1;
+        }
+        // The proof's deterministic half: |f̂'(e) − f̂(e)| < k'τ.
+        worst_octo_gap = worst_octo_gap.max((single_core.estimate(&input) - est).abs());
+    }
+
+    assert!(
+        worst_octo_gap < k_prime_tau,
+        "gap to the single-core sketch {worst_octo_gap} reached the k'τ = {k_prime_tau} ceiling"
+    );
+
+    let rate = violations as f64 / pairs.len() as f64;
+    println!(
+        "Theorem 3: eps={epsilon:.4} delta={delta:.4} eps*L2={band:.1} k'tau={k_prime_tau} \
+         violations={rate:.5} worst_gap_to_single_core={worst_octo_gap}"
+    );
+    assert!(
+        rate < delta,
+        "violation rate {rate:.5} exceeded δ = {delta:.5} over {} keys",
+        pairs.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Theorem 4: HyperLogLog exactness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn theorem_4_holds_unconditionally_because_this_implementation_pins_tau_to_zero() {
+    // Theorem 4 only promises Ẑ = Ẑ' once Ẑ > 2·α_m·m²·2^(τ−2), because a
+    // worker holds back register improvements below τ−1. This implementation
+    // sets HLL_PROMASK = 0, so C'[i] = C[i] for every i and the equality holds
+    // at any cardinality - including ones orders of magnitude below the
+    // precondition the paper would otherwise need.
+    assert_eq!(HLL_PROMASK, 0);
+
+    let m = HyperLogLog::<Classic>::default().registers_as_slice().len() as f64;
+    let alpha_m = 0.7213 / (1.0 + 1.079 / m);
+    // The precondition evaluated at the smallest threshold the paper suggests
+    // for HLL (Appendix B: "the threshold τ = 2 is often enough").
+    let precondition = 2.0 * alpha_m * m * m * 2f64.powi(2 - 2);
+
+    for n in [10u64, 100, 1_000, 10_000] {
+        let mut child = HyperLogLog::<Classic>::default();
+        let mut parent = HyperLogLog::<Classic>::default();
+        for i in 0..n {
+            child.insert_emit_delta(&DataInput::U64(i), &mut |d| parent.apply_delta(d));
+        }
+        let mut ideal = HyperLogLog::<Classic>::default();
+        for i in 0..n {
+            ideal.insert(&DataInput::U64(i));
+        }
+
+        assert!(
+            (n as f64) < precondition,
+            "n = {n} is above the paper's precondition {precondition:.3e}, \
+             so this case would not demonstrate the unconditional guarantee"
+        );
+        assert_eq!(
+            parent.registers_as_slice(),
+            ideal.registers_as_slice(),
+            "n = {n}: Ẑ' must equal Ẑ even far below the τ = 2 precondition"
+        );
+        assert_eq!(parent.estimate(), ideal.estimate(), "n = {n}");
+    }
+    println!(
+        "Theorem 4: tau=0 gives Z' = Z unconditionally; the tau=2 precondition \
+         would only bind above Z > {precondition:.3e}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Theorem 2: communication cost against sketch-merge
+// ---------------------------------------------------------------------------
+
+#[test]
+fn theorem_2_delta_promotion_sends_l_times_fewer_counters_for_the_same_goal() {
+    // "To achieve the accuracy goal, sketch-merge needs to send O(Δ⁻¹·k·N·d·l)
+    //  counters, while OctoSketch needs to send O(Δ⁻¹·k·N·d) counters."
+    //
+    // The proof holds both sides to the same accuracy goal Δ: sketch-merge
+    // ships the whole sketch every Δ/k items per worker, and OctoSketch sets
+    // its threshold to τ = Δ/k. This implementation pins τ = 31, so the goal
+    // it is solving for is Δ = k·τ.
+    let d = 3usize;
+    let l = 1_024usize;
+    let workers = 4usize;
+    let accuracy_goal = (workers as i32 * TAU) as f64;
+    let merge_period = TAU as usize;
+
+    let stream = zipf_u64(40_000, 2_048, 1.1, 11_005);
+    let mut octo = OctoCm::new(workers, d, l);
+    let mut merge = MergeCm::new(workers, d, l, merge_period);
+    let mut single_core = Cm::with_dimensions(d, l);
+    for (i, key) in stream.iter().enumerate() {
+        let input = DataInput::U64(*key);
+        octo.insert(i, &input);
+        merge.insert(i, &input);
+        single_core.insert(&input);
+    }
+
+    // Both configurations must actually meet the goal before their costs are
+    // comparable - that is the premise of the theorem, not a side check.
+    let mut worst_octo = 0.0f64;
+    let mut worst_merge = 0.0f64;
+    for key in 0u64..2_048 {
+        let input = DataInput::U64(key);
+        let ideal = single_core.estimate(&input) as f64;
+        worst_octo = worst_octo.max(ideal - octo.parent.estimate(&input) as f64);
+        worst_merge = worst_merge.max(ideal - merge.parent.estimate(&input) as f64);
+    }
+    assert!(
+        worst_octo <= accuracy_goal,
+        "octo missed the accuracy goal: {worst_octo} > {accuracy_goal}"
+    );
+    assert!(
+        worst_merge <= accuracy_goal,
+        "sketch-merge missed the accuracy goal: {worst_merge} > {accuracy_goal}"
+    );
+
+    let ratio = merge.sent_counters as f64 / octo.sent_counters as f64;
+    println!(
+        "Theorem 2: goal={accuracy_goal} octo_counters={} merge_counters={} ratio={ratio:.0}x (l={l})",
+        octo.sent_counters, merge.sent_counters
+    );
+    assert!(
+        ratio > l as f64 / 4.0,
+        "expected roughly an l = {l} fold saving, measured {ratio:.0}x"
+    );
+
+    // Counting bytes rather than counters keeps the claim honest: an Octo
+    // message carries indices as well as a value, a merged counter does not.
+    let octo_bytes = octo.sent_counters * std::mem::size_of::<CmDelta>();
+    let merge_bytes = merge.sent_counters * std::mem::size_of::<i32>();
+    let byte_ratio = merge_bytes as f64 / octo_bytes as f64;
+    println!("Theorem 2 (bytes): octo={octo_bytes} merge={merge_bytes} ratio={byte_ratio:.0}x");
+    assert!(
+        byte_ratio > l as f64 / 16.0,
+        "byte-level saving {byte_ratio:.0}x is smaller than expected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Figure 6 / Table 1: online accuracy against sketch-merge
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delta_promotion_beats_sketch_merge_on_online_accuracy() {
+    // The paper's headline claim is *online* accuracy: the error a query sees
+    // while the stream is still running. Sketch-merge is stale by up to one
+    // merge period; delta promotion is stale by at most k'τ whatever the
+    // arrival rate. Sweeping the baseline's communication budget from parity
+    // up to 10x Octo's shows the gap is a property of the mechanism, not of a
+    // budget chosen to flatter it.
+    let d = 3usize;
+    let l = 1_024usize;
+    let workers = 4usize;
+    let n = 60_000usize;
+    let checkpoints = 8usize;
+    let budget_multiples = [1usize, 10];
+
+    let stream = zipf_u64(n, 4_096, 1.1, 11_007);
+    let mut final_truth = FreqTruth::default();
+    for key in &stream {
+        final_truth.observe(*key as i64);
+    }
+    let watched: Vec<i64> = final_truth.top_k(32).into_iter().map(|(k, _)| k).collect();
+
+    // Sizing pass: what does delta promotion spend over this stream?
+    let mut probe = OctoCm::new(workers, d, l);
+    for (i, key) in stream.iter().enumerate() {
+        probe.insert(i, &DataInput::U64(*key));
+    }
+    let mut merges: Vec<MergeCm> = budget_multiples
+        .iter()
+        .map(|mult| {
+            let merges_per_worker = ((mult * probe.sent_counters) / (d * l))
+                .div_ceil(workers)
+                .max(1);
+            MergeCm::new(workers, d, l, (n / workers) / merges_per_worker)
+        })
+        .collect();
+
+    let mut truth = FreqTruth::default();
+    let mut octo = OctoCm::new(workers, d, l);
+    let mut single_core = Cm::with_dimensions(d, l);
+    let mut octo_error = 0.0f64;
+    let mut ideal_error = 0.0f64;
+    let mut merge_error = vec![0.0f64; merges.len()];
+    let mut samples = 0usize;
+    let stride = n / checkpoints;
+
+    for (i, key) in stream.iter().enumerate() {
+        let input = DataInput::U64(*key);
+        truth.observe(*key as i64);
+        octo.insert(i, &input);
+        single_core.insert(&input);
+        for merge in merges.iter_mut() {
+            merge.insert(i, &input);
+        }
+
+        // Query at points that deliberately do not line up with a merge
+        // boundary: an online query arrives whenever it arrives.
+        if i > 0 && i % stride == stride / 3 {
+            for watched_key in &watched {
+                let probe_input = DataInput::U64(*watched_key as u64);
+                let exact = truth.get(*watched_key) as f64;
+                octo_error += (octo.parent.estimate(&probe_input) as f64 - exact).abs();
+                ideal_error += (single_core.estimate(&probe_input) as f64 - exact).abs();
+                for (slot, merge) in merge_error.iter_mut().zip(merges.iter()) {
+                    *slot += (merge.parent.estimate(&probe_input) as f64 - exact).abs();
+                }
+                samples += 1;
+            }
+        }
+    }
+
+    let octo_mae = octo_error / samples as f64;
+    let ideal_mae = ideal_error / samples as f64;
+    println!("Online accuracy over {samples} queries: ideal={ideal_mae:.1} octo={octo_mae:.1}");
+    for ((mult, merge), error) in budget_multiples
+        .iter()
+        .zip(merges.iter())
+        .zip(merge_error.iter())
+    {
+        let merge_mae = error / samples as f64;
+        let spend = merge.sent_counters as f64 / octo.sent_counters as f64;
+        println!(
+            "  merge at {mult}x budget (period={}, actual spend {spend:.1}x): \
+             mae={merge_mae:.1} = {:.1}x octo",
+            merge.period,
+            merge_mae / octo_mae
+        );
+        assert!(
+            merge.sent_counters > octo.sent_counters,
+            "the baseline must not be starved of budget for this comparison to mean anything"
+        );
+        // Empirical and deliberately loose: measured 9.3x at parity - within
+        // noise of the paper's 9.32x for Count-Min - and 2.8x at 10x budget.
+        assert!(
+            merge_mae > octo_mae * 2.0,
+            "delta promotion should stay well ahead at {mult}x budget: \
+             octo={octo_mae:.1} vs merge={merge_mae:.1}"
+        );
+    }
+
+    let parity_mae = merge_error[0] / samples as f64;
+    assert!(
+        parity_mae > octo_mae * 5.0,
+        "at equal communication budget the gap should be large: \
+         octo={octo_mae:.1} vs merge={parity_mae:.1}"
+    );
+    assert!(
+        octo_mae <= ideal_mae + (workers as i32 * TAU) as f64,
+        "octo online error {octo_mae:.1} drifted more than k'τ from ideal {ideal_mae:.1}"
+    );
+}
+
+#[test]
+fn sketch_merge_staleness_grows_with_the_merge_period_while_promotion_does_not() {
+    // The mechanism behind the previous test, isolated: sketch-merge error is
+    // proportional to its period, delta promotion error is capped at k'τ no
+    // matter how much traffic arrives between queries. The deficit is averaged
+    // over many query points - sampling only at the end of the stream would
+    // land on a merge boundary whenever the period divides the per-worker
+    // item count, and report a staleness of zero.
+    let d = 3usize;
+    let l = 1_024usize;
+    let workers = 4usize;
+    let n = 40_000usize;
+    let query_points = 40usize;
+    let stream = zipf_u64(n, 2_048, 1.1, 11_009);
+
+    let mut whole_stream_truth = FreqTruth::default();
+    for key in &stream {
+        whole_stream_truth.observe(*key as i64);
+    }
+    let hottest = whole_stream_truth.top_k(1)[0].0;
+    let probe = DataInput::U64(hottest as u64);
+
+    let periods = [500usize, 1_000, 2_000, 4_000];
+    let mut truth = FreqTruth::default();
+    let mut octo = OctoCm::new(workers, d, l);
+    let mut merges: Vec<MergeCm> = periods
+        .iter()
+        .map(|p| MergeCm::new(workers, d, l, *p))
+        .collect();
+    let mut octo_deficit = 0.0f64;
+    let mut merge_deficit = vec![0.0f64; periods.len()];
+    let mut samples = 0usize;
+    let stride = n / query_points;
+
+    for (i, key) in stream.iter().enumerate() {
+        let input = DataInput::U64(*key);
+        truth.observe(*key as i64);
+        octo.insert(i, &input);
+        for merge in merges.iter_mut() {
+            merge.insert(i, &input);
+        }
+        if i > 0 && i % stride == stride / 3 {
+            let exact = truth.get(hottest) as f64;
+            octo_deficit += exact - octo.parent.estimate(&probe) as f64;
+            for (slot, merge) in merge_deficit.iter_mut().zip(merges.iter()) {
+                *slot += exact - merge.parent.estimate(&probe) as f64;
+            }
+            samples += 1;
+        }
+    }
+
+    let octo_mean = octo_deficit / samples as f64;
+    let merge_means: Vec<f64> = merge_deficit.iter().map(|d| d / samples as f64).collect();
+    println!(
+        "hottest key: octo mean deficit={octo_mean:.1}, merge by period {periods:?} = {:?}",
+        merge_means
+            .iter()
+            .map(|m| format!("{m:.1}"))
+            .collect::<Vec<_>>()
+    );
+
+    assert!(
+        octo_mean <= (workers as i32 * TAU) as f64,
+        "octo mean deficit {octo_mean:.1} exceeded k'τ"
+    );
+    for (window, pair) in merge_means.windows(2).zip(periods.windows(2)) {
+        assert!(
+            window[1] > window[0],
+            "doubling the merge period from {} to {} should increase staleness: \
+             {:.1} -> {:.1}",
+            pair[0],
+            pair[1],
+            window[0],
+            window[1]
+        );
+    }
+    assert!(
+        merge_means[periods.len() - 1] > octo_mean * 3.0,
+        "expected the widest merge period to be far staler than delta promotion"
+    );
 }

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -22,12 +22,14 @@
 
 mod common;
 
+use asap_sketchlib::common::BOTTOM_LAYER_FINDER;
 use asap_sketchlib::{
     CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin, DD_PROMASK, DDSketch,
     DataInput, DdWorkerSketch, ErtlMLE, FastPath, HLL_PROMASK, HllDelta, HyperLogLog,
-    HyperLogLogP12, HyperLogLogP16, OctoAggregator, OctoPlan, OctoThreshold, OctoWorker,
-    RegularPath, UnivMon, UnivMonOctoAggregator, UnivMonOctoPlan, UnivMonOctoWorker, Vector2D,
-    hash64_seeded,
+    HyperLogLogP12, HyperLogLogP16, L2HH, L2hhWorkerSketch, LayeredCountDelta, OctoAggregator,
+    OctoPlan, OctoThreshold, OctoWorker, RegularPath, UnivMon, UnivMonDeltaFidelity,
+    UnivMonOctoAggregator, UnivMonOctoPlan, UnivMonOctoWorker, Vector2D, bottom_layer_for_hash,
+    hash64_seeded, hash128_seeded, input_to_owned, univmon_layer_threshold,
 };
 use common::{FreqTruth, zipf_u64};
 use rand::SeedableRng;
@@ -2692,5 +2694,130 @@ fn univmon_heavy_hitter_recall_beats_sketch_merge() {
     assert!(
         octo_recall > 0.9,
         "heavy hitters should be found nearly always, got {octo_recall:.3}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Why UnivMon scales its threshold per layer
+// ---------------------------------------------------------------------------
+
+/// Drives a UnivMon pyramid through the delta path with a caller-chosen
+/// per-layer threshold, so a flat threshold can be compared against the scaled
+/// one the shipped worker uses.
+fn univmon_through_deltas(
+    stream: &[u64],
+    heap: usize,
+    rows: usize,
+    cols: usize,
+    layers: usize,
+    layer_threshold: impl Fn(usize) -> u32,
+) -> UnivMon {
+    let mut workers: Vec<L2hhWorkerSketch> = (0..layers)
+        .map(|layer| L2hhWorkerSketch::new(rows, cols, layer))
+        .collect();
+    let mut parent = UnivMon::init_univmon(heap, rows, cols, layers);
+    let mut weight = 0u64;
+
+    for key in stream {
+        let input = DataInput::U64(*key);
+        weight += 1;
+        let bottom = bottom_layer_for_hash(hash64_seeded(BOTTOM_LAYER_FINDER, &input), layers);
+        let owned = input_to_owned(&input);
+        for (layer, worker) in workers.iter_mut().enumerate().take(bottom + 1) {
+            let hashed = hash128_seeded(layer, &input);
+            let mut promoted = Vec::new();
+            worker
+                .insert_hash_emit_delta(hashed, layer_threshold(layer), &mut |d| promoted.push(d));
+            for delta in promoted {
+                parent.apply_layered_delta(
+                    &LayeredCountDelta {
+                        layer: layer as u32,
+                        key: owned.clone(),
+                        delta,
+                        worker_id: 0,
+                        weight_total: weight,
+                    },
+                    if layer_threshold(layer) <= 1 {
+                        UnivMonDeltaFidelity::EveryInsert
+                    } else {
+                        UnivMonDeltaFidelity::PromotedOnly
+                    },
+                );
+            }
+        }
+        parent.set_total_weight(weight as usize);
+    }
+    parent
+}
+
+#[test]
+fn a_flat_threshold_starves_the_deep_univmon_layers() {
+    // A UnivMon layer only receives the keys that survive L coin flips, so
+    // layer L carries about n / 2^L of the stream. One threshold across the
+    // whole pyramid is sized for layer 0 and leaves the deep layers - the ones
+    // the recursive estimator leans on for cardinality - with nothing. This is
+    // the measurement `univmon_layer_threshold` exists for.
+    let (heap, rows, cols, layers) = (64usize, 5usize, 1_024usize, 12usize);
+    let base = 31u32;
+    let stream = zipf_u64(60_000, 4_096, 1.1, 12_201);
+
+    let mut ideal = UnivMon::init_univmon(heap, rows, cols, layers);
+    for key in &stream {
+        ideal.insert(&DataInput::U64(*key), 1);
+    }
+
+    let flat = univmon_through_deltas(&stream, heap, rows, cols, layers, |_| base);
+    let scaled = univmon_through_deltas(&stream, heap, rows, cols, layers, |layer| {
+        univmon_layer_threshold(base, layer)
+    });
+
+    let nonzero = |sketch: &UnivMon, layer: usize| -> usize {
+        let L2HH::COUNT(inner) = &sketch.l2_sketch_layers[layer];
+        (0..inner.rows())
+            .flat_map(|r| (0..inner.cols()).map(move |c| (r, c)))
+            .filter(|(r, c)| inner.as_storage().query_one_counter(*r, *c) != 0)
+            .count()
+    };
+    let deepest = layers - 1;
+    println!(
+        "UnivMon card: ideal={:.0} flat-tau={:.0} scaled-tau={:.0} | deepest layer non-zero cells: \
+         ideal={} flat={} scaled={}",
+        ideal.calc_card(),
+        flat.calc_card(),
+        scaled.calc_card(),
+        nonzero(&ideal, deepest),
+        nonzero(&flat, deepest),
+        nonzero(&scaled, deepest),
+    );
+
+    // The deep layers are what a flat threshold empties.
+    assert!(
+        nonzero(&ideal, deepest) > 0,
+        "the ideal sketch reaches this layer"
+    );
+    assert_eq!(
+        nonzero(&flat, deepest),
+        0,
+        "a flat threshold leaves the deepest layer empty"
+    );
+    assert_eq!(
+        nonzero(&scaled, deepest),
+        nonzero(&ideal, deepest),
+        "scaling the threshold per layer keeps the deep layers exact"
+    );
+
+    // And that is what wrecks the estimate the deep layers feed.
+    let relative = |sketch: &UnivMon| {
+        (sketch.calc_card() - ideal.calc_card()).abs() / ideal.calc_card().abs().max(1.0)
+    };
+    assert!(
+        relative(&flat) > 0.5,
+        "a flat threshold should lose most of the cardinality, got {:.3}",
+        relative(&flat)
+    );
+    assert!(
+        relative(&scaled) < 0.1,
+        "the scaled threshold should track it, got {:.3}",
+        relative(&scaled)
     );
 }

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -2704,6 +2704,15 @@ fn univmon_heavy_hitter_recall_beats_sketch_merge() {
 /// Drives a UnivMon pyramid through the delta path with a caller-chosen
 /// per-layer threshold, so a flat threshold can be compared against the scaled
 /// one the shipped worker uses.
+///
+/// Deliberately a replica rather than `UnivMonOctoWorker`: the shipped worker
+/// applies the scaled rule unconditionally, so the flat counterfactual cannot
+/// be run through it. Layer selection, the per-layer seeds and the fidelity
+/// choice mirror the shipped code; the weight bookkeeping does not - this sets
+/// the exact total on every insert where the aggregator sums lagging per-worker
+/// reports - so the scaled arm here is a slightly better case than the pipeline
+/// delivers. `run_octo_univmon_reaches_the_deepest_layer` checks the structural
+/// half against the real pipeline.
 fn univmon_through_deltas(
     stream: &[u64],
     heap: usize,

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -1,0 +1,1201 @@
+//! E2E OctoSketch suite: delta-promotion conservation invariants for the
+//! CountMin, Count and HyperLogLog child/parent protocol, and the
+//! `octo-runtime` multi-threaded pipeline checked against single-threaded
+//! replays of the same round-robin partition.
+//!
+//! The protocol is fully deterministic: `run_octo` dispatches round-robin from
+//! the calling thread, and the aggregator only ever applies commutative
+//! updates (`+=` for the counter sketches, `max` for HLL registers). Thread
+//! interleaving therefore cannot change the parent, so every runtime test here
+//! asserts *exact* equality against a replay instead of a statistical band.
+
+mod common;
+
+use asap_sketchlib::{
+    CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin, DataInput, ErtlMLE,
+    FastPath, HLL_PROMASK, HllDelta, HyperLogLog, HyperLogLogP12, HyperLogLogP16, RegularPath,
+    Vector2D,
+};
+use common::zipf_u64;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+
+type Cm = CountMin<Vector2D<i32>, RegularPath>;
+type CmFast = CountMin<Vector2D<i32>, FastPath>;
+type Cs = Count<Vector2D<i32>, RegularPath>;
+type CsFast = Count<Vector2D<i32>, FastPath>;
+
+const ROWS: usize = 5;
+const COLS: usize = 2048;
+
+/// Largest amount a single cell can lag its exact count: promotion fires at a
+/// multiple of the mask, so at most `mask - 1` un-promoted increments remain.
+/// This is τ in the OctoSketch paper's notation (NSDI '24, §4.1).
+const MAX_CELL_RESIDUAL: i32 = CM_PROMASK as i32 - 1;
+
+fn keys(n: usize, domain: usize, seed: u64) -> Vec<u64> {
+    zipf_u64(n, domain, 1.1, seed)
+}
+
+fn inputs_from(keys: &[u64]) -> Vec<DataInput<'static>> {
+    keys.iter().copied().map(DataInput::U64).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Child-run helpers: drive one child sketch over a stream, capture its deltas
+// ---------------------------------------------------------------------------
+
+fn cm_child_run(stream: &[u64], rows: usize, cols: usize) -> (Cm, Vec<CmDelta>) {
+    let mut child = Cm::with_dimensions(rows, cols);
+    let mut deltas = Vec::new();
+    for k in stream {
+        child.insert_emit_delta(&DataInput::U64(*k), &mut |d| deltas.push(d));
+    }
+    (child, deltas)
+}
+
+fn cs_child_run(stream: &[u64], rows: usize, cols: usize) -> (Cs, Vec<CountDelta>) {
+    let mut child = Cs::with_dimensions(rows, cols);
+    let mut deltas = Vec::new();
+    for k in stream {
+        child.insert_emit_delta(&DataInput::U64(*k), &mut |d| deltas.push(d));
+    }
+    (child, deltas)
+}
+
+fn hll_child_run(stream: &[u64]) -> (HyperLogLog<Classic>, Vec<HllDelta>) {
+    let mut child = HyperLogLog::<Classic>::default();
+    let mut deltas = Vec::new();
+    for k in stream {
+        child.insert_emit_delta(&DataInput::U64(*k), &mut |d| deltas.push(d));
+    }
+    (child, deltas)
+}
+
+fn cm_cells(sketch: &Cm) -> Vec<i32> {
+    let (rows, cols) = (sketch.rows(), sketch.cols());
+    (0..rows)
+        .flat_map(|r| (0..cols).map(move |c| (r, c)))
+        .map(|(r, c)| sketch.as_storage().query_one_counter(r, c))
+        .collect()
+}
+
+fn cs_cells(sketch: &Cs) -> Vec<i32> {
+    let (rows, cols) = (sketch.rows(), sketch.cols());
+    (0..rows)
+        .flat_map(|r| (0..cols).map(move |c| (r, c)))
+        .map(|(r, c)| sketch.as_storage().query_one_counter(r, c))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// CountMin delta protocol
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cm_emit_path_leaves_the_child_identical_to_a_plain_insert() {
+    let stream = keys(20_000, 512, 9_101);
+    let (child, _) = cm_child_run(&stream, ROWS, COLS);
+
+    let mut reference = Cm::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    assert_eq!(
+        cm_cells(&child),
+        cm_cells(&reference),
+        "emitting deltas must not perturb the child's own counters"
+    );
+}
+
+#[test]
+fn cm_deltas_are_well_formed_and_carry_exactly_one_promotion() {
+    let stream = keys(20_000, 512, 9_102);
+    let (_, deltas) = cm_child_run(&stream, ROWS, COLS);
+
+    assert!(!deltas.is_empty(), "a 20k stream must promote something");
+    for d in &deltas {
+        assert_eq!(d.value, CM_PROMASK, "CM promotes exactly the mask value");
+        assert!((d.row as usize) < ROWS, "row {} out of range", d.row);
+        assert!((d.col as usize) < COLS, "col {} out of range", d.col);
+    }
+}
+
+#[test]
+fn cm_parent_holds_the_promoted_multiple_of_every_child_cell() {
+    let stream = keys(30_000, 512, 9_103);
+    let (child, deltas) = cm_child_run(&stream, ROWS, COLS);
+
+    let mut parent = Cm::with_dimensions(ROWS, COLS);
+    for d in &deltas {
+        parent.apply_delta(*d);
+    }
+
+    let (child_cells, parent_cells) = (cm_cells(&child), cm_cells(&parent));
+    let mask = CM_PROMASK as i32;
+    let mut worst_residual = 0;
+    for (i, (&c, &p)) in child_cells.iter().zip(parent_cells.iter()).enumerate() {
+        assert_eq!(
+            p,
+            mask * (c / mask),
+            "cell {i}: parent must hold every completed promotion of child count {c}"
+        );
+        worst_residual = worst_residual.max(c - p);
+    }
+    assert!(
+        worst_residual <= MAX_CELL_RESIDUAL,
+        "residual {worst_residual} exceeds one promotion window"
+    );
+    assert!(
+        worst_residual > 0,
+        "a skewed stream should leave some un-promoted remainder"
+    );
+}
+
+#[test]
+fn cm_octo_estimate_trails_the_single_thread_estimate_by_under_one_promotion() {
+    let stream = keys(40_000, 256, 9_104);
+    let (child, deltas) = cm_child_run(&stream, ROWS, COLS);
+
+    let mut parent = Cm::with_dimensions(ROWS, COLS);
+    for d in &deltas {
+        parent.apply_delta(*d);
+    }
+
+    // Per row the parent lags by `count mod mask`, so the row-wise minimum
+    // lags by strictly less than one promotion window and never overshoots.
+    for k in 0u64..256 {
+        let key = DataInput::U64(k);
+        let single = child.estimate(&key);
+        let octo = parent.estimate(&key);
+        assert!(
+            octo <= single,
+            "key {k}: octo {octo} must not exceed single-thread {single}"
+        );
+        assert!(
+            single - octo <= MAX_CELL_RESIDUAL,
+            "key {k}: deficit {} exceeds one promotion window",
+            single - octo
+        );
+    }
+}
+
+#[test]
+fn cm_fast_path_promotes_on_the_same_schedule_as_the_regular_path() {
+    let stream = keys(20_000, 512, 9_105);
+
+    let mut fast_child = CmFast::with_dimensions(ROWS, COLS);
+    let mut fast_parent = CmFast::with_dimensions(ROWS, COLS);
+    let mut fast_deltas = 0usize;
+    for k in &stream {
+        fast_child.insert_emit_delta(&DataInput::U64(*k), &mut |d| {
+            assert_eq!(d.value, CM_PROMASK);
+            fast_parent.apply_delta(d);
+            fast_deltas += 1;
+        });
+    }
+
+    assert!(fast_deltas > 0, "a 20k stream must promote something");
+
+    // The fast path derives all columns from one hash, so its collision
+    // pattern - and therefore its promotion count - differs from the regular
+    // path. Only the per-cell promotion rule is shared.
+    let mask = CM_PROMASK as i32;
+    for r in 0..ROWS {
+        for c in 0..COLS {
+            let child_cell = fast_child.as_storage().query_one_counter(r, c);
+            let parent_cell = fast_parent.as_storage().query_one_counter(r, c);
+            assert_eq!(parent_cell, mask * (child_cell / mask), "cell ({r},{c})");
+        }
+    }
+}
+
+#[test]
+fn cm_delta_addressing_holds_at_the_widest_supported_geometry() {
+    // `CmDelta` addresses cells with u16 row/col, so 65_536 columns is the
+    // widest geometry the promotion protocol can carry (max index 65_535).
+    let rows = 3;
+    let cols = u16::MAX as usize + 1;
+    let stream = keys(60_000, 4_096, 9_108);
+
+    let mut child = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
+    let mut parent = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(rows, cols);
+    for k in &stream {
+        child.insert_emit_delta(&DataInput::U64(*k), &mut |d| parent.apply_delta(d));
+    }
+
+    let mask = CM_PROMASK as i32;
+    for r in 0..rows {
+        for c in 0..cols {
+            let child_cell = child.as_storage().query_one_counter(r, c);
+            assert_eq!(
+                parent.as_storage().query_one_counter(r, c),
+                mask * (child_cell / mask),
+                "cell ({r},{c}) mis-addressed at the u16 column boundary"
+            );
+        }
+    }
+}
+
+#[test]
+fn cm_delta_application_is_order_independent() {
+    let stream = keys(15_000, 512, 9_106);
+    let (_, deltas) = cm_child_run(&stream, ROWS, COLS);
+
+    let mut in_order = Cm::with_dimensions(ROWS, COLS);
+    for d in &deltas {
+        in_order.apply_delta(*d);
+    }
+
+    let mut shuffled = deltas.clone();
+    shuffled.shuffle(&mut StdRng::seed_from_u64(9_106));
+    let mut out_of_order = Cm::with_dimensions(ROWS, COLS);
+    for d in &shuffled {
+        out_of_order.apply_delta(*d);
+    }
+
+    assert_eq!(
+        cm_cells(&in_order),
+        cm_cells(&out_of_order),
+        "the aggregator applies commutative updates, so delivery order is free"
+    );
+}
+
+#[test]
+fn cm_sharded_children_conserve_counts_against_a_single_pass() {
+    let stream = keys(40_000, 512, 9_107);
+    let shards = 4;
+
+    let mut children: Vec<Cm> = (0..shards)
+        .map(|_| Cm::with_dimensions(ROWS, COLS))
+        .collect();
+    let mut parent = Cm::with_dimensions(ROWS, COLS);
+    for (i, k) in stream.iter().enumerate() {
+        let mut out = Vec::new();
+        children[i % shards].insert_emit_delta(&DataInput::U64(*k), &mut |d| out.push(d));
+        for d in out {
+            parent.apply_delta(d);
+        }
+    }
+
+    let mut reference = Cm::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    // parent + Σ per-shard residuals == the single-pass sketch, cell for cell.
+    for r in 0..ROWS {
+        for c in 0..COLS {
+            let promoted = parent.as_storage().query_one_counter(r, c);
+            let mask = CM_PROMASK as i32;
+            let residual: i32 = children
+                .iter()
+                .map(|ch| ch.as_storage().query_one_counter(r, c) % mask)
+                .sum();
+            assert_eq!(
+                promoted + residual,
+                reference.as_storage().query_one_counter(r, c),
+                "cell ({r},{c}) lost or duplicated counts across {shards} shards"
+            );
+            assert!(
+                residual <= shards as i32 * MAX_CELL_RESIDUAL,
+                "cell ({r},{c}) residual {residual} exceeds one window per shard"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Count sketch delta protocol
+// ---------------------------------------------------------------------------
+
+#[test]
+fn count_deltas_carry_exactly_the_signed_threshold() {
+    let stream = keys(30_000, 256, 9_201);
+    let (_, deltas) = cs_child_run(&stream, ROWS, COLS);
+
+    assert!(!deltas.is_empty(), "a 30k stream must promote something");
+    for d in &deltas {
+        assert_eq!(
+            d.value.unsigned_abs(),
+            COUNT_PROMASK,
+            "Count resets on promotion, so a delta is always ±the mask"
+        );
+        assert!((d.row as usize) < ROWS, "row {} out of range", d.row);
+        assert!((d.col as usize) < COLS, "col {} out of range", d.col);
+    }
+}
+
+#[test]
+fn count_promotion_is_lossless_modulo_the_child_residual() {
+    let stream = keys(30_000, 256, 9_202);
+    let (child, deltas) = cs_child_run(&stream, ROWS, COLS);
+
+    let mut parent = Cs::with_dimensions(ROWS, COLS);
+    for d in &deltas {
+        parent.apply_delta(*d);
+    }
+
+    let mut reference = Cs::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    let (child_cells, parent_cells, ref_cells) =
+        (cs_cells(&child), cs_cells(&parent), cs_cells(&reference));
+    for (i, ((&c, &p), &r)) in child_cells
+        .iter()
+        .zip(parent_cells.iter())
+        .zip(ref_cells.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            p + c,
+            r,
+            "cell {i}: promoted {p} plus residual {c} must reconstruct {r}"
+        );
+        assert!(
+            c.abs() <= MAX_CELL_RESIDUAL,
+            "cell {i}: residual {c} should have been promoted"
+        );
+    }
+}
+
+#[test]
+fn count_octo_estimate_stays_within_one_residual_of_the_single_thread_estimate() {
+    let stream = keys(40_000, 256, 9_203);
+    let (_, deltas) = cs_child_run(&stream, ROWS, COLS);
+
+    let mut parent = Cs::with_dimensions(ROWS, COLS);
+    for d in &deltas {
+        parent.apply_delta(*d);
+    }
+    let mut reference = Cs::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    // Every row cell is within `MAX_CELL_RESIDUAL` of the reference, and the
+    // estimate is an order statistic over those rows, so the same bound holds.
+    for k in 0u64..256 {
+        let key = DataInput::U64(k);
+        let gap = (parent.estimate(&key) - reference.estimate(&key)).abs();
+        assert!(
+            gap <= MAX_CELL_RESIDUAL as f64,
+            "key {k}: estimate gap {gap} exceeds one promotion window"
+        );
+    }
+}
+
+#[test]
+fn count_fast_path_conserves_counts_like_the_regular_path() {
+    let stream = keys(20_000, 256, 9_204);
+
+    let mut child = CsFast::with_dimensions(ROWS, COLS);
+    let mut parent = CsFast::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        child.insert_emit_delta(&DataInput::U64(*k), &mut |d| {
+            assert_eq!(d.value.unsigned_abs(), COUNT_PROMASK);
+            parent.apply_delta(d);
+        });
+    }
+
+    let mut reference = CsFast::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    for r in 0..ROWS {
+        for c in 0..COLS {
+            assert_eq!(
+                parent.as_storage().query_one_counter(r, c)
+                    + child.as_storage().query_one_counter(r, c),
+                reference.as_storage().query_one_counter(r, c),
+                "cell ({r},{c})"
+            );
+        }
+    }
+}
+
+#[test]
+fn count_delta_application_is_order_independent() {
+    let stream = keys(15_000, 256, 9_205);
+    let (_, deltas) = cs_child_run(&stream, ROWS, COLS);
+
+    let mut in_order = Cs::with_dimensions(ROWS, COLS);
+    for d in &deltas {
+        in_order.apply_delta(*d);
+    }
+    let mut shuffled = deltas.clone();
+    shuffled.shuffle(&mut StdRng::seed_from_u64(9_205));
+    let mut out_of_order = Cs::with_dimensions(ROWS, COLS);
+    for d in &shuffled {
+        out_of_order.apply_delta(*d);
+    }
+
+    assert_eq!(cs_cells(&in_order), cs_cells(&out_of_order));
+}
+
+#[test]
+fn count_sharded_children_conserve_signed_counts() {
+    let stream = keys(40_000, 256, 9_206);
+    let shards = 3;
+
+    let mut children: Vec<Cs> = (0..shards)
+        .map(|_| Cs::with_dimensions(ROWS, COLS))
+        .collect();
+    let mut parent = Cs::with_dimensions(ROWS, COLS);
+    for (i, k) in stream.iter().enumerate() {
+        let mut out = Vec::new();
+        children[i % shards].insert_emit_delta(&DataInput::U64(*k), &mut |d| out.push(d));
+        for d in out {
+            parent.apply_delta(d);
+        }
+    }
+
+    let mut reference = Cs::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    for r in 0..ROWS {
+        for c in 0..COLS {
+            let residual: i32 = children
+                .iter()
+                .map(|ch| ch.as_storage().query_one_counter(r, c))
+                .sum();
+            assert_eq!(
+                parent.as_storage().query_one_counter(r, c) + residual,
+                reference.as_storage().query_one_counter(r, c),
+                "cell ({r},{c})"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HyperLogLog delta protocol
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hll_promotion_reproduces_the_single_thread_registers_exactly() {
+    let stream: Vec<u64> = (0..60_000u64).collect();
+    let (child, deltas) = hll_child_run(&stream);
+
+    let mut parent = HyperLogLog::<Classic>::default();
+    for d in &deltas {
+        parent.apply_delta(*d);
+    }
+
+    let mut reference = HyperLogLog::<Classic>::default();
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    assert_eq!(
+        HLL_PROMASK, 0,
+        "the exactness argument relies on every improvement being promoted"
+    );
+    assert_eq!(
+        parent.registers_as_slice(),
+        reference.registers_as_slice(),
+        "max-register promotion is lossless"
+    );
+    assert_eq!(
+        child.registers_as_slice(),
+        reference.registers_as_slice(),
+        "the emit path must leave the child identical to a plain insert"
+    );
+    assert_eq!(parent.estimate(), reference.estimate());
+}
+
+#[test]
+fn hll_promotion_is_exact_for_every_variant_and_precision() {
+    let stream: Vec<u64> = (0..40_000u64)
+        .map(|i| i.wrapping_mul(2_654_435_761))
+        .collect();
+
+    macro_rules! check {
+        ($ty:ty, $label:literal) => {{
+            let mut child = <$ty>::default();
+            let mut parent = <$ty>::default();
+            for k in &stream {
+                child.insert_emit_delta(&DataInput::U64(*k), &mut |d| parent.apply_delta(d));
+            }
+            let mut reference = <$ty>::default();
+            for k in &stream {
+                reference.insert(&DataInput::U64(*k));
+            }
+            assert_eq!(
+                parent.registers_as_slice(),
+                reference.registers_as_slice(),
+                "{} registers diverged",
+                $label
+            );
+            assert_eq!(
+                child.registers_as_slice(),
+                reference.registers_as_slice(),
+                "{} child perturbed by the emit path",
+                $label
+            );
+        }};
+    }
+
+    check!(HyperLogLogP12<Classic>, "P12/Classic");
+    check!(HyperLogLog<Classic>, "P14/Classic");
+    check!(HyperLogLogP16<Classic>, "P16/Classic");
+    check!(HyperLogLogP12<ErtlMLE>, "P12/ErtlMLE");
+    check!(HyperLogLog<ErtlMLE>, "P14/ErtlMLE");
+    check!(HyperLogLogP16<ErtlMLE>, "P16/ErtlMLE");
+}
+
+#[test]
+fn hll_deltas_are_strictly_increasing_per_register_and_never_repeat() {
+    let stream: Vec<u64> = (0..30_000u64).collect();
+    let (child, deltas) = hll_child_run(&stream);
+
+    let register_count = child.registers_as_slice().len();
+    let mut best = vec![0u8; register_count];
+    for d in &deltas {
+        let pos = d.pos as usize;
+        assert!(pos < register_count, "register {pos} out of range");
+        assert!(
+            d.value > best[pos],
+            "register {pos} re-promoted a non-improving value {}",
+            d.value
+        );
+        best[pos] = d.value;
+    }
+    assert_eq!(
+        best,
+        child.registers_as_slice(),
+        "the delta stream must replay the child's final register state"
+    );
+}
+
+#[test]
+fn hll_duplicate_keys_promote_nothing_after_the_first_improvement() {
+    let mut child = HyperLogLog::<Classic>::default();
+    let mut deltas = 0usize;
+    for _ in 0..1_000 {
+        child.insert_emit_delta(&DataInput::U64(7), &mut |_| deltas += 1);
+    }
+    assert_eq!(deltas, 1, "only the first insert can improve a register");
+}
+
+#[test]
+fn hll_delta_application_is_order_independent() {
+    let stream: Vec<u64> = (0..30_000u64).collect();
+    let (_, deltas) = hll_child_run(&stream);
+
+    let mut in_order = HyperLogLog::<Classic>::default();
+    for d in &deltas {
+        in_order.apply_delta(*d);
+    }
+    let mut shuffled = deltas.clone();
+    shuffled.shuffle(&mut StdRng::seed_from_u64(9_301));
+    let mut out_of_order = HyperLogLog::<Classic>::default();
+    for d in &shuffled {
+        out_of_order.apply_delta(*d);
+    }
+
+    assert_eq!(
+        in_order.registers_as_slice(),
+        out_of_order.registers_as_slice(),
+        "max is commutative, so delivery order is free"
+    );
+}
+
+#[test]
+fn hll_sharded_children_match_a_single_pass_exactly() {
+    let stream: Vec<u64> = (0..50_000u64).collect();
+    let shards = 4;
+
+    let mut children: Vec<HyperLogLog<Classic>> =
+        (0..shards).map(|_| HyperLogLog::default()).collect();
+    let mut parent = HyperLogLog::<Classic>::default();
+    for (i, k) in stream.iter().enumerate() {
+        let mut out = Vec::new();
+        children[i % shards].insert_emit_delta(&DataInput::U64(*k), &mut |d| out.push(d));
+        for d in out {
+            parent.apply_delta(d);
+        }
+    }
+
+    let mut reference = HyperLogLog::<Classic>::default();
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
+
+    assert_eq!(
+        parent.registers_as_slice(),
+        reference.registers_as_slice(),
+        "sharded HLL promotion carries no partition penalty"
+    );
+}
+
+#[test]
+fn hll_cardinality_error_survives_the_delta_round_trip() {
+    let truth = 100_000u64;
+    let stream: Vec<u64> = (0..truth).collect();
+    let (_, deltas) = hll_child_run(&stream);
+    let mut parent = HyperLogLog::<Classic>::default();
+    for d in &deltas {
+        parent.apply_delta(*d);
+    }
+
+    // P14 standard error is 1.04/sqrt(2^14) ≈ 0.81%; allow 3σ.
+    let estimate = parent.estimate() as f64;
+    let error = (estimate - truth as f64).abs() / truth as f64;
+    assert!(
+        error < 0.025,
+        "delta-fed HLL error {error:.4} exceeds 3σ (estimate {estimate}, truth {truth})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Runtime: `run_octo` / `OctoRuntime`
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "octo-runtime")]
+mod runtime {
+    use super::*;
+    use asap_sketchlib::{
+        CmOctoAggregator, CmOctoWorker, CountOctoAggregator, CountOctoWorker, HllOctoAggregator,
+        HllOctoWorker, OctoAggregator, OctoConfig, OctoRuntime, OctoWorker, run_octo,
+    };
+
+    fn config(num_workers: usize) -> OctoConfig {
+        OctoConfig {
+            num_workers,
+            // CI runners have fewer cores than the widest configuration here.
+            pin_cores: false,
+            queue_capacity: 4096,
+        }
+    }
+
+    fn cm_runtime(inputs: &[DataInput<'_>], workers: usize, rows: usize, cols: usize) -> Cm {
+        run_octo(
+            inputs,
+            &config(workers),
+            |_| CmOctoWorker::new(rows, cols),
+            || CmOctoAggregator {
+                sketch: Cm::with_dimensions(rows, cols),
+            },
+        )
+        .parent
+        .sketch
+    }
+
+    /// Single-threaded replay of the runtime's round-robin dispatch.
+    fn cm_replay(inputs: &[DataInput<'_>], workers: usize, rows: usize, cols: usize) -> Cm {
+        let mut children: Vec<Cm> = (0..workers)
+            .map(|_| Cm::with_dimensions(rows, cols))
+            .collect();
+        let mut parent = Cm::with_dimensions(rows, cols);
+        for (i, input) in inputs.iter().enumerate() {
+            let mut out = Vec::new();
+            children[i % workers].insert_emit_delta(input, &mut |d| out.push(d));
+            for d in out {
+                parent.apply_delta(d);
+            }
+        }
+        parent
+    }
+
+    fn cs_replay(inputs: &[DataInput<'_>], workers: usize, rows: usize, cols: usize) -> Cs {
+        let mut children: Vec<Cs> = (0..workers)
+            .map(|_| Cs::with_dimensions(rows, cols))
+            .collect();
+        let mut parent = Cs::with_dimensions(rows, cols);
+        for (i, input) in inputs.iter().enumerate() {
+            let mut out = Vec::new();
+            children[i % workers].insert_emit_delta(input, &mut |d| out.push(d));
+            for d in out {
+                parent.apply_delta(d);
+            }
+        }
+        parent
+    }
+
+    #[test]
+    fn run_octo_cm_matches_a_single_threaded_replay_of_the_same_partition() {
+        let inputs = inputs_from(&keys(40_000, 512, 9_401));
+        for workers in [1usize, 2, 3, 4, 7] {
+            assert_eq!(
+                cm_cells(&cm_runtime(&inputs, workers, ROWS, COLS)),
+                cm_cells(&cm_replay(&inputs, workers, ROWS, COLS)),
+                "{workers} workers: runtime diverged from the deterministic replay"
+            );
+        }
+    }
+
+    #[test]
+    fn run_octo_count_matches_a_single_threaded_replay_of_the_same_partition() {
+        let inputs = inputs_from(&keys(40_000, 256, 9_402));
+        for workers in [1usize, 2, 4] {
+            let got = run_octo(
+                &inputs,
+                &config(workers),
+                |_| CountOctoWorker::new(ROWS, COLS),
+                || CountOctoAggregator {
+                    sketch: Cs::with_dimensions(ROWS, COLS),
+                },
+            )
+            .parent
+            .sketch;
+            assert_eq!(
+                cs_cells(&got),
+                cs_cells(&cs_replay(&inputs, workers, ROWS, COLS)),
+                "{workers} workers: runtime diverged from the deterministic replay"
+            );
+        }
+    }
+
+    #[test]
+    fn run_octo_hll_is_bit_exact_and_worker_count_invariant() {
+        let inputs = inputs_from(&(0..80_000u64).collect::<Vec<_>>());
+        let mut reference = HyperLogLog::<Classic>::default();
+        for input in &inputs {
+            reference.insert(input);
+        }
+
+        for workers in [1usize, 2, 3, 4, 8] {
+            let got = run_octo(
+                &inputs,
+                &config(workers),
+                |_| HllOctoWorker::new(),
+                || HllOctoAggregator {
+                    sketch: HyperLogLog::<Classic>::default(),
+                },
+            )
+            .parent
+            .sketch;
+            assert_eq!(
+                got.registers_as_slice(),
+                reference.registers_as_slice(),
+                "{workers} workers: HLL promotion must carry no partition penalty"
+            );
+        }
+    }
+
+    #[test]
+    fn run_octo_is_deterministic_across_repeated_runs() {
+        let inputs = inputs_from(&keys(30_000, 512, 9_403));
+        let first = cm_runtime(&inputs, 4, ROWS, COLS);
+        let second = cm_runtime(&inputs, 4, ROWS, COLS);
+        assert_eq!(
+            cm_cells(&first),
+            cm_cells(&second),
+            "commutative aggregation makes the parent independent of interleaving"
+        );
+    }
+
+    #[test]
+    fn streaming_runtime_matches_the_batch_helper() {
+        let inputs = inputs_from(&keys(30_000, 512, 9_404));
+        let batch = cm_runtime(&inputs, 4, ROWS, COLS);
+
+        let mut runtime = OctoRuntime::new(
+            &config(4),
+            |_| CmOctoWorker::new(ROWS, COLS),
+            || CmOctoAggregator {
+                sketch: Cm::with_dimensions(ROWS, COLS),
+            },
+        );
+        for input in &inputs {
+            runtime.insert(input.clone());
+        }
+        let streamed = runtime.finish().parent.sketch;
+
+        assert_eq!(cm_cells(&batch), cm_cells(&streamed));
+    }
+
+    #[test]
+    fn insert_batch_matches_element_wise_inserts() {
+        let inputs = inputs_from(&keys(20_000, 512, 9_405));
+
+        let mut one_by_one = OctoRuntime::new(
+            &config(3),
+            |_| CmOctoWorker::new(ROWS, COLS),
+            || CmOctoAggregator {
+                sketch: Cm::with_dimensions(ROWS, COLS),
+            },
+        );
+        for input in &inputs {
+            one_by_one.insert(input.clone());
+        }
+
+        let mut batched = OctoRuntime::new(
+            &config(3),
+            |_| CmOctoWorker::new(ROWS, COLS),
+            || CmOctoAggregator {
+                sketch: Cm::with_dimensions(ROWS, COLS),
+            },
+        );
+        batched.insert_batch(&inputs);
+
+        assert_eq!(
+            cm_cells(&one_by_one.finish().parent.sketch),
+            cm_cells(&batched.finish().parent.sketch)
+        );
+    }
+
+    #[test]
+    fn degenerate_config_is_clamped_rather_than_rejected() {
+        let inputs = inputs_from(&(0..5_000u64).collect::<Vec<_>>());
+        let cfg = OctoConfig {
+            num_workers: 0,
+            pin_cores: false,
+            queue_capacity: 0,
+        };
+        let got = run_octo(
+            &inputs,
+            &cfg,
+            |_| HllOctoWorker::new(),
+            || HllOctoAggregator {
+                sketch: HyperLogLog::<Classic>::default(),
+            },
+        )
+        .parent
+        .sketch;
+
+        let mut reference = HyperLogLog::<Classic>::default();
+        for input in &inputs {
+            reference.insert(input);
+        }
+        assert_eq!(
+            got.registers_as_slice(),
+            reference.registers_as_slice(),
+            "zero workers/capacity must clamp to one, not drop data"
+        );
+    }
+
+    #[test]
+    fn a_one_slot_queue_applies_backpressure_without_deadlocking() {
+        let inputs = inputs_from(&(0..20_000u64).collect::<Vec<_>>());
+        let cfg = OctoConfig {
+            num_workers: 4,
+            pin_cores: false,
+            queue_capacity: 1,
+        };
+        let got = run_octo(
+            &inputs,
+            &cfg,
+            |_| HllOctoWorker::new(),
+            || HllOctoAggregator {
+                sketch: HyperLogLog::<Classic>::default(),
+            },
+        )
+        .parent
+        .sketch;
+
+        let mut reference = HyperLogLog::<Classic>::default();
+        for input in &inputs {
+            reference.insert(input);
+        }
+        assert_eq!(got.registers_as_slice(), reference.registers_as_slice());
+    }
+
+    #[test]
+    fn borrowed_string_inputs_survive_the_cross_thread_transport() {
+        let owned: Vec<String> = (0..5_000).map(|i| format!("session-{i:05}")).collect();
+        let inputs: Vec<DataInput<'_>> = owned.iter().map(|s| DataInput::Str(s)).collect();
+
+        let got = run_octo(
+            &inputs,
+            &config(4),
+            |_| HllOctoWorker::new(),
+            || HllOctoAggregator {
+                sketch: HyperLogLog::<Classic>::default(),
+            },
+        )
+        .parent
+        .sketch;
+
+        let mut reference = HyperLogLog::<Classic>::default();
+        for input in &inputs {
+            reference.insert(input);
+        }
+        assert_eq!(
+            got.registers_as_slice(),
+            reference.registers_as_slice(),
+            "borrowed &str payloads must reach the workers intact"
+        );
+    }
+
+    #[test]
+    fn an_empty_stream_finishes_with_a_pristine_parent() {
+        let got = run_octo(
+            &[],
+            &config(4),
+            |_| CmOctoWorker::new(ROWS, COLS),
+            || CmOctoAggregator {
+                sketch: Cm::with_dimensions(ROWS, COLS),
+            },
+        )
+        .parent
+        .sketch;
+        assert!(cm_cells(&got).iter().all(|&c| c == 0));
+    }
+
+    // -- custom worker/aggregator: the public trait surface must be usable
+    //    from outside the crate, not just by the bundled adapters.
+
+    struct SumWorker {
+        worker_id: usize,
+        seen: u64,
+    }
+
+    #[derive(Clone, Copy)]
+    struct SumDelta {
+        worker_id: usize,
+        keys_seen: u64,
+    }
+
+    impl OctoWorker for SumWorker {
+        type Delta = SumDelta;
+
+        fn process<F>(&mut self, _input: &DataInput, emit: &mut F)
+        where
+            F: FnMut(Self::Delta),
+        {
+            self.seen += 1;
+            emit(SumDelta {
+                worker_id: self.worker_id,
+                keys_seen: 1,
+            });
+        }
+    }
+
+    struct SumAggregator {
+        per_worker: Vec<u64>,
+    }
+
+    impl OctoAggregator for SumAggregator {
+        type Delta = SumDelta;
+
+        fn apply(&mut self, delta: SumDelta) {
+            self.per_worker[delta.worker_id] += delta.keys_seen;
+        }
+    }
+
+    #[test]
+    fn a_user_defined_worker_and_aggregator_round_trip_every_input() {
+        let workers = 3;
+        let n = 10_001u64;
+        let inputs = inputs_from(&(0..n).collect::<Vec<_>>());
+
+        let result = run_octo(
+            &inputs,
+            &config(workers),
+            |worker_id| SumWorker { worker_id, seen: 0 },
+            || SumAggregator {
+                per_worker: vec![0; workers],
+            },
+        );
+
+        assert_eq!(
+            result.parent.per_worker.iter().sum::<u64>(),
+            n,
+            "no input may be dropped"
+        );
+        // Round-robin from a single dispatching thread: worker w takes every
+        // index ≡ w (mod workers).
+        for (w, &load) in result.parent.per_worker.iter().enumerate() {
+            let expected = (0..n as usize).filter(|i| i % workers == w).count() as u64;
+            assert_eq!(load, expected, "worker {w} received the wrong share");
+        }
+    }
+
+    #[test]
+    fn the_read_handle_observes_a_monotone_prefix_of_the_final_state() {
+        let workers = 2;
+        let n = 4_000u64;
+        let mut runtime = OctoRuntime::new(
+            &config(workers),
+            |worker_id| SumWorker { worker_id, seen: 0 },
+            || SumAggregator {
+                per_worker: vec![0; workers],
+            },
+        );
+        let reader = runtime.read_handle();
+
+        let mut last = 0u64;
+        for i in 0..n {
+            runtime.insert(DataInput::U64(i));
+            if i % 500 == 0 {
+                let observed = reader.with_parent(|p| p.per_worker.iter().sum::<u64>());
+                assert!(
+                    observed >= last,
+                    "live total went backwards: {last} -> {observed}"
+                );
+                assert!(observed <= n, "live total {observed} exceeded the stream");
+                last = observed;
+            }
+        }
+
+        let result = runtime.finish();
+        let total = result.parent.per_worker.iter().sum::<u64>();
+        assert_eq!(total, n);
+        assert!(total >= last, "final total must dominate every snapshot");
+    }
+
+    #[test]
+    #[should_panic(expected = "Octo runtime has been finished")]
+    fn reading_through_a_stale_handle_panics() {
+        let workers = 2;
+        let runtime = OctoRuntime::new(
+            &config(workers),
+            |worker_id| SumWorker { worker_id, seen: 0 },
+            || SumAggregator {
+                per_worker: vec![0; workers],
+            },
+        );
+        let reader = runtime.read_handle();
+        let _ = runtime.finish();
+        reader.with_parent(|p| p.per_worker.len());
+    }
+
+    #[test]
+    fn close_is_idempotent_and_preserves_already_queued_work() {
+        let workers = 4;
+        let n = 3_001u64;
+        let mut runtime = OctoRuntime::new(
+            &config(workers),
+            |worker_id| SumWorker { worker_id, seen: 0 },
+            || SumAggregator {
+                per_worker: vec![0; workers],
+            },
+        );
+        for i in 0..n {
+            runtime.insert(DataInput::U64(i));
+        }
+        runtime.close();
+        runtime.close();
+
+        let result = runtime.finish();
+        assert_eq!(
+            result.parent.per_worker.iter().sum::<u64>(),
+            n,
+            "close must drain what was already queued"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot insert after runtime has been closed")]
+    fn inserting_after_close_panics() {
+        let workers = 2;
+        let mut runtime = OctoRuntime::new(
+            &config(workers),
+            |worker_id| SumWorker { worker_id, seen: 0 },
+            || SumAggregator {
+                per_worker: vec![0; workers],
+            },
+        );
+        runtime.close();
+        runtime.insert(DataInput::U64(1));
+    }
+
+    // -- accuracy end to end -------------------------------------------------
+
+    #[test]
+    fn run_octo_cm_zipf_error_stays_within_the_cms_bound_plus_the_residual() {
+        let rows = 5;
+        let cols = 4096;
+        let stream = keys(200_000, 4_096, 9_501);
+        let inputs = inputs_from(&stream);
+
+        let mut truth = common::FreqTruth::default();
+        for k in &stream {
+            truth.observe(*k as i64);
+        }
+
+        let parent = cm_runtime(&inputs, 4, rows, cols);
+
+        // Upper side: the usual one-sided CMS bound ε·N with ε = e/cols.
+        // Lower side: OctoSketch (NSDI '24) Theorem 1 charges the promotion
+        // protocol an additive k'·τ, where k' is the number of workers a key
+        // may reach. `run_octo` dispatches round-robin, so every key reaches
+        // every worker and k' = num_workers - the worst case of that bound.
+        let epsilon_n = (std::f64::consts::E / cols as f64) * truth.total() as f64;
+        let floor = 4.0 * MAX_CELL_RESIDUAL as f64;
+        for k in 0u64..4_096 {
+            let exact = truth.get(k as i64) as f64;
+            let est = parent.estimate(&DataInput::U64(k)) as f64;
+            assert!(
+                est >= exact - floor,
+                "key {k}: octo estimate {est} fell more than {floor} below truth {exact}"
+            );
+            assert!(
+                est <= exact + epsilon_n,
+                "key {k}: octo estimate {est} exceeded truth {exact} + {epsilon_n:.1}"
+            );
+        }
+    }
+
+    #[test]
+    fn run_octo_hll_cardinality_error_stays_within_three_sigma() {
+        let truth = 200_000u64;
+        let inputs = inputs_from(&(0..truth).collect::<Vec<_>>());
+        let got = run_octo(
+            &inputs,
+            &config(4),
+            |_| HllOctoWorker::new(),
+            || HllOctoAggregator {
+                sketch: HyperLogLog::<Classic>::default(),
+            },
+        )
+        .parent
+        .sketch;
+
+        let estimate = got.estimate() as f64;
+        let error = (estimate - truth as f64).abs() / truth as f64;
+        assert!(
+            error < 0.025,
+            "octo HLL error {error:.4} exceeds 3σ (estimate {estimate}, truth {truth})"
+        );
+    }
+
+    #[test]
+    fn run_octo_count_frequencies_track_a_zipf_stream() {
+        let rows = 5;
+        let cols = 4096;
+        let stream = keys(200_000, 2_048, 9_502);
+        let inputs = inputs_from(&stream);
+
+        let mut truth = common::FreqTruth::default();
+        for k in &stream {
+            truth.observe(*k as i64);
+        }
+
+        let parent = run_octo(
+            &inputs,
+            &config(4),
+            |_| CountOctoWorker::new(rows, cols),
+            || CountOctoAggregator {
+                sketch: Cs::with_dimensions(rows, cols),
+            },
+        )
+        .parent
+        .sketch;
+
+        // Count-Sketch error is ±‖f‖₂/√cols w.h.p.; per OctoSketch Theorem 1
+        // the promotion protocol adds k'·τ, and round-robin makes k' = workers.
+        let tolerance =
+            3.0 * truth.l2_norm() / (cols as f64).sqrt() + 4.0 * MAX_CELL_RESIDUAL as f64;
+        let mut violations = Vec::new();
+        for (key, exact) in truth.top_k(64) {
+            let est = parent.estimate(&DataInput::U64(key as u64));
+            if (est - exact as f64).abs() > tolerance {
+                violations.push(format!("key {key}: est {est} vs exact {exact}"));
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "count-sketch estimates outside ±{tolerance:.1}: {violations:?}"
+        );
+    }
+}

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -13,9 +13,12 @@
 //! itself (NSDI '24, Zhang/Chen/Liu): whether estimates land inside Theorems
 //! 1, 3 and 4, and whether delta promotion actually beats the periodic
 //! sketch-merge baseline the paper measures against (Theorem 2, Figure 6).
-//! `run_octo` dispatches round-robin, so every key reaches every worker and
-//! the paper's k' - the number of workers a flow may pass by - equals k here,
-//! the worst case each of those bounds admits.
+//! The runtime defaults to `OctoPartition::HashByKey`, so a flow lands on one
+//! worker and the paper's k' - the number of workers a flow may pass by - is 1.
+//! The bound tests sweep `RoundRobin` as well, where k' = k. Note that k' is
+//! about a *flow*: a counter is shared by whatever flows hash into it, and each
+//! worker may hold back up to tau of its own share, so the provable per-counter
+//! gap is k*tau under either partition.
 
 mod common;
 
@@ -675,7 +678,7 @@ fn hll_sharded_children_match_a_single_pass_exactly() {
 }
 
 #[test]
-fn hll_cardinality_error_survives_the_delta_round_trip() {
+fn hll_cardinality_survives_the_delta_round_trip_exactly() {
     let truth = 100_000u64;
     let stream: Vec<u64> = (0..truth).collect();
     let (_, deltas) = hll_child_run(&stream);
@@ -683,14 +686,24 @@ fn hll_cardinality_error_survives_the_delta_round_trip() {
     for d in &deltas {
         parent.apply_delta(*d);
     }
+    let mut reference = HyperLogLog::<Classic>::default();
+    for k in &stream {
+        reference.insert(&DataInput::U64(*k));
+    }
 
-    // P14 standard error is 1.04/sqrt(2^14) ≈ 0.81%; allow 3σ.
-    let estimate = parent.estimate() as f64;
-    let error = (estimate - truth as f64).abs() / truth as f64;
-    assert!(
-        error < 0.025,
-        "delta-fed HLL error {error:.4} exceeds 3σ (estimate {estimate}, truth {truth})"
+    // At HLL_PROMASK = 0 every improvement is promoted, so this is an equality,
+    // not a tolerance: a band would pass on an implementation that dropped a
+    // slice of the register improvements.
+    assert_eq!(
+        parent.registers_as_slice(),
+        reference.registers_as_slice(),
+        "delta-fed registers must match a single pass byte for byte"
     );
+    assert_eq!(parent.estimate(), reference.estimate());
+    // The sketch's own accuracy, for context: P14 standard error is
+    // 1.04/sqrt(2^14) ~ 0.81%.
+    let error = (parent.estimate() as f64 - truth as f64).abs() / truth as f64;
+    assert!(error < 0.025, "P14 error {error:.4} exceeds 3 sigma");
 }
 
 // ---------------------------------------------------------------------------
@@ -1054,6 +1067,12 @@ mod runtime {
         );
         let reader = runtime.read_handle();
 
+        assert_eq!(
+            reader.with_parent(|p| p.per_worker.iter().sum::<u64>()),
+            0,
+            "nothing inserted yet"
+        );
+
         let mut last = 0u64;
         for i in 0..n {
             runtime.insert(DataInput::U64(i));
@@ -1068,10 +1087,25 @@ mod runtime {
             }
         }
 
-        let result = runtime.finish();
-        let total = result.parent.per_worker.iter().sum::<u64>();
-        assert_eq!(total, n);
-        assert!(total >= last, "final total must dominate every snapshot");
+        // Monotonicity alone is satisfied by a handle stuck at zero, so wait
+        // for it to actually reach the live total while the runtime is still
+        // open. That is the property the handle exists for.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let observed = reader.with_parent(|p| p.per_worker.iter().sum::<u64>());
+            assert!(observed >= last, "live total went backwards");
+            last = observed;
+            if observed == n {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "read handle stalled at {observed}/{n}"
+            );
+            std::hint::spin_loop();
+        }
+
+        assert_eq!(runtime.finish().parent.per_worker.iter().sum::<u64>(), n);
     }
 
     #[test]
@@ -1182,6 +1216,13 @@ mod runtime {
         .parent
         .sketch;
 
+        // Max-register promotion is lossless, so the runtime's parent must be
+        // the single-threaded sketch exactly, not merely within 3 sigma of it.
+        let mut reference = HyperLogLog::<Classic>::default();
+        for input in &inputs {
+            reference.insert(input);
+        }
+        assert_eq!(got.registers_as_slice(), reference.registers_as_slice());
         let estimate = got.estimate() as f64;
         let error = (estimate - truth as f64).abs() / truth as f64;
         assert!(
@@ -1896,7 +1937,10 @@ impl OnlineComparison {
         );
     }
 
-    /// Both baselines must be at least as expensive as the scheme they lose to.
+    /// Harness self-check, not evidence: `merge_periods` already rounds the
+    /// baseline's spend up past its budget. This catches a sizing bug that
+    /// would starve the baseline and make the comparison meaningless; the
+    /// printed spend multiples are what say how well it was funded.
     fn assert_baselines_were_funded(&self) {
         assert!(
             self.parity_counters >= self.octo_counters,

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -747,6 +747,8 @@ mod runtime {
         for (i, input) in inputs.iter().enumerate() {
             replay.insert(i, input);
         }
+        // `run_octo` flushes when the stream ends, so the replay must too.
+        replay.flush();
         replay.parent
     }
 
@@ -755,6 +757,7 @@ mod runtime {
         for (i, input) in inputs.iter().enumerate() {
             replay.insert(i, input);
         }
+        replay.flush();
         replay.parent
     }
 
@@ -1167,7 +1170,7 @@ mod runtime {
     // -- accuracy end to end -------------------------------------------------
 
     #[test]
-    fn run_octo_cm_zipf_error_stays_within_the_cms_bound_plus_the_residual() {
+    fn a_finished_run_carries_only_count_mins_own_one_sided_error() {
         let rows = 5;
         let cols = 4096;
         let stream = keys(200_000, 4_096, 9_501);
@@ -1180,19 +1183,18 @@ mod runtime {
 
         let parent = cm_runtime(&inputs, 4, rows, cols);
 
-        // Upper side: the usual one-sided CMS bound ε·N with ε = e/cols.
-        // Lower side: OctoSketch (NSDI '24) Theorem 1 charges the promotion
-        // protocol an additive k'·τ, where k' is the number of workers a key
-        // may reach. `run_octo` dispatches round-robin, so every key reaches
-        // every worker and k' = num_workers - the worst case of that bound.
+        // `run_octo` flushes when the stream ends, so no promotion residue
+        // survives and the protocol contributes nothing: what is left is
+        // Count-Min's own one-sided error, never below truth and at most eps*N
+        // above it with eps = e/cols. Between flushes the parent would instead
+        // sit up to k*tau low - that band is what the theorem tests measure.
         let epsilon_n = (std::f64::consts::E / cols as f64) * truth.total() as f64;
-        let floor = TAU as f64;
         for k in 0u64..4_096 {
             let exact = truth.get(k as i64) as f64;
             let est = parent.estimate(&DataInput::U64(k)) as f64;
             assert!(
-                est >= exact - floor,
-                "key {k}: octo estimate {est} fell more than {floor} below truth {exact}"
+                est >= exact,
+                "key {k}: a flushed Count-Min must never underestimate: {est} < {exact}"
             );
             assert!(
                 est <= exact + epsilon_n,
@@ -1254,9 +1256,9 @@ mod runtime {
         .parent
         .sketch;
 
-        // Count-Sketch error is ±‖f‖₂/√cols w.h.p.; per OctoSketch Theorem 1
-        // the promotion protocol adds k'·τ, and round-robin makes k' = workers.
-        let tolerance = 3.0 * truth.l2_norm() / (cols as f64).sqrt() + TAU as f64;
+        // A finished run is flushed, so the promotion protocol adds nothing
+        // and what is left is the Count-Sketch bound itself: +/- ||f||_2/sqrt(cols) w.h.p.
+        let tolerance = 3.0 * truth.l2_norm() / (cols as f64).sqrt();
         let mut violations = Vec::new();
         for (key, exact) in truth.top_k(64) {
             let est = parent.estimate(&DataInput::U64(key as u64));
@@ -1335,6 +1337,32 @@ impl OctoCm {
             self.parent.apply_delta(d);
         }
     }
+
+    /// Hands over every residual counter, mirroring what the runtime does when
+    /// a stream is finished or handed over for querying. The bound and
+    /// conservation tests deliberately do not call this: the residue is what
+    /// they are measuring.
+    fn flush(&mut self) {
+        let (rows, cols) = (self.parent.rows(), self.parent.cols());
+        for child in self.children.iter_mut() {
+            for row in 0..rows {
+                for col in 0..cols {
+                    let held = child.as_storage().query_one_counter(row, col);
+                    if held != 0 {
+                        self.parent.apply_delta(CmDelta {
+                            row: row as u32,
+                            col: col as u32,
+                            value: held as u32,
+                        });
+                        child
+                            .as_storage_mut()
+                            .update_one_counter(row, col, |c, _| *c = 0, ());
+                        self.sent_counters += 1;
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Sketch-merge: each worker keeps a full sketch and ships all `rows*cols`
@@ -1405,6 +1433,28 @@ impl OctoCs {
         self.sent_counters += promoted.len();
         for d in promoted {
             self.parent.apply_delta(d);
+        }
+    }
+
+    /// See `OctoCm::flush`.
+    fn flush(&mut self) {
+        let (rows, cols) = (self.parent.rows(), self.parent.cols());
+        for child in self.children.iter_mut() {
+            for row in 0..rows {
+                for col in 0..cols {
+                    let held = child.as_storage().query_one_counter(row, col);
+                    if held != 0 {
+                        self.parent.apply_delta(CountDelta {
+                            row: row as u32,
+                            col: col as u32,
+                            value: held,
+                        });
+                        child
+                            .as_storage_mut()
+                            .update_one_counter(row, col, |c, _| *c = 0, ());
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Brings the OctoSketch framework in line with the paper (NSDI '24), fixes what
the review found, and removes the module's only `unsafe`.

## Why

The module implemented Idea 1 (change-based updates) and nothing else. Idea 2
(adaptive thresholds) and Idea 3 (reconstructed workers, key storage only in the
aggregator) were absent, `tau` was a compile-time constant, four of the paper's
nine sketches were unwired, and `OctoRuntime::insert` was an unsound safe API.

## What changed

**Correctness**

- Delta indices were `u16`: any sketch wider than 65536 columns silently wrapped
  promotions onto the wrong cell. Now `u32`, with values widened to `u32`/`i32`
  so `tau` can reach the paper's own 128 without the `i8` value overflowing.
- Count-Min clears the counter it promotes (Algorithm 1) instead of testing
  `count % tau == 0` and letting the child run unbounded.
- `MAX_PROMASK` drops from 255 to 127. The signed one-byte workers clamped to
  `i8::MAX` while the shared threshold and the full sketches clamped to 255, so a
  `tau` in `128..=255` meant two different things in one pipeline and left the
  adaptive controller a band where raising it changed nothing.
- `L2hhWorkerSketch` refuses a geometry whose per-row shifts leave the 128-bit
  hash; release builds used to wrap the shift and alias a deep row onto a shallow
  one.
- `DDSketch::apply_delta` bounds the index by its own mapping; a delta from a
  finer-alpha worker used to grow the dense store across the gap to `i32::MAX`.
- `HllOctoWorker` refuses a threshold no register gain can reach, instead of
  promoting nothing and leaving the parent estimating zero.
- `UnivMonOctoAggregator` recomputes per-layer completeness from the live `tau`;
  a verdict frozen at construction let a layer keep claiming a complete candidate
  set after the controller raised `tau` past 1, which sends `heavy_threshold`
  down its permissive branch and overcounts.
- The aggregator rejects a worker-id collision rather than folding two workers
  into one slot and turning the fleet total into a maximum.

**Soundness**

`insert` took a `DataInput<'_>` whose lifetime was unrelated to the runtime,
transmuted it to `'static` and queued it for another thread. Safe code could hand
over a borrowed `&str` and free it on the next line, and workers hashed freed
heap. `a_borrowed_key_may_be_dropped_the_moment_insert_returns` is the
regression test; it fails on the old code and passes now.

The fix is not to make the key outlive the runtime — a borrowed key exists
precisely so its owner does not have to. It is to finish with the borrow before
the hand-off. `OctoPlan` stays on the dispatching thread, holds the geometry,
builds the workers, and converts each input into a borrow-free payload: hashes
for a worker that only hashes, an owned key only where one must be stored.
`octo.rs` now contains no `unsafe`.

**The paper's missing pieces**

- One-byte worker counters with no key storage (§4.1, §3.2 Idea 3), the paper's
  4x memory saving.
- `tau` as a shared `OctoThreshold`, with `OctoAdaptiveThreshold` implementing the
  queue-driven control of §4.3 (Equations 1 and 2) and `threshold_for_error`
  implementing Equation 4.
- `OctoPartition::HashByKey`, now the default, giving each flow one worker.
- Keyed deltas, so the `*TopK*` aggregators hold the pipeline's only
  heavy-hitter heap (Algorithm 2).
- DDSketch and UnivMon worker/aggregator pairs.
- `flush`, so a query answers against the whole stream. Count-Min and Count only
  sit under `tau` low between promotions, but a DDSketch bucket that never
  reaches `tau` is *absent* — a near-distinct stream left the parent holding
  nothing and every quantile returning `None`.

**A finding the paper does not cover**

UnivMon's pyramid is sparse by construction: layer L carries about `n / 2^L`. A
flat threshold sized for layer 0 starves the deep layers the recursive estimator
depends on — at `tau = 31` over 12 layers, layers 10 and 11 came out empty and the
cardinality estimate collapsed from 3387 to 187. `univmon_layer_threshold` halves
`tau` per layer with a floor of 1, and the cardinality comes back: 187 under a
flat threshold against 3387 under the scaled one, which is the single-core
answer exactly. `a_flat_threshold_starves_the_deep_univmon_layers` reproduces
both arms from the tree, and `run_octo_univmon_reaches_the_deepest_layer` checks
the structural half against the shipped pipeline.

## Measurements

`tests/e2e_octo.rs` compares delta promotion against periodic sketch-merge for
every integrated sketch, at matched communication budget, querying while the
stream runs:

| sketch | metric | single core | octo | merge, comparable budget |
| --- | --- | --- | --- | --- |
| Count-Min | top-32 mean abs error vs truth | 3.4 | 13.8 | 194.3 at 4.2x |
| Count | top-32 mean abs error vs truth | 1.86 | 14.97 | 158.3 at 8.2x |
| HyperLogLog (τ=0) | cardinality rel. error vs truth | 0.0039 | 0.0039 | 0.2489 at 4.4x |
| UnivMon (τ=64) | g-sum **gap to the single-core sketch** | not applicable (own error vs truth 0.0398) | 0.0062 | 0.564 at 6.6x |
| UnivMon (τ=64) | top-16 recall at layer 0 | not measured | 0.961 | 0.500 at 6x |
| DDSketch (τ=4) | quantile rel. error vs truth | 0.0045 | 0.0859 | 0.0045 at 3.0x |

The two UnivMon rows do not use the same metric as the others and the column
cannot be read straight down. UnivMon's own approximation error at these
dimensions is larger than anything a distribution scheme adds, so its octo and
merge figures are distances from a single-core sketch (the paper's Definition 1)
rather than errors against truth; measured on the others' metric it would be
about 0.04. The recall row has no single-core column because that comparison was
never run: it measures octo against sketch-merge only. UnivMon's g-sum figures
are not bit-stable across runs — its query path iterates a `HashMap`, whose seed
is randomised per process — so they are quoted to three significant figures. The HyperLogLog row is an equality by construction: at τ=0 every
register improvement is promoted, so the parent *is* the single-core sketch.

DDSketch is the one integrated sketch where delta promotion does not pay off, and
the suite pins that rather than hiding it: a lagging Count-Min counter is still
counted, a missing bucket is not, and a quantile is a statement about where mass
sits.

`examples/octo_throughput_probe.rs` separates the three stages and prints the
host it measured, because absolute rates belong to a machine. What is
machine-independent, and exact for that workload, is the message volume: an
insert produces 9.169 deltas at τ=1, 1.435 at τ=16, 0.441 at τ=64 and 0.278 at
τ=127, while the gap to a single-core answer stays at 0.0000 through τ=32 and
reaches only 0.0005 at τ=127.

The shape that follows: a worker's per-insert work is a hash and a few one-byte
increments, because the L2 accumulator, the median estimate and the heavy-hitter
heap all move to the aggregator, which touches them once per promotion rather
than once per insert. But one aggregator serves every worker, so the pipeline
ceiling is its rate over deltas per insert — at τ=1 an insert makes about nine
deltas and the pipeline is *slower* than a single core, with break-even near
τ=16 on the machine this was developed on. Since accuracy stays flat well past
τ=64, the trade is throughput against messages rather than against error, which
is why τ is what the controller drives.

## Known limits

- The aggregator's ceiling is `HHHeap::refresh_positions`, which rebuilds the
  whole position index on every accepted update; its rate falls off as
  `1/heap_size`. Single-threaded UnivMon pays the same cost per insert. Fixing it
  is a separate change in shared code.
- Core pinning is a silent no-op on Apple Silicon: arm64 rejects
  `thread_policy_set(THREAD_AFFINITY_POLICY)`, and `core_affinity::get_core_ids`
  reports a count without testing it. Measurements here are unpinned.
- CocoSketch and Elastic sketch are still unwired; both replace a whole
  `(key, counter)` bucket rather than incrementing a cell, so they need a
  bucket-valued delta.
- The keyed workers cannot flush: their deltas carry the key and a worker keeps
  no key storage, so a residual cell cannot be attributed back to a key. The
  consequence is sharper than a low counter — the aggregator only learns a key
  exists from a delta, so under `HashByKey` a key is invisible to the top-k heap
  until it occurs τ times. 20 collision-free keys at 30 occurrences
  each with τ=31 leave the heap empty; one more occurrence each and all 20
  appear. Collisions move that boundary in both directions.
- Between flushes a shared cell trails by up to `workers · (τ - 1)`, not τ.
- `OctoRuntime::insert` prepares on the calling thread, so that thread is a
  serialization point for the whole fleet. The paper instead has each worker
  pull from its own NIC queue.
- HyperLogLog is only really usable at τ=0: a held-back register reads at the
  parent as an empty bucket rather than a low one, and the harmonic mean the
  estimator is built on collapses.
- Count-Min and Count delta paths call the free `hash64_seeded` while
  `insert`/`estimate` call `H::hash64_seeded`, so a non-default `SketchHasher`
  would promote and query different cells. Pre-existing; every non-default impl
  in the repo is behind `#[cfg(test)]`.

## Tests

108 Octo tests, 53 in `tests/e2e_octo.rs` and 55 in-module. The load-bearing ones
are equalities rather than tolerances: per-cell conservation between a worker's
residue and its parent, the runtime against a single-threaded replay of the same
partition, and a one-worker UnivMon at `tau=1` reproducing a single-threaded
sketch exactly — counters, L2, heaps, total weight and g-sum. On top of that sit
the paper's Theorems 1, 3 and 4 with measured violation rates against delta, and
Theorem 2's communication ratio.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets
--all-features --locked -- -D warnings` and `cargo test --all-features --locked`
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



