### PR TITLE
feat(uniform): ASAPv1 wire payload for UniformSampling (0x0d 0x00)

### DIFF
--- a/docs/api/api_uniform_sampling.md
+++ b/docs/api/api_uniform_sampling.md
@@ -45,7 +45,18 @@ fn merge(&mut self, other: &UniformSampling) -> Result<(), &'static str>
 
 ## Serialization
 
-Derives serde; no dedicated byte API helpers.
+```rust
+fn serialize_to_bytes(&self) -> Result<Vec<u8>, rmp_serde::encode::Error>
+fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, rmp_serde::decode::Error>
+```
+
+ASAPv1 wire format, kind_id `0x0d 0x00`. Metadata carries `metadata_version`,
+`sample_rate` and `item_type`; the sampler does not hash, so there is no
+hash-spec group. The payload is `[priorities, values, total_seen, rng_state]`,
+emitted in ascending priority. `rng_state` is the SplitMix64 word the next
+priority is drawn from, so a decoded sampler continues the same draw sequence.
+
+Also derives serde for the internal Rust-only codec.
 
 ## Examples
 

--- a/src/sketches/uniform.rs
+++ b/src/sketches/uniform.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::DataInput;
 
+mod wire;
+
 const DEFAULT_SEED: u64 = 0x9E37_79B9_7F4A_7C15;
 const GAMMA: u64 = 0xBF58_476D_1CE4_E5B9;
 const DELTA: u64 = 0x94D0_49BB_1331_11EB;

--- a/src/sketches/uniform/wire.rs
+++ b/src/sketches/uniform/wire.rs
@@ -1,0 +1,479 @@
+//! ASAPv1 wire serialization for [`UniformSampling`].
+//!
+//! Child submodule of [`crate::sketches::uniform`]: it holds ALL of the
+//! sampler's serialization (the metadata/payload DTOs, the kind_id constant,
+//! and the `serialize_to_bytes` / `deserialize_from_bytes` impls).
+//!
+//! Being a descendant module, it reads the private `sample_rate`, `total_seen`,
+//! `rng_state` and `entries` fields directly and rebuilds the struct without
+//! widening any field visibility.
+//!
+//! UniformSampling is one algorithm — a single kind_id `0x0d 0x00`.
+//!
+//! ## No hash spec
+//!
+//! The sampler never hashes: it draws a SplitMix64 priority per update and
+//! orders entries by that priority. So the hash-spec metadata group has no
+//! truthful value here and is omitted entirely, as KLL's is.
+//!
+//! ## RNG state
+//!
+//! `rng_state` is the SplitMix64 word the next priority is drawn from, carried
+//! in the payload so a decoded sampler continues the same draw sequence. It is
+//! the counterpart of KLL's `coin`.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+
+use super::{SampleEntry, UniformSampling};
+
+/// UniformSampling kind_id: family `0x0d`, single algorithm variant `0x00`.
+const US_KIND: &[u8] = &[0x0d, 0x00];
+
+/// Metadata `item_type`: the sampler stores every retained sample as `f64`.
+const SAMPLE_ITEM_TYPE: &str = "f64";
+
+/// UniformSampling descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`) with keys in this declaration order — the canonical order
+/// the wire spec fixes (Go must mirror it).
+///
+/// Structural params only; the sampler does not hash, so there is no hash-spec
+/// group. `deny_unknown_fields` makes decode fail closed on any unexpected key.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UsMetadata {
+    metadata_version: u8,
+    sample_rate: f64,
+    item_type: String,
+}
+
+/// Builds the UniformSampling descriptor metadata. `sample_rate` is the
+/// sampler's construction rate; `item_type` names the element type of the
+/// payload's `values` array.
+fn us_metadata(sample_rate: f64) -> UsMetadata {
+    UsMetadata {
+        metadata_version: 1,
+        sample_rate,
+        item_type: SAMPLE_ITEM_TYPE.to_string(),
+    }
+}
+
+/// UniformSampling payload (ASAPv1 §3.8), a msgpack **array** (`to_vec`,
+/// positional): `[priorities, values, total_seen, rng_state]`.
+///
+/// `priorities` and `values` are parallel and equal-length; the number of
+/// retained samples is `len(values)` (derived, so not stored). `sample_rate`
+/// lives in the metadata.
+#[derive(Debug, Serialize, Deserialize)]
+struct UsPayload {
+    priorities: Vec<u64>,
+    values: Vec<f64>,
+    total_seen: u64,
+    rng_state: u64,
+}
+
+/// The canonical emitted order: ascending `priority`, ties broken by
+/// `f64::total_cmp` on the parallel value. Fixes one encoding per retained set.
+fn canonical_order(a: &(u64, f64), b: &(u64, f64)) -> std::cmp::Ordering {
+    a.0.cmp(&b.0).then_with(|| a.1.total_cmp(&b.1))
+}
+
+/// Rejects a rate outside `(0, 1]`, matching the constructor's own bound.
+/// A crafted rate must not reach `target_size`.
+fn check_sample_rate(sample_rate: f64) -> Result<(), String> {
+    if sample_rate.is_finite() && sample_rate > 0.0 && sample_rate <= 1.0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "UniformSampling sample_rate must be within (0, 1], got {sample_rate}"
+        ))
+    }
+}
+
+// Wire serialization for the sampler. `wire` is a descendant of the sketch
+// module, so this impl reads the private fields directly.
+impl UniformSampling {
+    /// Serializes the sampler into an ASAPv1 MessagePack envelope. Entries are
+    /// emitted in the canonical order (ascending priority, ties by
+    /// `total_cmp`), so a decoded sampler re-serializes byte-identically.
+    ///
+    /// A sampler holding more entries than its own rate allows, or carrying a
+    /// rate outside `(0, 1]`, is an error rather than bytes that would be
+    /// refused on decode.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        check_sample_rate(self.sample_rate).map_err(RmpEncodeError::Syntax)?;
+        let target = Self::target_size(self.total_seen, self.sample_rate);
+        if self.entries.len() > target {
+            return Err(RmpEncodeError::Syntax(format!(
+                "ASAPv1 UniformSampling envelope: {} entries exceed the target size {target} for total_seen {}",
+                self.entries.len(),
+                self.total_seen
+            )));
+        }
+        let mut ordered: Vec<(u64, f64)> = self
+            .entries
+            .iter()
+            .map(|entry| (entry.priority, entry.value))
+            .collect();
+        ordered.sort_by(canonical_order);
+        let metadata = rmp_serde::to_vec_named(&us_metadata(self.sample_rate))?;
+        let payload = rmp_serde::to_vec(&UsPayload {
+            priorities: ordered.iter().map(|e| e.0).collect(),
+            values: ordered.iter().map(|e| e.1).collect(),
+            total_seen: self.total_seen,
+            rng_state: self.rng_state,
+        })?;
+        Ok(envelope::encode(US_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a sampler from an ASAPv1 MessagePack envelope. The rate is
+    /// read from the (validated) metadata; the payload carries the retained
+    /// entries plus the two running scalars.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != US_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UniformSampling kind_id mismatch: stored {kind_id:?}, expected {US_KIND:?}"
+            )));
+        }
+        let meta: UsMetadata = from_slice(metadata)?;
+        check_sample_rate(meta.sample_rate).map_err(RmpDecodeError::Uncategorized)?;
+        // `sample_rate` is a property of the stored sampler, so it is echoed
+        // back into the expected block; `metadata_version` and `item_type` are
+        // pinned by the comparison.
+        if meta != us_metadata(meta.sample_rate) {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 UniformSampling envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let p: UsPayload = from_slice(payload)?;
+        if p.priorities.len() != p.values.len() {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UniformSampling priorities length {} != values length {}",
+                p.priorities.len(),
+                p.values.len()
+            )));
+        }
+        // The declared stream length never sizes an allocation: the entry
+        // vector is built from `len(values)`, so a payload declaring
+        // `total_seen = u64::MAX` with two samples costs two samples.
+        let target = Self::target_size(p.total_seen, meta.sample_rate);
+        if p.values.len() > target {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UniformSampling payload holds {} samples, above the target size {target} for total_seen {}",
+                p.values.len(),
+                p.total_seen
+            )));
+        }
+        let mut entries: Vec<SampleEntry> = Vec::with_capacity(p.values.len());
+        for (idx, (&priority, &value)) in p.priorities.iter().zip(p.values.iter()).enumerate() {
+            // Entries are held in ascending priority; `insert_entry` binary
+            // searches on that invariant, so an unordered payload is rejected
+            // rather than decoded into a sampler that misplaces its next entry.
+            if idx > 0
+                && canonical_order(
+                    &(p.priorities[idx - 1], p.values[idx - 1]),
+                    &(priority, value),
+                ) == std::cmp::Ordering::Greater
+            {
+                return Err(RmpDecodeError::Uncategorized(format!(
+                    "UniformSampling entries must be in ascending priority order, broken at index {idx}"
+                )));
+            }
+            entries.push(SampleEntry::new(priority, value));
+        }
+        Ok(UniformSampling {
+            sample_rate: meta.sample_rate,
+            total_seen: p.total_seen,
+            rng_state: p.rng_state,
+            entries,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filled(rate: f64, seed: u64, count: u64) -> UniformSampling {
+        let mut sampler = UniformSampling::with_seed(rate, seed);
+        for value in 0..count {
+            sampler.update(value as f64);
+        }
+        sampler
+    }
+
+    fn crafted(metadata: &UsMetadata, payload: &UsPayload) -> Vec<u8> {
+        envelope::encode(
+            US_KIND,
+            &rmp_serde::to_vec_named(metadata).unwrap(),
+            &rmp_serde::to_vec(payload).unwrap(),
+        )
+    }
+
+    #[test]
+    fn uniform_sampling_round_trip_serialization() {
+        let sampler = filled(0.25, 0xBEEF_FACE, 40);
+
+        let encoded = sampler.serialize_to_bytes().expect("serialize sampler");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x0d, 0x00]); // kind_id_len=2, kind_id=[0x0d,0x00]
+
+        let decoded =
+            UniformSampling::deserialize_from_bytes(&encoded).expect("deserialize sampler");
+
+        assert_eq!(sampler.sample_rate(), decoded.sample_rate());
+        assert_eq!(sampler.total_seen(), decoded.total_seen());
+        assert_eq!(sampler.len(), decoded.len());
+        assert_eq!(sampler.samples(), decoded.samples());
+    }
+
+    /// The priorities are payload state, not derived: a decoded sampler must
+    /// re-serialize to the exact bytes it decoded from.
+    #[test]
+    fn uniform_sampling_re_encodes_byte_identically() {
+        let sampler = filled(0.5, 0xFACE_FACE, 33);
+        let encoded = sampler.serialize_to_bytes().expect("serialize");
+        let decoded = UniformSampling::deserialize_from_bytes(&encoded).expect("decode");
+        assert_eq!(encoded, decoded.serialize_to_bytes().expect("re-serialize"));
+    }
+
+    /// The payload carries the RNG position, so a decoded sampler fed the same
+    /// later updates reaches the same state as the original fed those updates.
+    #[test]
+    fn uniform_sampling_rng_state_resumes_the_same_sequence() {
+        let mut sampler = filled(0.3, 0x1234_5678, 25);
+        let encoded = sampler.serialize_to_bytes().expect("serialize");
+        let mut decoded = UniformSampling::deserialize_from_bytes(&encoded).expect("decode");
+
+        for value in 100..140 {
+            sampler.update(value as f64);
+            decoded.update(value as f64);
+        }
+        assert_eq!(sampler.samples(), decoded.samples());
+        assert_eq!(sampler.total_seen(), decoded.total_seen());
+        assert_eq!(
+            sampler.serialize_to_bytes().expect("re-serialize source"),
+            decoded.serialize_to_bytes().expect("re-serialize decoded")
+        );
+    }
+
+    /// An empty sampler round-trips and has exactly one encoding for a given
+    /// rate and RNG position.
+    #[test]
+    fn uniform_sampling_empty_round_trip_has_exactly_one_encoding() {
+        let empty = UniformSampling::with_seed(0.1, 0xABC1);
+        assert!(empty.is_empty());
+
+        let encoded = empty.serialize_to_bytes().expect("serialize empty");
+        let decoded = UniformSampling::deserialize_from_bytes(&encoded).expect("decode empty");
+        assert!(decoded.is_empty());
+        assert_eq!(decoded.total_seen(), 0);
+        assert_eq!(decoded.sample_rate(), 0.1);
+
+        let twin = UniformSampling::with_seed(0.1, 0xABC1);
+        assert_eq!(encoded, twin.serialize_to_bytes().expect("serialize twin"));
+        assert_eq!(encoded, decoded.serialize_to_bytes().expect("re-serialize"));
+    }
+
+    /// A Count-Min envelope carries a different kind_id and must not decode as
+    /// a sampler.
+    #[test]
+    fn uniform_sampling_rejects_foreign_kind_id() {
+        let cms =
+            crate::CountMin::<crate::Vector2D<i64>, crate::RegularPath>::with_dimensions(3, 8);
+        let cms_bytes = cms.serialize_to_bytes().expect("serialize CMS");
+        assert!(
+            UniformSampling::deserialize_from_bytes(&cms_bytes).is_err(),
+            "CMS bytes must not decode as a UniformSampling"
+        );
+    }
+
+    /// Fail closed on an unexpected metadata key.
+    #[test]
+    fn us_metadata_rejects_unknown_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            sample_rate: f64,
+            item_type: String,
+            bogus_field: u8, // key not in UsMetadata
+        }
+        let m = us_metadata(0.25);
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            sample_rate: m.sample_rate,
+            item_type: m.item_type.clone(),
+            bogus_field: 7,
+        };
+        let bytes = rmp_serde::to_vec_named(&extra).unwrap();
+        assert!(rmp_serde::from_slice::<UsMetadata>(&bytes).is_err());
+    }
+
+    /// `item_type` is required: a metadata map missing it does not decode, so
+    /// the key cannot be silently defaulted.
+    #[test]
+    fn us_metadata_rejects_a_missing_item_type_key() {
+        #[derive(Serialize)]
+        struct WithoutItemType {
+            metadata_version: u8,
+            sample_rate: f64,
+        }
+        let m = us_metadata(0.25);
+        let without = WithoutItemType {
+            metadata_version: m.metadata_version,
+            sample_rate: m.sample_rate,
+        };
+        let bytes = rmp_serde::to_vec_named(&without).unwrap();
+        assert!(rmp_serde::from_slice::<UsMetadata>(&bytes).is_err());
+    }
+
+    /// Samples are `f64`; any other `item_type` name is rejected.
+    #[test]
+    fn us_metadata_rejects_a_foreign_item_type_name() {
+        let meta = UsMetadata {
+            metadata_version: 1,
+            sample_rate: 0.5,
+            item_type: "i64".to_string(),
+        };
+        let payload = UsPayload {
+            priorities: vec![1],
+            values: vec![3.0],
+            total_seen: 2,
+            rng_state: 9,
+        };
+        assert!(
+            UniformSampling::deserialize_from_bytes(&crafted(&meta, &payload)).is_err(),
+            "an i64-labelled envelope must not decode as an f64 sampler"
+        );
+    }
+
+    /// A rate outside `(0, 1]` is rejected before it reaches `target_size`.
+    #[test]
+    fn uniform_sampling_rejects_an_out_of_range_sample_rate() {
+        let payload = UsPayload {
+            priorities: Vec::new(),
+            values: Vec::new(),
+            total_seen: 0,
+            rng_state: 1,
+        };
+        for rate in [0.0, -0.5, 1.5, f64::NAN, f64::INFINITY] {
+            let meta = us_metadata(rate);
+            assert!(
+                UniformSampling::deserialize_from_bytes(&crafted(&meta, &payload)).is_err(),
+                "sample_rate {rate} must be rejected, not panic"
+            );
+        }
+    }
+
+    /// The declared stream length never sizes an allocation: a payload
+    /// declaring `total_seen = u64::MAX` with two samples costs two samples.
+    #[test]
+    fn uniform_sampling_huge_declared_stream_costs_two_samples() {
+        let meta = us_metadata(1.0);
+        let payload = UsPayload {
+            priorities: vec![7, 9],
+            values: vec![1.0, 2.0],
+            total_seen: u64::MAX,
+            rng_state: 3,
+        };
+        let decoded = UniformSampling::deserialize_from_bytes(&crafted(&meta, &payload))
+            .expect("a huge declared stream length is legal state");
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded.samples(), vec![1.0, 2.0]);
+    }
+
+    /// More retained samples than the rate allows for the declared stream
+    /// length is not a state the algorithm reaches.
+    #[test]
+    fn uniform_sampling_rejects_more_samples_than_the_rate_allows() {
+        let meta = us_metadata(0.5);
+        let payload = UsPayload {
+            priorities: vec![1, 2, 3],
+            values: vec![1.0, 2.0, 3.0],
+            total_seen: 2,
+            rng_state: 5,
+        };
+        assert!(
+            UniformSampling::deserialize_from_bytes(&crafted(&meta, &payload)).is_err(),
+            "3 samples must not decode at total_seen 2 and rate 0.5"
+        );
+    }
+
+    /// The two payload arrays are parallel; unequal lengths are rejected.
+    #[test]
+    fn uniform_sampling_rejects_parallel_array_length_mismatch() {
+        let meta = us_metadata(1.0);
+        let payload = UsPayload {
+            priorities: vec![1, 2, 3],
+            values: vec![1.0, 2.0],
+            total_seen: 3,
+            rng_state: 5,
+        };
+        assert!(UniformSampling::deserialize_from_bytes(&crafted(&meta, &payload)).is_err());
+    }
+
+    /// Entries are held in ascending priority; an unordered payload is
+    /// rejected rather than decoded into a sampler that misplaces its next
+    /// entry.
+    #[test]
+    fn uniform_sampling_rejects_unordered_priorities() {
+        let meta = us_metadata(1.0);
+        let payload = UsPayload {
+            priorities: vec![9, 2, 5],
+            values: vec![1.0, 2.0, 3.0],
+            total_seen: 3,
+            rng_state: 5,
+        };
+        assert!(UniformSampling::deserialize_from_bytes(&crafted(&meta, &payload)).is_err());
+
+        // Equal priorities must still be ordered by `total_cmp` on the value.
+        let tied = UsPayload {
+            priorities: vec![4, 4],
+            values: vec![8.0, 1.0],
+            total_seen: 2,
+            rng_state: 5,
+        };
+        assert!(UniformSampling::deserialize_from_bytes(&crafted(&meta, &tied)).is_err());
+    }
+
+    /// Truncated, foreign and garbage bytes are errors, never panics.
+    #[test]
+    fn uniform_sampling_rejects_crafted_bytes_without_panicking() {
+        let encoded = filled(0.5, 0x99, 10)
+            .serialize_to_bytes()
+            .expect("serialize");
+        for cut in [0, 1, 6, 9, 14, encoded.len() - 1] {
+            assert!(UniformSampling::deserialize_from_bytes(&encoded[..cut]).is_err());
+        }
+        assert!(UniformSampling::deserialize_from_bytes(&[0xff; 64]).is_err());
+
+        // Valid envelope + valid metadata, garbage payload.
+        let metadata = rmp_serde::to_vec_named(&us_metadata(0.5)).unwrap();
+        let bytes = envelope::encode(US_KIND, &metadata, &[0xc1, 0xc1, 0xc1]);
+        assert!(UniformSampling::deserialize_from_bytes(&bytes).is_err());
+    }
+
+    /// The format never emits bytes it would refuse to read back: a sampler
+    /// holding more entries than its own rate allows fails to serialize.
+    #[test]
+    fn uniform_sampling_rejects_serializing_an_over_full_sampler() {
+        let meta = us_metadata(1.0);
+        let payload = UsPayload {
+            priorities: vec![1, 2],
+            values: vec![1.0, 2.0],
+            total_seen: 2,
+            rng_state: 5,
+        };
+        let mut sampler = UniformSampling::deserialize_from_bytes(&crafted(&meta, &payload))
+            .expect("two samples at total_seen 2");
+        sampler.total_seen = 1;
+        assert!(
+            sampler.serialize_to_bytes().is_err(),
+            "an over-full sampler must not serialize"
+        );
+    }
+}


### PR DESCRIPTION
Designs and implements the ASAPv1 wire payload for `UniformSampling`, kind_id `0x0d 0x00`.

All serialization lives in the new child module `src/sketches/uniform/wire.rs`, which reads the sketch's private `sample_rate` / `total_seen` / `rng_state` / `entries` fields directly and rebuilds the struct — no field visibility was widened. No golden fixtures this round; `docs/asapv1_wire_format.md` was not touched, so the §3.x draft below is for a later harvest.

---

## §3.8: UniformSampling payload (`0x0d 0x00`)

`UniformSampling` is a priority-sampling reservoir: each update draws a 64-bit priority, the entry is inserted into a priority-ordered list, and the list is truncated to `ceil(total_seen * sample_rate)`. The retained state is therefore the `(priority, value)` pairs plus the two running scalars nothing else determines.

| Pos | Field | Type | Notes |
| ----- | ------- | ------ | ------- |
| 0 | `priorities` | array | u64 draw per retained entry, **ascending**; parallel to `values` |
| 1 | `values` | array | the retained samples, parallel to `priorities`; element type = `item_type` |
| 2 | `total_seen` | u64 | stream elements offered to the sampler, saturating at `u64::MAX` |
| 3 | `rng_state` | u64 | the SplitMix64 word the next priority is drawn from |

The two arrays are parallel and equal-length; the number of retained samples is `len(values)` (derived, so not stored). `sample_rate` is construction config and lives in the metadata, so the payload omits it, and the target size `ceil(total_seen * sample_rate)` is derived from the two and is not stored either.

`priorities` is **not** derivable from `values` and is carried: `merge` re-sorts both sides by priority and truncates, and `update` binary-searches the list on that key, so a payload carrying only the values would decode into a sampler that made different retention decisions from the one that was encoded. `total_seen` is likewise not derivable — a sampler that has seen 1000 elements at rate `0.1` holds the same 100 samples as one that has seen 1000 at rate `0.1` after a merge, but the next update's target size differs.

**Metadata vs payload.** `UniformSampling` **omits the hash-spec group entirely.** It never hashes: `update_input` widens a numeric `DataInput` to `f64` and `update` draws a SplitMix64 priority from the sampler's own RNG. No hasher is ever invoked and the type carries no `H: HashProfile` parameter, so `hash_profile_id` / `seed_list` / a seed index have no truthful value here. This is the KLL precedent (Q-KLL): a metadata field that cannot be truthful must not exist. The metadata is structural params only:

| Key | Type | Meaning |
| ------- | ------ | --------- |
| `metadata_version` | u8 | `1` |
| `sample_rate` | f64 | the construction rate, in `(0, 1]`; with `total_seen` it fixes the retained-sample bound |
| `item_type` | string | `"f64"`; the element type of `values` |

`sample_rate` is the sampler's one sizing parameter, chosen at construction, so per the config→metadata rule it belongs in the descriptor (like HLL's `precision`, Count-Min's `rows`/`cols`, or Space-Saving's `capacity`). It is a property of the *stored* sampler rather than of the target type, so decode echoes it back into the expected metadata rather than pinning it — the same treatment Count Sketch gives `rows`/`cols`. `metadata_version` and `item_type` are pinned by that comparison.

**Emitted order (cross-language contract).** The payload is **order-defined**: entries are written in **ascending `priority`**, ties broken by `f64::total_cmp` on the parallel value. This is required, not cosmetic. The in-memory list is already priority-ordered — `update` binary-searches on `priority` and `truncate_to` pops from the tail — but the position of two entries drawing the *same* priority depends on insertion history, so an unpinned order would let a decoded sampler re-serialize to different bytes than it decoded from. With the order pinned, two samplers holding the same `(priority, value)` set emit the same bytes whatever order they were seated in, and re-serializing a decoded sampler reproduces its bytes exactly. Decode requires the order and rejects a payload that breaks it: an unordered `priorities` array would silently break `insert_entry`'s binary search on the next update.

**Decode rules.** Fail **closed** on each, with an error and never a panic:

1. `kind_id` is `0x0d 0x00`; any other id is rejected.
2. `metadata_version == 1` and `item_type == "f64"`. `sample_rate` is echoed back rather than pinned.
3. `sample_rate` is finite and in `(0, 1]`. Checked **before** anything is derived from it: `0.0`, a negative, a value above `1`, `NaN` and the infinities are all rejected, matching the constructor's own assertion, so a crafted rate can never reach the target-size computation.
4. `priorities` and `values` have equal length.
5. The entries are in ascending `priority`, ties ordered by `total_cmp` of the parallel value. Anything else is rejected, which makes the decoded form canonical and keeps `insert_entry`'s binary-search invariant intact.
6. `len(values) <= ceil(total_seen * sample_rate)` — the retention bound the algorithm maintains after every `update` and `merge`. More retained samples than the declared stream length and rate allow is not a state the algorithm reaches.
7. `total_seen` and `sample_rate` **never size an allocation.** The entry vector is sized from `len(values)`, so a payload declaring `total_seen = u64::MAX` at rate `1.0` with two samples costs two samples. A decoder must not preallocate from a declared size. (Space-Saving rule 8.)

Rules 3 and 6 are enforced on the **encode** side too, so the format never emits bytes it would refuse to read back.

---

## Recorded decisions

### Q-US-RNG: the RNG state is carried, and it is fully reproducible in Go

**Decision: `rng_state` is carried in the payload as a single `u64` at position 3, and it is a *resumable* state, not opaque. A decoded sampler continues the same draw sequence; it does not reseed.**

- **Wire shape.** One `u64` scalar at payload position 3, not a nested array. KLL's `coin` is a nested 3-element array because SplitMix64 there is wrapped in a bit-cache (`[state, bit_cache, remaining_bits]`) and three fields need a container. `UniformSampling`'s generator has no cache: its entire state is one word, so a 1-element nesting would add a container level carrying nothing. The field is positional on the wire and named `rng_state` in this doc, exactly as `coin`'s three fields are.
- **Which algorithm the state belongs to.** **SplitMix64**, with the reference constants. `rng_state` is the *pre-increment* state — the value the next draw adds the golden gamma to, i.e. `UniformSampling::rng_state` verbatim.
- **What `sketchlib-go` must implement.** Four lines, no library:

  ```go
  func (s *UniformSampling) nextRandom() uint64 {
      s.rngState += 0x9E3779B97F4A7C15          // golden gamma
      z := s.rngState
      z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9
      z = (z ^ (z >> 27)) * 0x94D049BB133111EB
      return z ^ (z >> 31)
  }
  ```

  This is stock SplitMix64 (`wrapping_add` / `wrapping_mul`; Go's `uint64` arithmetic already wraps). Go must also mirror `merge`'s state mixing, `state = state ^ bits.RotateLeft64(other, 19)`, falling back to the golden gamma when the result is `0`.
- **Why resumable rather than opaque.** The precedent this had to choose between is KLL's: `coin` is resumable state, `seed` is opaque state Go carries verbatim. Reproducing this sequence in Go is realistic — it is four lines of stock SplitMix64 with published constants and no floating point — so there was no reason to fall back to the opaque-state rule. A decoded sampler retains the same retention decisions the original would have made, which is what makes a checkpoint/restore of a sampler meaningful.
- **No metadata `seed` key.** KLL carries an optional `seed` because it re-seeds from it on `clear()`. `UniformSampling` has no `clear()` and does not retain the constructor's `seed` — `with_seed` writes it straight into `rng_state`, which then evolves. There is nothing to re-seed from, so there is no key. `rng_state` alone is the complete RNG state.
- **`rng_state == 0` is legal.** `with_seed` and `merge` both coerce a zero to the golden gamma, but `next_random`'s `wrapping_add` can land on `0` mid-stream, so decode does not reject it. SplitMix64 has no bad state.

### Q-US-ITEM: `item_type` is `"f64"`, exact and never widened

The sampler stores every retained sample as `f64` — `update` takes an `f64` and `update_input` widens `I32` / `I64` / `U32` / `U64` / `F32` to one, rejecting every non-numeric `DataInput`. There is no type parameter, so `"f64"` is the only value the key can ever carry today. It is carried anyway, and pinned: decode rejects any other name. Following the KLL `item_type` / Space-Saving `key_type` rule, the name is the exact storage type and is never widened or narrowed, so `values` is read as float64 (`0xcb`) per §4 without a Go decoder needing to know the registry's element-type detail out of band. Unlike Space-Saving's `key_type` it can never be untruthful, so it costs nothing to carry and it leaves the descriptor self-describing.

### Q-US-ORDER: ascending priority, ties by `total_cmp`

See the emitted-order paragraph above. Encode sorts a copy into that order; decode requires it. Two consequences worth naming: an empty sampler has exactly one encoding for a given rate and RNG position, and a decoded sampler re-serializes byte-identically to the bytes it came from.

### Q-US-CAPACITY: the retention bound is derived, not declared

`UniformSampling` has no `capacity` field — it is rate-based, not reservoir-size-based. Its analogue of Space-Saving's `capacity` is `ceil(total_seen * sample_rate)`, derived from one metadata field and one payload field, so it is not stored. The "declared capacity must never size an allocation" rule applies to that derived bound in exactly the same way (decode rule 7).

### `NaN` samples are legal

`update(f64::NAN)` is legal in memory and `total_cmp` gives it a total order, so a `NaN` sample round-trips rather than being rejected.

---

## Tests (15, in `src/sketches/uniform/wire.rs`)

1. `uniform_sampling_round_trip_serialization` — round trip; asserts the envelope starts with `b"ASAPv1"` and `&encoded[7..10] == &[2u8, 0x0d, 0x00]`.
2. `uniform_sampling_re_encodes_byte_identically` — a decoded sampler re-serializes to the exact bytes it decoded from.
3. `uniform_sampling_rng_state_resumes_the_same_sequence` — the decoded sampler and the original, fed the same 40 subsequent updates, hold identical samples and re-serialize identically.
4. `uniform_sampling_empty_round_trip_has_exactly_one_encoding` — empty sampler round trip; an independently constructed twin and the decoded sampler both emit the same bytes.
5. `uniform_sampling_rejects_foreign_kind_id` — a Count-Min envelope does not decode as a sampler.
6. `us_metadata_rejects_unknown_keys` — `deny_unknown_fields`.
7. `us_metadata_rejects_a_missing_item_type_key` — a required key cannot be silently defaulted.
8. `us_metadata_rejects_a_foreign_item_type_name` — an `"i64"`-labelled envelope is rejected.
9. `uniform_sampling_rejects_an_out_of_range_sample_rate` — `0.0`, `-0.5`, `1.5`, `NaN`, `inf` are all errors, not panics.
10. `uniform_sampling_huge_declared_stream_costs_two_samples` — `total_seen = u64::MAX` at rate `1.0` with two samples decodes to exactly two samples; the declared size drives no allocation.
11. `uniform_sampling_rejects_more_samples_than_the_rate_allows` — three samples at `total_seen = 2`, rate `0.5` is rejected.
12. `uniform_sampling_rejects_parallel_array_length_mismatch`.
13. `uniform_sampling_rejects_unordered_priorities` — both a descending run and an equal-priority pair ordered wrongly by value.
14. `uniform_sampling_rejects_crafted_bytes_without_panicking` — six truncation points, an all-`0xff` buffer, and a valid envelope with a garbage payload.
15. `uniform_sampling_rejects_serializing_an_over_full_sampler` — the encode side refuses bytes the decoder would refuse.

No `AltHasher` test: `UniformSampling` does not hash, so there is no hash profile to vary.

## CI

`UniformSampling` is behind the `experimental` feature, so the default-feature clippy was run as well.

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --all-features --locked --verbose` — pass (781 lib tests, 15 of them new, plus every integration target)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` (default features) — fails on `main` too, on four pre-existing feature-gated dead-code warnings in `tests/e2e_octo.rs`; nothing in this branch is involved. CI runs the all-features clippy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
