### PR TITLE
feat(cms): carry i32 counters on the ASAPv1 wire (0x02 0x00)

### DIFF
--- a/docs/api/api_countmin.md
+++ b/docs/api/api_countmin.md
@@ -62,13 +62,13 @@ fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
 These produce/consume the **ASAPv1** wire envelope (kind `0x02 0x00`) — see the
 [ASAPv1 wire format spec](../asapv1_wire_format.md). They are **not** available
 on every `CountMin`: the impl exists only for wire-eligible configs
-`CountMin<Vector2D<T>, Mode, H>` where `T` is `i64` or `f64` (`CmsWireCounter`),
-`Mode` is `FastPath` or `RegularPath` (`CmsWireMode`), and `H: HashProfile`. The
-default storage is `Vector2D<i32>`, which is **not** wire-eligible — an `i32` /
+`CountMin<Vector2D<T>, Mode, H>` where `T` is `i32`, `i64` or `f64`
+(`CmsWireCounter`), `Mode` is `FastPath` or `RegularPath` (`CmsWireMode`), and
+`H: HashProfile`. `i32` is carried at its own width and pinned on decode. An
 `i128` / other exotic-counter or non-`Vector2D` sketch must be converted to a
-`Vector2D<i64>` / `Vector2D<f64>` first (only you know if the mapping is
-lossless). `rows`/`cols` are carried in the envelope metadata; the payload is
-just `[counts]`.
+wire-eligible storage first (only you know if the mapping is lossless).
+`rows`/`cols` are carried in the envelope metadata; the payload is just
+`[counts]`.
 
 ## Examples
 

--- a/docs/asapv1_wire_format.md
+++ b/docs/asapv1_wire_format.md
@@ -283,7 +283,7 @@ The two tables below are the field-by-field detail of each group.
 | `precision` | u8 | HLL | `12` / `14` / `16`; register count = `2^precision` |
 | `rows` | u32 | Count-Min, Bloom | matrix depth; for Bloom the number of slices |
 | `cols` | u32 | Count-Min, Bloom | matrix width; for Bloom the bits per slice |
-| `counter_type` | string | Count-Min | `"i64"` or `"f64"`; element type of `counts` |
+| `counter_type` | string | Count-Min | `"i32"`, `"i64"` or `"f64"`; element type of `counts`, never widened |
 | `mode` | string | Count-Min, Bloom | `"fast"` or `"regular"`; key-to-column derivation |
 | `k` | u32 | KLL | compactor capacity (accuracy parameter) |
 | `m` | u32 | KLL | minimum level capacity |
@@ -363,7 +363,7 @@ The variant is in `kind_id`, precision is in the metadata (and equals `log2(regi
 
 The `CountMin` struct is generic in memory (counter `i32`/`i64`/`i128`/`f64`, `RegularPath`/`FastPath`, Nitro, and so on).
 **That freedom is kept in memory; nothing is forbidden.**
-The wire supports a fixed set. The two parameters that shape it, **counter type** (`"i64"`/`"f64"`) and **mode** (`"fast"`/`"regular"`), live in the metadata, so the payload itself is just shape and counters:
+The wire supports a fixed set. The two parameters that shape it, **counter type** (`"i32"`/`"i64"`/`"f64"`) and **mode** (`"fast"`/`"regular"`), live in the metadata, so the payload itself is just shape and counters:
 
 | Pos | Field | Type | Notes |
 | ----- | ------- | ------ | ------- |
@@ -372,9 +372,9 @@ The wire supports a fixed set. The two parameters that shape it, **counter type*
 `rows` and `cols` live in the metadata as structural params (Section 2), so the payload omits them.
 The payload is a **1-element positional array `[counts]`**, mirroring HLL Classic's `[registers]`.
 
-Wire counter types are `i64` and `f64` only (`i32` widens to `i64`; `i128` and exotic counters are not wire types).
+Wire counter types are `"i32"`, `"i64"` and `"f64"` (`i128` and exotic counters are not wire types). `i32` is carried at its own width, not widened, and the decoder pins it: `i32` bytes do not decode into an `i64` sketch, or the reverse.
 `mode` records `RegularPath` vs `FastPath` because they place a key in different columns (compare `cm_regular_path_correctness` vs `cm_fast_path_correctness`), so a reader must know which to reproduce a query.
-A counter type other than i64/f64, or non-`Vector2D` storage, must be converted first; see Section 5, "Converting an exotic in-memory sketch".
+A counter type other than i32/i64/f64, or non-`Vector2D` storage, must be converted first; see Section 5, "Converting an exotic in-memory sketch".
 Both modes, `FastPath` and `RegularPath`, serialize directly (you'd only "convert" a mode to *change* it, which needs re-inserting the data).
 
 ### 3.3: KLL payload (`0x06 0x00` compact / `0x06 0x01` dynamic)
@@ -575,7 +575,7 @@ Fail **closed** on any mismatch:
 2. Every hash-spec field matches the **target hasher's** `HashProfile`: decode compares the read metadata against `hll_metadata::<H>` / `cms_metadata::<H>` for the exact type being decoded into, so it does not merely accept the standard profile. Bytes carrying a different profile are rejected.
 3. Structural params are consistent with `kind_id` and the payload:
    - HLL: `registers.len() == 2^precision ==` the target storage's register count.
-   - Count-Min: `counts` element type matches `counter_type`; `counts.len() == rows*cols`.
+   - Count-Min: `counts` element type matches `counter_type` (`"i32"`/`"i64"`/`"f64"`, never widened); `counts.len() == rows*cols`.
    - Count Sketch: `counts` element type matches `counter_type` (`"i32"`/`"i64"`, never widened); `counts.len() == rows*cols`.
 
 ### Converting an exotic in-memory sketch to a wire form
@@ -623,7 +623,7 @@ Keep it through the transition, retire `portable` once goldens are in place.
 - **Q-META**: metadata is a msgpack **map**; canonical key order per Section 4; optional fields are omitted keys.
 - **Q-SEEDS**: `seed_list` is **inlined** in v1 so the bytes self-describe the hash. Resolving seeds from `hash_profile_id` alone is a v2 space optimization. Each sketch still carries only the seed *index* it uses.
 - **Q-PROFILE**: the hash-spec metadata is **derived from the hasher's `HashProfile`** (`hll_metadata::<H>` / `cms_metadata::<H>`) and never hardcoded, so it is always truthful to the hasher. Custom hash profiles are **supported and self-describing**. Merge compatibility is hash-spec equality, so a custom-profile sketch is not mergeable with a standard one.
-- **Q-CMS**: Count-Min is one `kind_id` (`0x02 0x00`); counter type and mode live in the metadata, so the id stays single.
+- **Q-CMS**: Count-Min is one `kind_id` (`0x02 0x00`); counter type and mode live in the metadata, so the id stays single. The counter-type domain is `"i32"`, `"i64"` and `"f64"`, with no `i128` (no msgpack integer form); `i32` is recorded at its own width and pinned on decode.
 - **Q-KLL**: KLL metadata carries **no hash-spec group** — KLL is comparison-based and never hashes, so those fields have no truthful value. Its metadata is structural-only (`metadata_version`, `k`, `m`, `item_type`, optional `seed`) and is *not* `HashProfile`-derived. The two KLL variants (compact `0x06 0x00`, dynamic `0x06 0x01`) share one payload `[levels, items, coin]` and differ only by `kind_id`. `item_type` (`"f64"`/`"i64"`) is a metadata param, not a separate `kind_id` (mirrors Q-CMS's `counter_type`). Retained samples use the top-most-level-first layout that matches `sketchlib-go`'s `KLLState`.
 - **Q-KLL-SEED**: KLL records its reproducible compaction `seed` as an **optional** metadata key. It is construction config (so metadata, not payload, per the config→metadata rule), and it is the first optional key in v1: present only when the sketch carries a seed, omitted otherwise. Rationale: the payload's `coin` already carries the RNG's *current* position (enough to resume compaction), but `seed` is what a later `clear()` re-seeds from — so serializing it lets a decoded sketch keep `clear()`-reproducibility instead of falling back to wall-clock. Cost of omitting it is bounded (only a decoded-then-`clear()`ed sketch loses cross-run byte reproducibility — never correctness), but it is cheap to carry and future-proofs the checkpoint/restore path. `KLLDynamic` has no seed concept and never emits the key; the two variants are deliberately **not** forced to be symmetric here. Go carries and preserves the key without interpreting it.
 - **Q-CS**: Count Sketch is one `kind_id` (`0x04 0x00`) and mirrors Count-Min's metadata and `[counts]` payload, including `counter_type`. Its type domain differs: `"i32"` and `"i64"`, with no `"f64"` (counters must be signed and negatable) and no `i128` (no msgpack integer form). Structural-param order matches Q-CMS: `... matrix_seed_index, rows, cols, counter_type, mode`. **`i32` is not widened to `i64`** — unlike Count-Min, whose counters are plain numbers, a Count Sketch appears *nested* inside `HydraCounter` and `EHSketchList` as `Vector2D<i32>` and must decode back into that variant, so the width is identity and is recorded exactly. Cells are signed, so a decoder must not assume monotonicity.

--- a/src/message_pack_format/native/countminsketch.rs
+++ b/src/message_pack_format/native/countminsketch.rs
@@ -1,8 +1,8 @@
 //! Native MessagePack codec impl for [`crate::sketches::countminsketch::CountMin`].
 //!
-//! Only the canonical wire configs — i64/f64 counters (`CmsWireCounter`) with a
-//! fast/regular mode (`CmsWireMode`) — are serializable. Exotic in-memory
-//! counters (i32/i128/…) must be converted to a wire type first.
+//! Only the canonical wire configs — i32/i64/f64 counters (`CmsWireCounter`)
+//! with a fast/regular mode (`CmsWireMode`) — are serializable. Exotic in-memory
+//! counters (i128/…) must be converted to a wire type first.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/sketches/countminsketch/wire.rs
+++ b/src/sketches/countminsketch/wire.rs
@@ -10,11 +10,12 @@
 //!
 //! Count-Min is one algorithm — a single kind_id `0x02 0x00`. The structural
 //! parameters — the matrix dimensions (`rows` / `cols`), the **counter type**
-//! (i64/f64) and the column-derivation **mode** (fast/regular) — all live in the
-//! metadata, so the payload itself is just `[counts]` (a 1-element array
+//! (i32/i64/f64) and the column-derivation **mode** (fast/regular) — all live in
+//! the metadata, so the payload itself is just `[counts]` (a 1-element array
 //! mirroring HLL Classic's `[registers]`). Only the canonical wire configs
-//! (i64/f64 counters × fast/regular) get a serialization; exotic in-memory
-//! counters (i32/i128/…) must be converted to a wire type first.
+//! (i32/i64/f64 counters × fast/regular) get a serialization; exotic in-memory
+//! counters (i128/…) must be converted to a wire type first. `i32` is carried at
+//! its own width and is pinned on decode.
 
 use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
 use serde::{Deserialize, Serialize};
@@ -28,10 +29,13 @@ use super::CountMin;
 const CMS_KIND: &[u8] = &[0x02, 0x00];
 
 /// Names the wire counter type carried in the metadata (`counter_type`).
-/// Implemented only for the two wire-eligible counter types.
+/// Implemented only for the wire-eligible counter types.
 pub trait CmsWireCounter: Copy {
-    /// Metadata `counter_type` string — `"i64"` or `"f64"`.
+    /// Metadata `counter_type` string — `"i32"`, `"i64"` or `"f64"`.
     const COUNTER_TYPE: &'static str;
+}
+impl CmsWireCounter for i32 {
+    const COUNTER_TYPE: &'static str = "i32";
 }
 impl CmsWireCounter for i64 {
     const COUNTER_TYPE: &'static str = "i64";
@@ -351,5 +355,71 @@ mod tests {
         };
         let bytes = rmp_serde::to_vec_named(&extra).unwrap();
         assert!(rmp_serde::from_slice::<CmsMetadata>(&bytes).is_err());
+    }
+
+    /// The `i32` wire config round-trips, and the counter type is pinned by the
+    /// target: i32 bytes must not decode into an i64 sketch or the reverse.
+    #[test]
+    fn count_min_i32_round_trips_and_is_pinned_by_counter_type() {
+        let cells = |r: usize, c: usize| (r * 4 + c) as i32;
+        let narrow =
+            CountMin::<Vector2D<i32>, RegularPath>::from_storage(Vector2D::from_fn(2, 4, cells));
+        let wide = CountMin::<Vector2D<i64>, RegularPath>::from_storage(Vector2D::from_fn(
+            2,
+            4,
+            |r, c| cells(r, c) as i64,
+        ));
+
+        let narrow_bytes = narrow.serialize_to_bytes().expect("serialize i32");
+        assert_eq!(&narrow_bytes[7..10], &[2u8, 0x02, 0x00]);
+        let decoded = CountMin::<Vector2D<i32>, RegularPath>::deserialize_from_bytes(&narrow_bytes)
+            .expect("decode i32");
+        assert_eq!(
+            narrow.as_storage().as_slice(),
+            decoded.as_storage().as_slice()
+        );
+
+        // The two sketches hold numerically equal cells, so only the metadata
+        // `counter_type` separates their bytes.
+        let wide_bytes = wide.serialize_to_bytes().expect("serialize i64");
+        assert_ne!(narrow_bytes, wide_bytes);
+        assert!(
+            CountMin::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&narrow_bytes).is_err(),
+            "i32 bytes must not decode as an i64 sketch"
+        );
+        assert!(
+            CountMin::<Vector2D<i32>, RegularPath>::deserialize_from_bytes(&wide_bytes).is_err(),
+            "i64 bytes must not decode as an i32 sketch"
+        );
+    }
+
+    /// Each of the three wire counter types rejects the others' bytes.
+    #[test]
+    fn count_min_counter_types_reject_each_other() {
+        let float = CountMin::<Vector2D<f64>, RegularPath>::from_storage(Vector2D::from_fn(
+            2,
+            4,
+            |r, c| (r * 4 + c) as f64,
+        ));
+        let float_bytes = float.serialize_to_bytes().expect("serialize f64");
+        assert!(
+            CountMin::<Vector2D<i32>, RegularPath>::deserialize_from_bytes(&float_bytes).is_err(),
+            "an i32 sketch must reject f64 bytes"
+        );
+        assert!(
+            CountMin::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&float_bytes).is_err(),
+            "an i64 sketch must reject f64 bytes"
+        );
+
+        let narrow = CountMin::<Vector2D<i32>, RegularPath>::from_storage(Vector2D::from_fn(
+            2,
+            4,
+            |r, c| (r * 4 + c) as i32,
+        ));
+        let narrow_bytes = narrow.serialize_to_bytes().expect("serialize i32");
+        assert!(
+            CountMin::<Vector2D<f64>, RegularPath>::deserialize_from_bytes(&narrow_bytes).is_err(),
+            "an f64 sketch must reject i32 bytes"
+        );
     }
 }


### PR DESCRIPTION
Adds `"i32"` as a legal `counter_type` for the Count-Min wire form (kind_id `0x02 0x00`), making Count-Min symmetric with Count Sketch (`0x04 0x00`), which already carries `i32` at its own width.

This unblocks nested Count-Min decoding: `HydraCounter::CM`, `EHSketchList::CM` and `Elastic::light` all hold `Vector2D<i32>`, and a nested sketch must decode back into the exact variant it was stored as. Before this change `CmsWireCounter` was implemented only for `i64` and `f64`, so an `i32` Count-Min could not serialize at all.

**No existing bytes change.** An `i64` or `f64` Count-Min encodes byte-identically before and after; the only new bytes are those produced by the newly reachable `i32` config. The `counter_type` stays pinned on decode through the existing `meta != cms_metadata::<H>(...)` equality check — no validation was weakened.

## Code

- `impl CmsWireCounter for i32` in `src/sketches/countminsketch/wire.rs`. The existing impl bounds (`AddAssign + Serialize + Deserialize`) are already satisfied by `i32` — `Vector2D<i32>` is `CountMin`'s default storage — so no bounds were widened and the impl was not restructured.
- Module docs in `src/sketches/countminsketch/wire.rs` and `src/message_pack_format/native/countminsketch.rs` now name the current wire counter set (`i32`/`i64`/`f64`). The `MessagePackCodec` shim needed no bound changes; the `i32` config is reachable through it as-is.

## Tests added

Both in `mod tests` of `src/sketches/countminsketch/wire.rs`; no existing test was weakened or removed.

- `count_min_i32_round_trips_and_is_pinned_by_counter_type` — an `i32` Count-Min round-trips through `serialize_to_bytes` / `deserialize_from_bytes` under the `0x02 0x00` kind_id; two Count-Mins holding numerically equal cells, one `i32` and one `i64`, produce different bytes (only the metadata `counter_type` separates them), and each rejects the other's bytes.
- `count_min_counter_types_reject_each_other` — `f64` bytes are rejected by both the `i32` and the `i64` target, and `"i32"` bytes are rejected by the `f64` target.

## Docs

`docs/asapv1_wire_format.md`: §3.2 wire-counter-types line (the `i32` widens to `i64` clause is gone), the §2 Structural params `counter_type` row, §5 Validation item 3's Count-Min bullet, and the `Q-CMS` decision entry. `docs/api/api_countmin.md`'s wire-eligible-config paragraph.

## CI

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --all-features --locked --verbose` — all suites pass (768 unit tests + integration suites, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
