### PR TITLE
feat(coco): ASAPv1 wire payload for CocoSketch (0x0c 0x00)

### DIFF
--- a/docs/api/api_coco.md
+++ b/docs/api/api_coco.md
@@ -94,7 +94,20 @@ fn merge(&mut self, other: &Coco<H>)
 
 ## Serialization
 
-Derives serde; no dedicated byte API helpers.
+```rust
+fn serialize_to_bytes(&self) -> Result<Vec<u8>, rmp_serde::encode::Error>
+fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, rmp_serde::decode::Error>
+```
+
+ASAPv1 MessagePack, kind_id `0x0c 0x00`. The metadata carries the hash spec plus
+the table geometry as `rows` (`d`) and `cols` (`w`); the payload is
+`[keys, values]`, two dense row-major arrays of `rows * cols` entries. A free
+bucket is msgpack `nil`, so an inserted `""` key stays distinct from a bucket
+that holds nothing. Both methods require `H: HashProfile`.
+
+A zero dimension, a table whose bucket count disagrees with `w`/`d`, a payload
+length that disagrees with the declared geometry, and a `nil` key carrying a
+non-zero value are all rejected on both sides. `Coco` also derives serde.
 
 ## Examples
 

--- a/src/sketches/coco.rs
+++ b/src/sketches/coco.rs
@@ -20,6 +20,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
+mod wire;
+
 /// One table slot: the key it currently represents and the mass attributed to it.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CocoBucket {

--- a/src/sketches/coco/wire.rs
+++ b/src/sketches/coco/wire.rs
@@ -1,0 +1,509 @@
+//! ASAPv1 wire serialization for CocoSketch.
+//!
+//! Child submodule of [`crate::sketches::coco`]: it holds ALL of Coco's
+//! serialization (the metadata/payload DTOs, the kind_id constant, and the
+//! `serialize_to_bytes` / `deserialize_from_bytes` impls) while the algorithm
+//! lives in the parent module file. Being a descendant module, it reads the
+//! sketch's private `_hasher` marker and rebuilds the struct directly, without
+//! widening any field visibility. See the Coco section of
+//! `docs/asapv1_wire_format.md`.
+//!
+//! Coco is one algorithm — a single kind_id `0x0c 0x00`. Its structural
+//! parameters are the table geometry: `rows` (the sketch's `d`, the arrays an
+//! insert scans) and `cols` (the sketch's `w`, the buckets per array). Both are
+//! construction config and live in the metadata, so the payload is the bucket
+//! state alone: `[keys, values]`, two parallel row-major arrays of `rows*cols`
+//! entries.
+//!
+//! ## An unoccupied bucket is msgpack `nil`
+//!
+//! A bucket's key is `Option<String>` and `insert` accepts any `&str`,
+//! including `""`. So `Some("")` is an occupied bucket that `estimate_key("")`
+//! answers for, and it must not share an encoding with an unoccupied one.
+//! `keys[i]` is therefore msgpack `nil` (`0xc0`) when the bucket is free and a
+//! msgpack `str` otherwise.
+//!
+//! ## Emitted order (byte-stable round trips)
+//!
+//! The arrays are dense and **row-major** over the whole table, index order,
+//! the same layout Count-Min packs `counts` in. Every bucket is emitted, so a
+//! decoded sketch re-serializes byte-identically.
+//!
+//! ## Keys are `String`
+//!
+//! A Coco key is a `String` at every entry point, so there is no `key_type`
+//! param: the kind_id fixes the element type of `keys`.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+use crate::{HashProfile, SketchHasher, Vector2D};
+
+use super::{Coco, CocoBucket};
+
+/// Coco kind_id: family `0x0c`, single algorithm variant `0x00`.
+const COCO_KIND: &[u8] = &[0x0c, 0x00];
+
+/// Coco descriptor metadata (ASAPv1 §2), a msgpack **map** (`to_vec_named`)
+/// with keys in this declaration order — the canonical order the wire spec
+/// fixes (Go must mirror it). Hash-spec fields first, then the structural
+/// params `rows` / `cols`, which are the sketch's `d` and `w`.
+///
+/// There is **no seed-index key**: Coco hashes array `i` with
+/// `hash64_seeded(i, ..)`, a fixed part of the algorithm rather than a profile
+/// choice, so no `HashProfile` index field would describe it truthfully.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CocoMetadata {
+    metadata_version: u8,
+    hash_profile_id: String,
+    hash_algorithm: String,
+    seed_derivation: String,
+    input_encoding: String,
+    seed_list: Vec<u64>,
+    rows: u32,
+    cols: u32,
+}
+
+/// Builds the Coco descriptor metadata from the hasher's [`HashProfile`], so
+/// the wire bytes truthfully describe how the sketch was hashed (rather than
+/// hardcoding the standard profile). `rows` is the sketch's `d`, `cols` its
+/// `w`.
+fn coco_metadata<H: HashProfile>(rows: u32, cols: u32) -> CocoMetadata {
+    CocoMetadata {
+        metadata_version: 1,
+        hash_profile_id: H::PROFILE_ID.to_string(),
+        hash_algorithm: H::ALGORITHM.to_string(),
+        seed_derivation: H::SEED_DERIVATION.to_string(),
+        input_encoding: H::INPUT_ENCODING.to_string(),
+        seed_list: H::seed_list(),
+        rows,
+        cols,
+    }
+}
+
+/// Coco payload (ASAPv1, kind_id `0x0c 0x00`), a msgpack **array** (`to_vec`, positional):
+/// `[keys, values]`. Both are dense and row-major over the table, so their
+/// length is `rows*cols`; `keys[i]` is `nil` for an unoccupied bucket and a
+/// `str` otherwise, and `values[i]` is that bucket's attributed mass.
+#[derive(Debug, Serialize, Deserialize)]
+struct CocoPayload {
+    keys: Vec<Option<String>>,
+    values: Vec<u64>,
+}
+
+/// Rejects a geometry the format cannot carry. Zero in either dimension is out:
+/// `Vector2D` derives its column mask via `cols.ilog2()`, and a table with no
+/// buckets records nothing.
+fn check_geometry(rows: usize, cols: usize) -> Result<(), String> {
+    if rows == 0 || cols == 0 {
+        return Err(format!(
+            "Coco table dimensions must be non-zero: rows={rows}, cols={cols}"
+        ));
+    }
+    Ok(())
+}
+
+// Wire serialization for Coco. `wire` is a descendant of the sketch module, so
+// this impl reads the private hasher marker and rebuilds the struct directly.
+impl<H: SketchHasher + HashProfile> Coco<H> {
+    /// Serializes the sketch into an ASAPv1 MessagePack envelope. The metadata
+    /// is derived from the hasher's [`HashProfile`], so it truthfully describes
+    /// how the sketch was hashed.
+    ///
+    /// A table whose bucket count disagrees with the sketch's own geometry, or
+    /// a geometry with a zero dimension, is an error rather than bytes that
+    /// would be refused on decode.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let (rows, cols) = (self.d, self.w);
+        check_geometry(rows, cols).map_err(RmpEncodeError::Syntax)?;
+        let buckets = self.table.as_slice();
+        if self.table.rows() != rows
+            || self.table.cols() != cols
+            || buckets.len() != rows.saturating_mul(cols)
+        {
+            return Err(RmpEncodeError::Syntax(format!(
+                "ASAPv1 Coco envelope: table {}x{} ({} buckets) != declared {rows}x{cols}",
+                self.table.rows(),
+                self.table.cols(),
+                buckets.len()
+            )));
+        }
+        let to_u32 = |v: usize, name: &str| {
+            u32::try_from(v).map_err(|_| {
+                RmpEncodeError::Syntax(format!("ASAPv1 Coco envelope: {name} {v} exceeds u32"))
+            })
+        };
+        let metadata = rmp_serde::to_vec_named(&coco_metadata::<H>(
+            to_u32(rows, "rows")?,
+            to_u32(cols, "cols")?,
+        ))?;
+        let payload = rmp_serde::to_vec(&CocoPayload {
+            keys: buckets.iter().map(|b| b.full_key.clone()).collect(),
+            values: buckets.iter().map(|b| b.val).collect(),
+        })?;
+        Ok(envelope::encode(COCO_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The table
+    /// geometry is read from the (validated) metadata; the payload carries only
+    /// the bucket keys and their masses.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != COCO_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "Coco kind_id mismatch: stored {kind_id:?}, expected {COCO_KIND:?}"
+            )));
+        }
+        let meta: CocoMetadata = from_slice(metadata)?;
+        // Validate the hash spec against this target; `rows`/`cols` are
+        // structural (the table is dynamically sized), so they are echoed back
+        // into the expected block rather than known a priori.
+        if meta != coco_metadata::<H>(meta.rows, meta.cols) {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 Coco envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let (rows, cols) = (meta.rows as usize, meta.cols as usize);
+        // The geometry is validated before anything is sized from it, so
+        // crafted dimensions never reach an allocation.
+        check_geometry(rows, cols).map_err(RmpDecodeError::Uncategorized)?;
+        let mut p: CocoPayload = from_slice(payload)?;
+        let expected = rows.saturating_mul(cols);
+        if p.keys.len() != expected || p.values.len() != expected {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "Coco payload lengths (keys {}, values {}) != rows*cols {expected}",
+                p.keys.len(),
+                p.values.len()
+            )));
+        }
+        // An unoccupied bucket holds no mass: `insert` always elects a key into
+        // the bucket it credits. Rejecting mass under a `nil` key keeps the
+        // decoded table canonical.
+        if let Some(i) = (0..expected).find(|&i| p.keys[i].is_none() && p.values[i] != 0) {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "Coco bucket {i} is unoccupied but carries value {}",
+                p.values[i]
+            )));
+        }
+        let table = Vector2D::from_fn(rows, cols, |r, c| {
+            let i = r * cols + c;
+            CocoBucket {
+                full_key: p.keys[i].take(),
+                val: p.values[i],
+            }
+        });
+        Ok(Coco {
+            w: cols,
+            d: rows,
+            table,
+            _hasher: std::marker::PhantomData,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CANONICAL_HASH_SEED, DataInput, DefaultXxHasher, Vector2D};
+
+    /// The whole table as `(key, value)` pairs in row-major order.
+    fn cells<H: SketchHasher>(sketch: &Coco<H>) -> Vec<(Option<String>, u64)> {
+        sketch
+            .table
+            .as_slice()
+            .iter()
+            .map(|b| (b.full_key.clone(), b.val))
+            .collect()
+    }
+
+    #[test]
+    fn coco_round_trip_serialization() {
+        let mut sketch: Coco = Coco::init_with_size(8, 4);
+        sketch.insert("19.98.10.26|80", 521);
+        sketch.insert("34.52.73.17|118", 856);
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize Coco");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x0c, 0x00]); // kind_id_len=2, kind_id=[0x0c,0x00]
+
+        let decoded: Coco = Coco::deserialize_from_bytes(&encoded).expect("deserialize Coco");
+        assert_eq!(decoded.w, 8);
+        assert_eq!(decoded.d, 4);
+        assert_eq!(cells(&sketch), cells(&decoded));
+        assert_eq!(decoded.estimate_key("19.98.10.26|80"), 521);
+    }
+
+    /// Coco and Count-Min both carry `rows`/`cols` metadata; a CMS envelope
+    /// must not decode as a Coco.
+    #[test]
+    fn coco_rejects_foreign_kind_id() {
+        let cms = crate::CountMin::<Vector2D<i64>, crate::RegularPath>::with_dimensions(4, 8);
+        let cms_bytes = cms.serialize_to_bytes().expect("serialize CMS");
+        assert!(
+            Coco::<DefaultXxHasher>::deserialize_from_bytes(&cms_bytes).is_err(),
+            "CMS bytes must not decode as a Coco"
+        );
+    }
+
+    /// Fail closed on an unexpected metadata key.
+    #[test]
+    fn coco_metadata_rejects_unknown_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            rows: u32,
+            cols: u32,
+            bogus_field: u8, // key not in CocoMetadata
+        }
+        let m = coco_metadata::<DefaultXxHasher>(4, 8);
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            rows: m.rows,
+            cols: m.cols,
+            bogus_field: 7,
+        };
+        let bytes = rmp_serde::to_vec_named(&extra).unwrap();
+        assert!(rmp_serde::from_slice::<CocoMetadata>(&bytes).is_err());
+    }
+
+    /// `cols` is required: a Coco metadata map missing it does not decode, so
+    /// the key cannot be silently defaulted.
+    #[test]
+    fn coco_metadata_rejects_a_missing_cols_key() {
+        #[derive(Serialize)]
+        struct WithoutCols {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            rows: u32,
+        }
+        let m = coco_metadata::<DefaultXxHasher>(4, 8);
+        let without = WithoutCols {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            rows: m.rows,
+        };
+        let bytes = rmp_serde::to_vec_named(&without).unwrap();
+        assert!(rmp_serde::from_slice::<CocoMetadata>(&bytes).is_err());
+    }
+
+    /// Fail closed (not panic) on a crafted envelope with a zero dimension:
+    /// `Vector2D` derives its column mask via `cols.ilog2()`, which panics on
+    /// `cols == 0`.
+    #[test]
+    fn coco_rejects_zero_dimension_payload() {
+        let metadata = rmp_serde::to_vec_named(&coco_metadata::<DefaultXxHasher>(4, 0)).unwrap();
+        let payload = rmp_serde::to_vec(&CocoPayload {
+            keys: Vec::new(),
+            values: Vec::new(),
+        })
+        .unwrap();
+        let bytes = envelope::encode(COCO_KIND, &metadata, &payload);
+        assert!(
+            Coco::<DefaultXxHasher>::deserialize_from_bytes(&bytes).is_err(),
+            "zero-dimension metadata must be rejected, not panic"
+        );
+    }
+
+    /// Crafted dimensions must not drive a huge allocation: the length check
+    /// runs before `Vector2D::from_fn`.
+    #[test]
+    fn coco_rejects_dimension_length_mismatch() {
+        let metadata =
+            rmp_serde::to_vec_named(&coco_metadata::<DefaultXxHasher>(1024, 1024)).unwrap();
+        let payload = rmp_serde::to_vec(&CocoPayload {
+            keys: vec![None, None, None],
+            values: vec![0, 0, 0],
+        })
+        .unwrap();
+        let bytes = envelope::encode(COCO_KIND, &metadata, &payload);
+        assert!(
+            Coco::<DefaultXxHasher>::deserialize_from_bytes(&bytes).is_err(),
+            "payload lengths must match rows*cols"
+        );
+    }
+
+    /// An unoccupied bucket holds no mass, so a payload crediting one is
+    /// rejected rather than decoded into a table no insert could produce.
+    #[test]
+    fn coco_rejects_mass_under_an_unoccupied_bucket() {
+        let metadata = rmp_serde::to_vec_named(&coco_metadata::<DefaultXxHasher>(1, 2)).unwrap();
+        let payload = rmp_serde::to_vec(&CocoPayload {
+            keys: vec![None, None],
+            values: vec![0, 9],
+        })
+        .unwrap();
+        let bytes = envelope::encode(COCO_KIND, &metadata, &payload);
+        assert!(
+            Coco::<DefaultXxHasher>::deserialize_from_bytes(&bytes).is_err(),
+            "a nil key with a non-zero value must be rejected"
+        );
+    }
+
+    /// A sketch whose declared geometry disagrees with its table must not emit
+    /// bytes the decoder would refuse.
+    #[test]
+    fn coco_rejects_serializing_a_geometry_mismatch() {
+        let mut sketch: Coco = Coco::init_with_size(8, 4);
+        sketch.w = 16;
+        assert!(
+            sketch.serialize_to_bytes().is_err(),
+            "a table whose bucket count disagrees with its geometry must not serialize"
+        );
+
+        let empty: Coco = Coco::init_with_size(8, 0);
+        assert!(
+            empty.serialize_to_bytes().is_err(),
+            "a zero-dimension geometry must not serialize"
+        );
+    }
+
+    /// An unoccupied bucket is `nil`, not an empty string, so an inserted `""`
+    /// key stays distinguishable from the buckets that hold nothing.
+    #[test]
+    fn coco_empty_buckets_are_nil_and_never_collide_with_an_empty_key() {
+        let all_empty: Coco = Coco::init_with_size(4, 2);
+        let encoded = all_empty.serialize_to_bytes().expect("serialize");
+        let (_, _, payload) = envelope::split(&encoded).expect("split");
+        assert_eq!(
+            payload.iter().filter(|&&b| b == 0xc0).count(),
+            8,
+            "nil per bucket"
+        );
+        assert!(!payload.contains(&0xa0), "no empty-string key is emitted");
+        let decoded: Coco = Coco::deserialize_from_bytes(&encoded).expect("deserialize");
+        assert_eq!(cells(&all_empty), cells(&decoded));
+        assert!(decoded.recorded_flows().next().is_none());
+
+        let mut with_empty_key: Coco = Coco::init_with_size(4, 2);
+        with_empty_key.insert("", 5);
+        let encoded = with_empty_key.serialize_to_bytes().expect("serialize");
+        let (_, _, payload) = envelope::split(&encoded).expect("split");
+        assert!(payload.contains(&0xa0), "the inserted empty key is a str");
+        let decoded: Coco = Coco::deserialize_from_bytes(&encoded).expect("deserialize");
+        assert_eq!(cells(&with_empty_key), cells(&decoded));
+        assert_eq!(decoded.recorded_flows().count(), 1);
+        assert_eq!(decoded.estimate_key(""), 5);
+    }
+
+    /// A table mixing occupied and free buckets round-trips bucket for bucket.
+    #[test]
+    fn coco_mixed_occupancy_round_trips() {
+        let mut sketch: Coco = Coco::init_with_size(16, 3);
+        for i in 0..10u64 {
+            sketch.insert(&format!("flow::{i}"), i + 1);
+        }
+        let occupied = sketch.recorded_flows().count();
+        assert!(occupied > 0 && occupied < 16 * 3, "mix both bucket states");
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        let decoded: Coco = Coco::deserialize_from_bytes(&encoded).expect("deserialize");
+        assert_eq!(cells(&sketch), cells(&decoded));
+        for i in 0..10u64 {
+            let key = format!("flow::{i}");
+            assert_eq!(sketch.estimate_key(&key), decoded.estimate_key(&key));
+        }
+    }
+
+    /// The emitted order is the table's own index order, so a decoded sketch
+    /// re-serializes to the bytes it came from.
+    #[test]
+    fn coco_decoded_sketch_reserializes_byte_identically() {
+        let mut sketch: Coco = Coco::init_with_size(16, 3);
+        for i in 0..12u64 {
+            sketch.insert(&format!("fam{}|item{i}", i % 4), i % 5 + 1);
+        }
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        let decoded: Coco = Coco::deserialize_from_bytes(&encoded).expect("deserialize");
+        assert_eq!(encoded, decoded.serialize_to_bytes().expect("re-serialize"));
+    }
+
+    // A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    // declares a DIFFERENT `HashProfile`. Coco metadata is derived from the
+    // profile, so an `AltHasher` sketch serializes truthfully.
+    #[derive(Clone, Debug)]
+    struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &crate::HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &crate::HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    #[test]
+    fn coco_custom_hasher_profile_round_trips_and_is_self_describing() {
+        // (a) A Coco built with a custom-profile hasher round-trips.
+        let mut alt: Coco<AltHasher> = Coco::init_with_size(8, 4);
+        let mut std: Coco = Coco::init_with_size(8, 4);
+        alt.insert("flow::42", 7);
+        alt.insert("flow::7", 3);
+        std.insert("flow::42", 7);
+        std.insert("flow::7", 3);
+
+        let alt_bytes = alt.serialize_to_bytes().expect("alt serialize");
+        let decoded = Coco::<AltHasher>::deserialize_from_bytes(&alt_bytes).expect("alt decode");
+        assert_eq!(cells(&alt), cells(&decoded));
+
+        // (b) Bytes differ from the standard-profile sketch (metadata derived
+        // from the different profile).
+        let std_bytes = std.serialize_to_bytes().expect("std serialize");
+        assert_ne!(alt_bytes, std_bytes);
+
+        // (c) Standard-profile decode fails closed on custom-profile bytes.
+        assert!(
+            Coco::<DefaultXxHasher>::deserialize_from_bytes(&alt_bytes).is_err(),
+            "standard-profile decode must reject custom-profile bytes"
+        );
+    }
+}


### PR DESCRIPTION
Designs and implements the ASAPv1 wire payload for CocoSketch, kind_id `0x0c 0x00`.
All serialization lives in a new child module `src/sketches/coco/wire.rs`, which reads
the sketch's private fields without widening any visibility. No golden fixtures this
round, and `docs/asapv1_wire_format.md` is untouched — the spec draft below is for a
later harvesting pass.

## §3.x: Coco payload (`0x0c 0x00`)

`Coco` is the CocoSketch of SIGCOMM '21 section 4.1: a `d x w` table of buckets, each
holding the one key it currently represents and the mass attributed to it. The table
geometry is construction config, so it lives in the metadata as `rows` (the sketch's
`d`, the arrays an insert scans) and `cols` (its `w`, the buckets per array), named
the way Count-Min and Bloom name their grid. The payload is then the bucket state
alone:

| Pos | Field | Type | Notes |
| ----- | ------- | ------ | ------- |
| 0 | `keys` | array | one entry per bucket, packed **row-major**, `rows*cols` entries; `nil` for an unoccupied bucket, `str` for an occupied one |
| 1 | `values` | array | u64 mass attributed to that bucket, parallel to `keys`; `values[i] == 0` wherever `keys[i]` is `nil` |

The two arrays are parallel, dense and equal-length. Nothing else in the struct reaches
the wire: `w` and `d` are the metadata's `cols` and `rows`, and every query the sketch
answers — `estimate_key`, `recorded_flows`, `group_by`, `estimate_projected` — is
recomputed from the buckets on demand, so there is no summary to carry.

**Metadata vs payload.** `w` and `d` are the sketch's only construction parameters, so
per the config→metadata rule they belong in the descriptor, like HLL's `precision` or
Count-Min's `rows`/`cols`. The payload omits them and the decoder sizes the table from
them. There is **no `key_type`**: a Coco key is a `String` at every entry point
(`insert(&str, u64)`), so the kind_id already fixes the element type of `keys`, and a
field the kind_id determines does not belong on the wire.

Coco carries the hash-spec group — it hashes, and a consumer must reproduce that hash to
query a key — but carries **no seed-index key**. Array `i` is hashed with
`hash64_seeded(i, ..)`, starting at index `0` and walking the seed list, which is a fixed
part of the algorithm rather than a profile choice. Neither `canonical_seed_index` nor
`matrix_seed_index` would describe it truthfully (Coco never reads
`H::MATRIX_SEED_INDEX`), and a metadata field that can be wrong is worse than none —
the same line §3.5 draws for Space-Saving.

**Emitted order (cross-language contract).** The payload is dense over the whole table
in **row-major index order**: bucket `(r, c)` is at position `r*cols + c` in both arrays,
the same layout Count-Min packs `counts` in. Every bucket is emitted, occupied or not,
so the order is the table's own and nothing has to be sorted. This makes a decoded sketch
re-serialize byte-identically, and it is what `sketchlib-go` must mirror.

**An unoccupied bucket is msgpack `nil`, never an empty string.** A bucket's key is
`Option<String>` in memory, and `insert` accepts any `&str`, `""` included. An inserted
`""` produces `Some("")`: a genuinely occupied bucket that `estimate_key("")` answers for
and that `recorded_flows` yields. Encoding a free bucket as `""` would make the two
indistinguishable on the wire, and a decoder would resurrect an empty-string flow holding
the free bucket's mass. So `keys[i]` is msgpack `nil` (`0xc0`) when the bucket is free and
a msgpack `str` (`0xa0` for the empty key) when it is occupied. **Consequence for
`sketchlib-go`:** the `keys` array is heterogeneous — nil or str — and must be modelled as
`[]*string` (or an equivalent nullable string), never as `[]string` with `""` standing in
for absent. A Go encoder that writes `""` for a free bucket produces different bytes and a
different sketch.

**Bucket values are never negative.** Mass is `u64` and only ever grows by `+= v`, so
every `values[i]` goes in the msgpack **uint** family at minimal width per §4. Coco has
nothing like Count Sketch's signed cells.

**Wire-eligible geometries.** `rows >= 1` and `cols >= 1`. `cols == 0` is not
representable at all — `Vector2D` derives its column mask through `cols.ilog2()`, which
panics on zero — and a table with no arrays records nothing. Both are rejected on
**both** sides, so the format never emits bytes it would refuse to read back. There is no
power-of-two constraint on `cols` (Coco folds with `% w`, not a mask) and no upper bound
on `rows`: a `rows > 20` table has arrays that wrap onto duplicate seeds, but its state
still round-trips exactly, so it stays wire-eligible (tracked separately in #108).

**Decode rules** (all fail closed, per Section 1's decoder rules):

1. `kind_id` is `0x0c 0x00`; any other id is rejected.
2. The metadata's hash spec must equal the target type's own, with `rows` / `cols` echoed
   back since those are structural and the table is sized from them. Cross-profile bytes
   are rejected.
3. `rows` and `cols` are both non-zero. Checked **before** anything is sized from the
   declared geometry, so a hostile geometry never reaches an allocation and never reaches
   `cols.ilog2()`.
4. `len(keys) == len(values) == rows * cols` exactly, and that product must not overflow.
   Checked **before** the table is built, so crafted dimensions cannot drive a huge
   reserve.
5. `values[i] == 0` wherever `keys[i]` is `nil`. An unoccupied bucket holds no mass —
   `insert` always elects a key into the bucket it credits — so no encoder can produce
   such an entry, and rejecting it keeps the decoded table canonical: a round trip
   re-serializes byte-identically. This mirrors Bloom's trailing-padding rule (§3.4, rule
   5).

Rules 3 and 4 are enforced on the **encode** side too: a zero dimension, or a table whose
bucket count disagrees with the sketch's own `w`/`d`, fails to serialize.

## Decisions recorded

- **Empty bucket = msgpack `nil` (`0xc0`), not an empty string.** `""` is a reachable key
  (`insert("", v)` occupies a bucket that `estimate_key("")` reads back), so an
  empty-string encoding would collide with a legitimately-empty inserted key. Go must
  model `keys` as nullable strings; writing `""` for a free bucket is a byte divergence
  and a semantic one.
- **Emitted order: row-major index order over the dense table.** Every bucket is emitted,
  so a decoded sketch re-serializes byte-identically and no sort is needed.
- **No per-bucket counter is negative.** `val` is `u64` and only accumulates; uint family,
  minimal width.
- **No `key_type` metadata field.** Coco keys are `String` only, in memory and on the
  wire, so the kind_id fixes the element type. Nothing wider is designed this round; if
  the in-memory key type ever widens, the wire covers only the `String` configuration and
  anything else is rejected on both sides, the way Bloom rejects an out-of-subset
  geometry.
- **No seed-index metadata key.** Coco hashes array `i` at seed index `i` unconditionally,
  a property of the algorithm rather than of the profile. Same reasoning as Space-Saving
  (§3.5).
- **Geometry names are `rows`/`cols`, not `d`/`w`.** One vocabulary for matrix geometry
  across Count-Min, Bloom and Coco; `rows == d`, `cols == w`, documented in the metadata
  DTO and in `docs/api/api_coco.md`.
- **No `rows <= 20` rule.** Bloom needed one because duplicate seeds make two slices
  identical bit for bit. Coco's arrays stay distinct storage even when their seeds
  coincide, and such a table round-trips exactly, so it is wire-eligible. #108 tracks the
  seed-list length question.
- **No `native/coco.rs` shim.** The `native/` shims cover the older sketches only; Bloom
  and Space-Saving added none when they landed their wire modules, so Coco follows them.

## Tests (12, in `src/sketches/coco/wire.rs`)

1. `coco_round_trip_serialization` — round trip; envelope starts with `b"ASAPv1"` and
   `encoded[7..10] == [2, 0x0c, 0x00]`.
2. `coco_rejects_foreign_kind_id` — a Count-Min envelope does not decode as a Coco.
3. `coco_metadata_rejects_unknown_keys` — `deny_unknown_fields`.
4. `coco_metadata_rejects_a_missing_cols_key` — a required key cannot be defaulted.
5. `coco_rejects_zero_dimension_payload` — crafted `cols == 0` is rejected before any
   allocation and does not panic.
6. `coco_rejects_dimension_length_mismatch` — a 3-entry payload under a declared
   `1024x1024` is rejected before the table is built.
7. `coco_rejects_mass_under_an_unoccupied_bucket` — a `nil` key with a non-zero value.
8. `coco_rejects_serializing_a_geometry_mismatch` — encode side: a table whose bucket
   count disagrees with its own `w`/`d`, and a zero-dimension geometry.
9. `coco_empty_buckets_are_nil_and_never_collide_with_an_empty_key` — an all-empty table
   emits one `0xc0` per bucket and no `0xa0`; a table holding an inserted `""` emits a
   `str` and round-trips with `estimate_key("") == 5`.
10. `coco_mixed_occupancy_round_trips` — a table with both bucket states round-trips
    bucket for bucket and answer for answer.
11. `coco_decoded_sketch_reserializes_byte_identically`.
12. `coco_custom_hasher_profile_round_trips_and_is_self_describing` — the `AltHasher`
    three-part test: round-trips, bytes differ from the standard profile, and a
    standard-profile target rejects custom-profile bytes.

## CI

- `cargo fmt --all -- --check` — pass.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass.
- `cargo test --all-features --locked --verbose` — pass.
- Default-feature clippy (`--all-targets --locked`, no `--all-features`) fails with four
  pre-existing dead-code errors in the integration tests; identical on `main` and
  untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
