### PR TITLE
feat(ddsketch): ASAPv1 wire payload for DDSketch (0x05 0x00)

### DIFF
--- a/docs/api/api_ddsketch.md
+++ b/docs/api/api_ddsketch.md
@@ -50,6 +50,31 @@ fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError>
 fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
 ```
 
+These produce/consume the **ASAPv1** wire envelope (kind `0x05 0x00`) — see the
+[ASAPv1 wire format spec](../asapv1_wire_format.md). DDSketch never hashes its
+inputs, so the metadata carries **no hash-spec group**: it is `metadata_version`
+plus `alpha`, the sketch's one construction parameter. `gamma` and its logs are
+derived from `alpha` and never reach the wire.
+
+The payload is `[counts, offset, sum, min, max]`: the dense bucket store carried
+verbatim (the bucket index of `counts[i]` is `offset + i`), plus the three
+scalars the buckets do not determine. `count` is **not** carried — it is the sum
+of the bucket counts and is recovered exactly on decode. `sum`, `min` and `max`
+come back exactly rather than as α-bounded bucket estimates, so a decoded sketch
+re-serializes byte-identically.
+
+There is one positive-range store and no zero-count bucket, because `add` drops
+non-positive, non-finite and non-indexable values. Bucket indices are still
+signed, so `offset` may be negative. Decode rejects an `alpha` outside `(0, 1)`,
+a store span past `i32`, a non-zero offset on an empty store, bucket counts that
+overflow the total, and scalars inconsistent with that total; `serialize_to_bytes`
+enforces the same rules, so the format never emits bytes it would refuse to read
+back.
+
+Independently of ASAPv1, `DDSketch` is plain `Serialize`/`Deserialize` for use
+where it is nested in another type (`EHSketchList`); that form skips the four
+running scalars.
+
 ## Examples
 
 ```rust

--- a/src/message_pack_format/native/ddsketch.rs
+++ b/src/message_pack_format/native/ddsketch.rs
@@ -1,4 +1,7 @@
 //! Native MessagePack codec impl for [`crate::sketches::ddsketch::DDSketch`].
+//!
+//! Produces and consumes the ASAPv1 envelope (kind_id `0x05 0x00`): `alpha` in
+//! the metadata, `[counts, offset, sum, min, max]` in the payload.
 
 use crate::message_pack_format::{Error, MessagePackCodec};
 use crate::sketches::ddsketch::DDSketch;

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -20,10 +20,10 @@ use crate::common::input::data_input_to_f64;
 use crate::common::numerical::NumericalValue;
 use crate::common::structures::Vector1D;
 use crate::octo_delta::DdDelta;
-use rmp_serde::decode::Error as RmpDecodeError;
-use rmp_serde::encode::Error as RmpEncodeError;
-use rmp_serde::{from_slice, to_vec_named};
 use serde::{Deserialize, Serialize};
+
+/// ASAPv1 wire serialization (kind_id `0x05 0x00`).
+mod wire;
 
 // Number of buckets to grow by when expanding.
 const GROW_CHUNK: usize = 128;
@@ -117,14 +117,13 @@ impl Buckets {
 
 /// Mergeable, relative-error quantile sketch using logarithmically-spaced buckets.
 ///
-/// The DataPoint-level METRIC scalars (`count`, `sum`, `min`, `max`) were
-/// dropped from the portable cross-language wire format
-/// (ProjectASAP/sketchlib-go#243). They are still tracked here as pure
-/// in-memory state because [`DDSketch::get_value_at_quantile`] and
-/// [`DDSketch::merge`] use them internally, but they are NOT serialized:
-/// `count`/`sum` are recovered exactly from the bucket counts on
-/// deserialize and `min`/`max` are re-estimated from the extreme
-/// non-empty buckets (within the α relative-accuracy bound).
+/// ASAPv1 serialization lives in the `wire` submodule (kind_id `0x05 0x00`); it
+/// carries `alpha`, the bucket store, and `sum` / `min` / `max`, and recovers
+/// `count` by summing the buckets.
+///
+/// The derived `Serialize` / `Deserialize` is a separate, Rust-internal form
+/// used where a `DDSketch` is nested in another type; it skips the four running
+/// scalars.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DDSketch {
     alpha: f64,
@@ -186,51 +185,6 @@ impl DDSketch {
             sum: 0.0,
             min: f64::INFINITY,
             max: f64::NEG_INFINITY,
-        }
-    }
-
-    /// Serializes the sketch to a MessagePack byte vector.
-    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
-        to_vec_named(self)
-    }
-
-    /// Deserializes a DDSketch from a MessagePack byte slice.
-    ///
-    /// The `count`/`sum`/`min`/`max` scalars are `#[serde(skip)]` (dropped
-    /// from the wire, ProjectASAP/sketchlib-go#243), so they default to
-    /// zero on decode. Recompute them from the bucket store: `count` is
-    /// exact (the sum of all bucket counts) and `sum`/`min`/`max` are
-    /// reconstructed from the per-bucket representative values, accurate
-    /// to within the sketch's α relative-accuracy bound.
-    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
-        let mut sk: Self = from_slice(bytes)?;
-        sk.recompute_scalars_from_store();
-        Ok(sk)
-    }
-
-    /// Rebuild the in-memory `count`/`sum`/`min`/`max` aggregates from the
-    /// bucket store after a deserialize that dropped them. `count` is exact;
-    /// `sum`/`min`/`max` are bucket-representative estimates (α-bounded).
-    fn recompute_scalars_from_store(&mut self) {
-        self.count = 0;
-        self.sum = 0.0;
-        self.min = f64::INFINITY;
-        self.max = f64::NEG_INFINITY;
-        let offset = self.store.offset;
-        for (i, &c) in self.store.counts.as_slice().iter().enumerate() {
-            if c == 0 {
-                continue;
-            }
-            let bin = offset + i as i32;
-            let rep = self.bin_representative(bin);
-            self.count += c;
-            self.sum += rep * c as f64;
-            if rep < self.min {
-                self.min = rep;
-            }
-            if rep > self.max {
-                self.max = rep;
-            }
         }
     }
 
@@ -599,55 +553,29 @@ mod tests {
     #[test]
     fn dds_serialization_round_trip() {
         let mut s = DDSketch::new(0.01);
-        let vals = [1.0, 2.0, 3.0, 10.0, 50.0, 100.0, 1000.0]; // sample values
-
-        for v in vals {
+        for v in [1.0, 2.0, 3.0, 10.0, 50.0, 100.0, 1000.0] {
             s.add(&v);
         }
 
-        let encoded = s.serialize_to_bytes().expect("DDSketch serialization fail"); // serialize to bytes
+        let encoded = s.serialize_to_bytes().expect("DDSketch serialization fail");
         assert!(
             !encoded.is_empty(),
             "encoded bytes should not be empty for DDSketch"
         );
-
         let decoded =
-            DDSketch::deserialize_from_bytes(&encoded).expect("DDSketch deserialization fail"); // deserialize back
+            DDSketch::deserialize_from_bytes(&encoded).expect("DDSketch deserialization fail");
 
-        // `count` survives exactly (recomputed by summing buckets). The
-        // `min`/`max`/`sum` scalars are no longer serialized
-        // (ProjectASAP/sketchlib-go#243) — they're reconstructed from the
-        // per-bucket representative `gamma^k*(1+alpha)`. With that DataDog
-        // representative a value sitting anywhere in a bucket (including the
-        // edges) is within EXACTLY alpha of the representative, so alpha is the
-        // correct tolerance — the old `sqrt(gamma)-1` slack was only needed for
-        // the midpoint `gamma^(k+0.5)` representative.
-        assert_eq!(decoded.get_count(), s.get_count()); // counts should match
-        let alpha = s.alpha();
-        let bucket_tol = alpha + 1e-9;
-        let min_rel = (decoded.min().unwrap() - s.min().unwrap()).abs() / s.min().unwrap();
-        let max_rel = (decoded.max().unwrap() - s.max().unwrap()).abs() / s.max().unwrap();
-        assert!(
-            min_rel <= bucket_tol,
-            "min rel err {min_rel} exceeds bucket tol {bucket_tol}"
-        );
-        assert!(
-            max_rel <= bucket_tol,
-            "max rel err {max_rel} exceeds bucket tol {bucket_tol}"
-        );
-
-        // Quantiles are driven by the (serialized) bucket store, but the
-        // original sketch clamps results to its exact in-memory min/max
-        // while the decoded sketch clamps to the reconstructed bucket-edge
-        // estimates — so the two can differ by up to one bucket width. Both
-        // remain within the relative-accuracy guarantee.
+        // `count` is summed back from the buckets; `sum`/`min`/`max` are carried
+        // on the wire, so every scalar and every quantile comes back exact.
+        assert_eq!(decoded.get_count(), s.get_count());
+        assert_eq!(decoded.sum(), s.sum());
+        assert_eq!(decoded.min(), s.min());
+        assert_eq!(decoded.max(), s.max());
         for q in [0.0, 0.1, 0.5, 0.9, 1.0] {
-            let a = s.get_value_at_quantile(q).unwrap();
-            let b = decoded.get_value_at_quantile(q).unwrap();
-            let rel = (a - b).abs() / a.abs();
-            assert!(
-                rel <= bucket_tol,
-                "quantile p={q} rel err {rel} exceeds bucket tol {bucket_tol} (a={a}, b={b})"
+            assert_eq!(
+                decoded.get_value_at_quantile(q),
+                s.get_value_at_quantile(q),
+                "quantile p={q} diverged after a round trip"
             );
         }
     }

--- a/src/sketches/ddsketch/wire.rs
+++ b/src/sketches/ddsketch/wire.rs
@@ -1,0 +1,544 @@
+//! ASAPv1 wire serialization for DDSketch.
+//!
+//! Child submodule of [`crate::sketches::ddsketch`]: it holds ALL of DDSketch's
+//! ASAPv1 serialization (the metadata/payload DTOs, the kind_id constant, and
+//! the `serialize_to_bytes` / `deserialize_from_bytes` impls) while the
+//! algorithm lives in the parent module file. Being a descendant module, it
+//! reads the sketch's private `store` / `count` / `sum` / `min` / `max` fields
+//! directly without widening any field visibility. See
+//! `docs/asapv1_wire_format.md` §3.
+//!
+//! ## DDSketch metadata has no hash spec
+//!
+//! DDSketch never hashes its inputs — it maps a value to a bucket index with
+//! `floor(ln(v) / ln(gamma))`, and carries no hasher type parameter at all. The
+//! hash-spec group has no truthful value here, so the metadata is structural
+//! params only (`metadata_version`, `alpha`). This is the KLL precedent (Q-KLL).
+//!
+//! ## Relative accuracy
+//!
+//! `alpha` is the one construction parameter, so it lives in the metadata. The
+//! `gamma` / `log_gamma` / `inv_log_gamma` triple is derived from it
+//! (`gamma = (1 + alpha) / (1 - alpha)`) and never reaches the wire.
+//!
+//! ## One positive-range store
+//!
+//! DDSketch is defined for positive reals: `add` drops non-positive,
+//! non-finite, and non-indexable values. There is no negative-range store and
+//! no zero-count bucket, so the payload has no field for either. Bucket
+//! *indices* are still signed — a value below `1.0` maps to a negative index —
+//! and `offset` carries that as a msgpack int.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::common::structures::Vector1D;
+use crate::message_pack_format::envelope;
+
+use super::{Buckets, DDSketch};
+
+/// DDSketch kind_id: family `0x05`, single algorithm variant `0x00`.
+const DD_KIND: &[u8] = &[0x05, 0x00];
+
+/// DDSketch descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`) with keys in this declaration order — the canonical order
+/// the wire spec fixes (Go must mirror it). There is no hash-spec group;
+/// `alpha` is the sketch's one construction parameter and so, per the spec's
+/// config→metadata rule, its only structural param.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DdMetadata {
+    metadata_version: u8,
+    alpha: f64,
+}
+
+/// Builds the DDSketch descriptor metadata for a relative accuracy `alpha`.
+fn dd_metadata(alpha: f64) -> DdMetadata {
+    DdMetadata {
+        metadata_version: 1,
+        alpha,
+    }
+}
+
+/// DDSketch payload (ASAPv1 §3), a msgpack **array** (`to_vec`, positional):
+/// `[counts, offset, sum, min, max]`. `counts` is the dense bucket store,
+/// carried verbatim including the growth padding, so a decoded sketch
+/// re-serializes byte-identically; the bucket index of `counts[i]` is
+/// `offset + i`. `sum` / `min` / `max` are the exact ingested scalars, which
+/// the bucket counts do not determine. The total sample count is the sum of
+/// `counts` and so is not carried.
+#[derive(Debug, Serialize, Deserialize)]
+struct DdPayload {
+    counts: Vec<u64>,
+    offset: i32,
+    sum: f64,
+    min: f64,
+    max: f64,
+}
+
+/// Checks a relative accuracy against the domain [`DDSketch::new`] accepts:
+/// finite and strictly inside `(0, 1)`. Outside it the `gamma` derivation is
+/// non-positive or infinite and every bucket index is meaningless.
+fn check_alpha(alpha: f64) -> Result<(), String> {
+    if !alpha.is_finite() || alpha <= 0.0 || alpha >= 1.0 {
+        return Err(format!("DDSketch alpha {alpha} is not in (0, 1)"));
+    }
+    Ok(())
+}
+
+/// Checks a bucket store's index span: an empty store sits at offset `0`, and
+/// a populated one's highest index `offset + len - 1` is representable as an
+/// `i32`. Applied before the store is rebuilt from the declared offset.
+fn check_store_span(offset: i32, len: usize) -> Result<(), String> {
+    if len == 0 {
+        if offset != 0 {
+            return Err(format!(
+                "DDSketch empty store must be at offset 0, got {offset}"
+            ));
+        }
+        return Ok(());
+    }
+    let highest = i64::from(offset) + len as i64 - 1;
+    if highest > i64::from(i32::MAX) {
+        return Err(format!(
+            "DDSketch store span past i32: offset={offset}, len={len}"
+        ));
+    }
+    Ok(())
+}
+
+/// Total sample count, the checked sum of every bucket. `None` on overflow.
+fn total_count(counts: &[u64]) -> Option<u64> {
+    counts.iter().try_fold(0u64, |acc, &c| acc.checked_add(c))
+}
+
+/// Checks the running scalars against the store's total count. An empty sketch
+/// carries `0.0` / `+inf` / `-inf`, the state [`DDSketch::new`] starts in. A
+/// populated one carries finite scalars with `0 < min <= max`, and `sum >= min`
+/// since every ingested value is at least `min`.
+fn check_scalars(count: u64, sum: f64, min: f64, max: f64) -> Result<(), String> {
+    if count == 0 {
+        if sum == 0.0 && min == f64::INFINITY && max == f64::NEG_INFINITY {
+            return Ok(());
+        }
+        return Err(format!(
+            "DDSketch empty store must carry sum=0, min=inf, max=-inf, got {sum}, {min}, {max}"
+        ));
+    }
+    if !(sum.is_finite() && min.is_finite() && max.is_finite()) {
+        return Err(format!(
+            "DDSketch scalars must be finite for a populated store: {sum}, {min}, {max}"
+        ));
+    }
+    if !(min > 0.0 && min <= max && sum >= min) {
+        return Err(format!(
+            "DDSketch scalars out of order: sum={sum}, min={min}, max={max}"
+        ));
+    }
+    Ok(())
+}
+
+// Wire serialization for DDSketch. `wire` is a descendant of the sketch module,
+// so these impls read the private fields and construct the struct directly.
+impl DDSketch {
+    /// Serializes the sketch into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x05 0x00`). `alpha` lands in the metadata; the payload is the
+    /// bucket store plus the three scalars the buckets do not determine.
+    ///
+    /// A sketch whose state the decoder would refuse — an out-of-range `alpha`,
+    /// a store spanning past `i32`, or bucket counts that overflow `u64` — is an
+    /// error rather than bytes that would be refused on decode.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let fail = |e: String| RmpEncodeError::Syntax(format!("ASAPv1 DDSketch envelope: {e}"));
+        check_alpha(self.alpha).map_err(fail)?;
+        let counts = self.store.counts.as_slice();
+        check_store_span(self.store.offset, counts.len()).map_err(fail)?;
+        let count = total_count(counts)
+            .ok_or_else(|| fail("bucket counts overflow the total sample count".to_string()))?;
+        check_scalars(count, self.sum, self.min, self.max).map_err(fail)?;
+
+        let metadata = rmp_serde::to_vec_named(&dd_metadata(self.alpha))?;
+        let payload = rmp_serde::to_vec(&DdPayload {
+            counts: counts.to_vec(),
+            offset: self.store.offset,
+            sum: self.sum,
+            min: self.min,
+            max: self.max,
+        })?;
+        Ok(envelope::encode(DD_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a DDSketch from an ASAPv1 MessagePack envelope. The index
+    /// mapping is rebuilt from the metadata `alpha` and the total sample count
+    /// is summed from the buckets. Every inconsistency fails closed.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != DD_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "DDSketch kind_id mismatch: stored {kind_id:?}, expected {DD_KIND:?}"
+            )));
+        }
+        let meta: DdMetadata = from_slice(metadata)?;
+        // `alpha` is a property of the stored sketch rather than of the target
+        // type, so it is echoed back into the expected block and bounded by
+        // range instead of being pinned.
+        if meta != dd_metadata(meta.alpha) {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 DDSketch envelope: metadata mismatch".to_string(),
+            ));
+        }
+        check_alpha(meta.alpha).map_err(RmpDecodeError::Uncategorized)?;
+
+        let p: DdPayload = from_slice(payload)?;
+        check_store_span(p.offset, p.counts.len()).map_err(RmpDecodeError::Uncategorized)?;
+        let count = total_count(&p.counts).ok_or_else(|| {
+            RmpDecodeError::Uncategorized(
+                "DDSketch bucket counts overflow the total sample count".to_string(),
+            )
+        })?;
+        check_scalars(count, p.sum, p.min, p.max).map_err(RmpDecodeError::Uncategorized)?;
+
+        let alpha = meta.alpha;
+        let gamma = (1.0 + alpha) / (1.0 - alpha);
+        let log_gamma = gamma.ln();
+        Ok(DDSketch {
+            alpha,
+            gamma,
+            log_gamma,
+            inv_log_gamma: 1.0 / log_gamma,
+            store: Buckets {
+                counts: Vector1D::from_vec(p.counts),
+                offset: p.offset,
+            },
+            count,
+            sum: p.sum,
+            min: p.min,
+            max: p.max,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALPHA: f64 = 0.01;
+
+    fn populated() -> DDSketch {
+        let mut sketch = DDSketch::new(ALPHA);
+        for v in [0.25f64, 1.0, 2.0, 3.0, 10.0, 50.0, 100.0, 1000.0] {
+            sketch.add(&v);
+        }
+        sketch
+    }
+
+    /// Builds a real envelope with real metadata around a hand-built payload,
+    /// so the crafted-bytes tests exercise the decoder's own rules rather than
+    /// the envelope's framing.
+    fn crafted(alpha: f64, counts: Vec<u64>, offset: i32, sum: f64, min: f64, max: f64) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(&dd_metadata(alpha)).unwrap();
+        let payload = rmp_serde::to_vec(&DdPayload {
+            counts,
+            offset,
+            sum,
+            min,
+            max,
+        })
+        .unwrap();
+        envelope::encode(DD_KIND, &metadata, &payload)
+    }
+
+    /// The message a rejected decode fails with, so a test can pin *which*
+    /// rule fired rather than settling for any error at all.
+    fn decode_error(bytes: &[u8]) -> String {
+        DDSketch::deserialize_from_bytes(bytes)
+            .expect_err("decode must fail")
+            .to_string()
+    }
+
+    #[test]
+    fn ddsketch_envelope_structure_and_round_trip() {
+        let sketch = populated();
+        let bytes = sketch.serialize_to_bytes().expect("serialize");
+
+        assert!(bytes.starts_with(b"ASAPv1"));
+        assert_eq!(&bytes[7..10], &[2u8, 0x05, 0x00]); // kind_id_len=2, kind_id=[0x05,0x00]
+        let (kind_id, metadata, _) = envelope::split(&bytes).expect("split");
+        assert_eq!(kind_id, &[0x05, 0x00]);
+        let meta: DdMetadata = from_slice(metadata).expect("metadata");
+        assert_eq!(meta.metadata_version, 1);
+        assert_eq!(meta.alpha, ALPHA);
+
+        let decoded = DDSketch::deserialize_from_bytes(&bytes).expect("decode");
+        assert_eq!(decoded.store_counts(), sketch.store_counts());
+        assert_eq!(decoded.store_offset(), sketch.store_offset());
+        assert_eq!(
+            decoded.serialize_to_bytes().expect("re-serialize"),
+            bytes,
+            "DDSketch serialized bytes differed after round trip"
+        );
+        for q in [0.0, 0.1, 0.5, 0.9, 1.0] {
+            assert_eq!(
+                decoded.get_value_at_quantile(q),
+                sketch.get_value_at_quantile(q)
+            );
+        }
+    }
+
+    /// `sum` / `min` / `max` are not derivable from the buckets, so they are
+    /// carried and come back exactly — not as the α-bounded bucket
+    /// representatives a recomputation would produce.
+    #[test]
+    fn ddsketch_scalars_survive_exactly() {
+        let sketch = populated();
+        let decoded =
+            DDSketch::deserialize_from_bytes(&sketch.serialize_to_bytes().expect("serialize"))
+                .expect("decode");
+        assert_eq!(decoded.sum(), sketch.sum());
+        assert_eq!(decoded.min(), Some(0.25));
+        assert_eq!(decoded.max(), Some(1000.0));
+        assert_eq!(decoded.alpha(), sketch.alpha());
+    }
+
+    /// The total sample count is the sum of the buckets, so the payload carries
+    /// no `count` field: it is a 5-element array and nothing more.
+    #[test]
+    fn ddsketch_count_is_recovered_from_the_buckets() {
+        let sketch = populated();
+        let bytes = sketch.serialize_to_bytes().expect("serialize");
+        let (_, _, payload) = envelope::split(&bytes).expect("split");
+
+        let five: (Vec<u64>, i32, f64, f64, f64) = from_slice(payload).expect("5-element payload");
+        assert_eq!(five.0.iter().sum::<u64>(), sketch.get_count());
+        assert!(
+            from_slice::<(Vec<u64>, i32, f64, f64, f64, u64)>(payload).is_err(),
+            "the payload must not carry a sixth element"
+        );
+
+        let decoded = DDSketch::deserialize_from_bytes(&bytes).expect("decode");
+        assert_eq!(decoded.get_count(), sketch.get_count());
+    }
+
+    #[test]
+    fn ddsketch_empty_round_trip() {
+        let sketch = DDSketch::new(ALPHA);
+        let bytes = sketch.serialize_to_bytes().expect("serialize");
+        let decoded = DDSketch::deserialize_from_bytes(&bytes).expect("decode");
+
+        assert_eq!(decoded.get_count(), 0);
+        assert_eq!(decoded.min(), None);
+        assert_eq!(decoded.max(), None);
+        assert!(decoded.store_counts().is_empty());
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), bytes);
+    }
+
+    /// A merged sketch — a store grown on both sides — round-trips with its
+    /// scalars and quantiles intact.
+    #[test]
+    fn ddsketch_merged_round_trip() {
+        let mut left = DDSketch::new(ALPHA);
+        let mut right = DDSketch::new(ALPHA);
+        for i in 1..=200u32 {
+            left.add(&f64::from(i));
+            right.add(&(f64::from(i) * 0.001));
+        }
+        left.merge(&right).expect("merge");
+
+        let bytes = left.serialize_to_bytes().expect("serialize");
+        let decoded = DDSketch::deserialize_from_bytes(&bytes).expect("decode");
+        assert_eq!(decoded.get_count(), left.get_count());
+        assert_eq!(decoded.sum(), left.sum());
+        assert_eq!(decoded.min(), left.min());
+        assert_eq!(decoded.max(), left.max());
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), bytes);
+    }
+
+    /// A crafted envelope carrying another sketch's kind_id must be rejected
+    /// even though its metadata and payload parse cleanly.
+    #[test]
+    fn ddsketch_rejects_foreign_kind_id() {
+        let cms =
+            crate::CountMin::<crate::Vector2D<i64>, crate::RegularPath>::with_dimensions(3, 8);
+        let cms_bytes = cms.serialize_to_bytes().expect("serialize CMS");
+        assert!(
+            DDSketch::deserialize_from_bytes(&cms_bytes).is_err(),
+            "Count-Min bytes must not decode as a DDSketch"
+        );
+
+        let metadata = rmp_serde::to_vec_named(&dd_metadata(ALPHA)).unwrap();
+        let payload = rmp_serde::to_vec(&DdPayload {
+            counts: Vec::new(),
+            offset: 0,
+            sum: 0.0,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+        })
+        .unwrap();
+        let bytes = envelope::encode(&[0x02, 0x00], &metadata, &payload);
+        assert!(
+            DDSketch::deserialize_from_bytes(&bytes).is_err(),
+            "a foreign kind_id must be rejected"
+        );
+    }
+
+    /// Fail closed on an unexpected metadata key.
+    #[test]
+    fn dd_metadata_rejects_unknown_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            alpha: f64,
+            bogus_field: u8, // key not in DdMetadata
+        }
+        let bytes = rmp_serde::to_vec_named(&WithExtra {
+            metadata_version: 1,
+            alpha: ALPHA,
+            bogus_field: 7,
+        })
+        .unwrap();
+        assert!(
+            rmp_serde::from_slice::<DdMetadata>(&bytes).is_err(),
+            "an unexpected metadata key must be rejected"
+        );
+    }
+
+    /// `alpha` is required: a DDSketch metadata map missing it does not decode,
+    /// so the key cannot be silently defaulted to zero.
+    #[test]
+    fn dd_metadata_rejects_a_missing_alpha_key() {
+        #[derive(Serialize)]
+        struct WithoutAlpha {
+            metadata_version: u8,
+        }
+        let bytes = rmp_serde::to_vec_named(&WithoutAlpha {
+            metadata_version: 1,
+        })
+        .unwrap();
+        assert!(
+            rmp_serde::from_slice::<DdMetadata>(&bytes).is_err(),
+            "a missing alpha key must be rejected"
+        );
+    }
+
+    /// `alpha` outside `(0, 1)` makes every bucket index meaningless, so it is
+    /// rejected rather than used to derive a nonsense mapping.
+    #[test]
+    fn ddsketch_rejects_alpha_outside_the_unit_interval() {
+        for alpha in [0.0, 1.0, -0.5, 2.0, f64::NAN, f64::INFINITY] {
+            let bytes = crafted(alpha, vec![3], 7, 6.0, 1.5, 2.5);
+            let err = decode_error(&bytes);
+            assert!(
+                err.contains("alpha") || err.contains("metadata mismatch"),
+                "alpha={alpha} must be rejected by the alpha rule, got {err}"
+            );
+        }
+        // The neighbouring in-range value is the control case.
+        assert!(
+            DDSketch::deserialize_from_bytes(&crafted(ALPHA, vec![3], 7, 6.0, 1.5, 2.5)).is_ok()
+        );
+    }
+
+    /// A store whose declared offset pushes its highest bucket index past
+    /// `i32` is rejected from the offset and the array length alone, before the
+    /// store is rebuilt — and never panics.
+    #[test]
+    fn ddsketch_rejects_a_store_span_past_i32() {
+        let err = decode_error(&crafted(ALPHA, vec![1; 10], i32::MAX - 2, 5.0, 1.0, 2.0));
+        assert!(
+            err.contains("store span past i32"),
+            "an overflowing store span must be rejected as such, got {err}"
+        );
+        // The same payload one bucket shorter than the boundary decodes.
+        let ok = crafted(ALPHA, vec![1; 3], i32::MAX - 2, 5.0, 1.0, 2.0);
+        assert!(DDSketch::deserialize_from_bytes(&ok).is_ok());
+    }
+
+    /// An empty store has exactly one encoding, so a crafted non-zero offset on
+    /// one is rejected instead of decoding into a sketch that re-serializes to
+    /// different bytes.
+    #[test]
+    fn ddsketch_rejects_a_nonzero_offset_on_an_empty_store() {
+        let err = decode_error(&crafted(
+            ALPHA,
+            Vec::new(),
+            42,
+            0.0,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ));
+        assert!(
+            err.contains("empty store must be at offset 0"),
+            "a non-zero empty-store offset must be rejected as such, got {err}"
+        );
+    }
+
+    /// Bucket counts that overflow the recovered total are rejected rather than
+    /// wrapping into a count the quantile walk would disagree with.
+    #[test]
+    fn ddsketch_rejects_a_total_count_overflow() {
+        let err = decode_error(&crafted(ALPHA, vec![u64::MAX, 1], 0, 5.0, 1.0, 2.0));
+        assert!(
+            err.contains("overflow the total sample count"),
+            "an overflowing bucket total must be rejected as such, got {err}"
+        );
+    }
+
+    /// The scalars the buckets do not determine are still bounded by them: an
+    /// empty store carries the sentinels, a populated one finite positive
+    /// bounds in order.
+    #[test]
+    fn ddsketch_rejects_inconsistent_scalars() {
+        let cases = [
+            // Populated store with the empty-store sentinels.
+            (vec![3u64], 7i32, 6.0f64, f64::INFINITY, f64::NEG_INFINITY),
+            // min above max.
+            (vec![3], 7, 6.0, 9.0, 2.0),
+            // Non-positive min.
+            (vec![3], 7, 6.0, 0.0, 2.0),
+            // Sum below the smallest ingested value.
+            (vec![3], 7, 0.5, 1.5, 2.5),
+            // Empty store carrying a non-zero sum.
+            (Vec::new(), 0, 5.0, f64::INFINITY, f64::NEG_INFINITY),
+            // All-zero buckets carrying populated-store scalars.
+            (vec![0, 0], 7, 6.0, 1.5, 2.5),
+        ];
+        for (counts, offset, sum, min, max) in cases {
+            let err = decode_error(&crafted(ALPHA, counts, offset, sum, min, max));
+            assert!(
+                err.contains("DDSketch empty store must carry")
+                    || err.contains("scalars out of order")
+                    || err.contains("scalars must be finite"),
+                "sum={sum}, min={min}, max={max} must be rejected by a scalar rule, got {err}"
+            );
+        }
+    }
+
+    /// A sketch whose store spans past `i32` would be refused on decode, so it
+    /// must not serialize either.
+    #[test]
+    fn ddsketch_rejects_serializing_a_store_span_past_i32() {
+        let mut sketch = DDSketch::new(ALPHA);
+        sketch.add(&1.0f64);
+        sketch.store.counts = Vector1D::from_vec(vec![1u64; 10]);
+        sketch.store.offset = i32::MAX - 2;
+        assert!(
+            sketch.serialize_to_bytes().is_err(),
+            "a store spanning past i32 must not serialize"
+        );
+    }
+
+    /// Bucket counts that overflow the total sample count must not serialize
+    /// either — the encode side enforces the decoder's rule.
+    #[test]
+    fn ddsketch_rejects_serializing_an_overflowing_bucket_total() {
+        let mut sketch = DDSketch::new(ALPHA);
+        sketch.add(&1.0f64);
+        sketch.store.counts = Vector1D::from_vec(vec![u64::MAX, 1]);
+        sketch.store.offset = 0;
+        assert!(
+            sketch.serialize_to_bytes().is_err(),
+            "bucket counts overflowing the total must not serialize"
+        );
+    }
+}


### PR DESCRIPTION
Puts DDSketch on the ASAPv1 envelope under its allocated kind_id `0x05 0x00`. All of the serialization moves into a new `src/sketches/ddsketch/wire.rs`, a child module of the sketch so it reads the private `store` / `count` / `sum` / `min` / `max` fields without widening any field visibility.

No golden fixtures this round, and `docs/asapv1_wire_format.md` is untouched — the §3.x draft below is for a later harvest agent.

## §3.8: DDSketch payload (`0x05 0x00`)

`DDSketch` maps a positive value to a logarithmic bucket index `floor(ln(v) / ln(γ))` and keeps a dense count per bucket. The relative accuracy `α` is the sketch's one construction parameter and lives in the metadata, so the payload is the bucket store plus the running scalars the buckets do not determine:

| Pos | Field | Type | Notes |
| ----- | ------- | ------ | ------- |
| 0 | `counts` | array | dense per-bucket sample counts, u64; the bucket index of `counts[i]` is `offset + i`. Carried verbatim, growth padding included |
| 1 | `offset` | int | absolute bucket index of `counts[0]`; **signed** (a value below `1.0` maps to a negative index). `0` when `counts` is empty |
| 2 | `sum` | f64 | exact sum of every ingested value; `0.0` when empty |
| 3 | `min` | f64 | smallest ingested value; `+inf` when empty |
| 4 | `max` | f64 | largest ingested value; `-inf` when empty |

**Metadata vs payload.** `alpha` is chosen at construction and shapes every bucket index, so per the config→metadata rule it is a structural param in the descriptor (like HLL's `precision`). `gamma`, `log_gamma` and `inv_log_gamma` are all derived from it (`γ = (1 + α) / (1 - α)`) and so appear nowhere: the decoder re-derives them exactly as `DDSketch::new` does. The dense store's dimensions are not configuration — the store grows with the data — so unlike Count-Min there is no `rows`/`cols` analogue in the metadata; `counts` is self-delimiting and `offset` positions it.

**DDSketch carries no hash-spec group.** DDSketch never hashes its inputs: it maps a raw `f64` through a logarithm and carries no hasher type parameter at all. The hash spec answers "how were keys hashed", and a sketch that does not hash has no truthful answer, so the group is omitted entirely and the metadata is `metadata_version` + `alpha` only. This is exactly the KLL precedent (Q-KLL), and the reason DDSketch's metadata schema is not `HashProfile`-derived the way HLL's / Count-Min's / Count Sketch's are.

**One positive-range store, no zero bucket.** `add` drops non-positive, non-finite, and non-indexable values, so there is no negative-range store and no zero-count bucket to encode — and a field that can never be truthful must not exist. Bucket *indices* are still signed, and `offset` carries that as a msgpack int per §4 (negative → the `int` family; non-negative → `uint`, minimal width). The five payload floats are always full float64.

**`count` is not carried.** Every path that advances `count` advances the bucket store by the same amount (`add` by one, `apply_delta` by the delta's value, `merge` by the other side's total), so the total sample count is exactly `sum(counts)` and is recomputed on decode. `sum`, `min` and `max` are *not* recoverable — the buckets only bound them to within α — so all three are carried.

**Decode rules** (all fail closed, per Section 1's decoder rules, with an error and never a panic):

1. `kind_id` is `0x05 0x00`; any other id is rejected.
2. The metadata map is exact: `metadata_version` and `alpha` are both required and no other key is accepted (`deny_unknown_fields`). `alpha` is a property of the *stored* sketch rather than of the target type, so it is echoed back into the expected block rather than pinned — the same treatment Count-Min gives `rows`/`cols`.
3. `alpha` is finite and strictly inside `(0, 1)` — the domain `DDSketch::new` asserts. Outside it the γ derivation is non-positive or infinite and every bucket index is meaningless.
4. An empty `counts` sits at `offset == 0`, so an empty store has exactly one encoding and a decoded sketch re-serializes byte-identically.
5. A populated `counts` has its highest bucket index `offset + len - 1` representable as an `i32`, checked in `i64` so the check itself cannot overflow. Applied from the declared offset and the array length alone, before the store is rebuilt.
6. The total sample count is the **checked** sum of `counts`; an overflowing total is rejected rather than wrapping into a count the quantile walk would disagree with.
7. The scalars are consistent with that total: an empty store carries `sum == 0.0`, `min == +inf`, `max == -inf`; a populated one carries finite `sum` / `min` / `max` with `0 < min <= max` and `sum >= min`.

Rules 3, 5, 6 and 7 are enforced on the **encode** side too, so the format never emits bytes it would refuse to read back.

## Decisions recorded

- **Q-DDS-HASH — no hash-spec group.** DDSketch does not hash its inputs (`add` takes a `NumericalValue`, converts to `f64`, and indexes it logarithmically; there is no `H: SketchHasher` parameter anywhere on the type). Its metadata is therefore structural-only, following KLL. No `AltHasher` three-part test applies, and none is added.
- **Q-DDS-COUNT — `count` is dropped from the wire and summed back from the buckets.** Verified against the struct: `add`, `apply_delta` and `merge` each advance `count` and the store by the same amount, and there is no zero-count or collapsed-bucket path that would make the recovery lossy (the store is dense and only ever grows; it is never collapsed). This matches `sketchlib-go` #243, which dropped `count` on the Go side. **Consequence for `sketchlib-go`:** Go must not emit a count field, and must recover the total by summing the bucket counts with an overflow check, since a crafted payload can otherwise wrap the u64 total.
- **Q-DDS-SCALARS — `sum` / `min` / `max` are carried, unlike #243.** They are not derivable from the buckets: the pre-existing fallback re-estimated them from the per-bucket representative `γ^k·(1+α)`, which is only α-accurate. Carrying them makes them exact and makes a round trip byte-identical (a lossy recovery would re-serialize a decoded sketch to different bytes). **Consequence for `sketchlib-go`:** the ASAPv1 DDSketch payload re-introduces these three at positions 2/3/4 — Go must carry them, not recompute them. They are the only fields where ASAPv1 diverges from the #243 proto shape.
- **Q-DDS-ALPHA — relative accuracy travels as `alpha` in the metadata, not γ.** It is construction config, and γ / `log_gamma` / `inv_log_gamma` are derived from it, so carrying γ too would be a derived field. Note Go's proto currently round-trips α through γ (`α_wire = (γ-1)/(γ+1)`, a ~25-ULP shift); ASAPv1 carries the user-supplied α verbatim so the bytes round-trip exactly.
- **Q-DDS-NEG — no negative-range store, no zero bucket.** `add` drops non-positive, non-finite and non-indexable values, so neither piece of state exists to encode. Bucket indices remain signed and `offset` is a signed msgpack int.
- **Q-DDS-VERBATIM — the store is carried verbatim, not trimmed.** The `GROW_CHUNK` padding zeros stay in `counts` and `offset` stays where the sketch put it, so a decoded sketch re-serializes byte-identically and `store_counts()` / `store_offset()` (which the proto path already exposes) mean the same thing on both sides. Trimming would make the bytes canonical across producers but break byte-identical re-serialization; verbatim also matches Go's `DdSketchState`.
- **Struct-level serde is left alone.** `DDSketch` keeps its derived `Serialize`/`Deserialize` because `EHSketchList::DDS` nests it; that Rust-internal form still skips the four running scalars. Only `serialize_to_bytes` / `deserialize_from_bytes` change, and the now-unused `recompute_scalars_from_store` is removed.

## Tests

Fourteen in `src/sketches/ddsketch/wire.rs`, plus a tightened one in the parent module.

1. `ddsketch_envelope_structure_and_round_trip` — envelope starts with `b"ASAPv1"`, `encoded[7..10] == [2, 0x05, 0x00]`, metadata decodes with `metadata_version == 1` and the source α; the store, the quantiles and the re-serialized bytes all match.
2. `ddsketch_scalars_survive_exactly` — `sum` / `min` / `max` come back exactly (0.25 and 1000.0, not bucket representatives).
3. `ddsketch_count_is_recovered_from_the_buckets` — the payload decodes as a 5-element tuple and **fails** to decode as a 6-element one, so no `count` field is present; the summed total matches `get_count()`.
4. `ddsketch_empty_round_trip` — empty sketch round-trips; `min`/`max` are `None`, the store is empty, bytes re-serialize identically.
5. `ddsketch_merged_round_trip` — a store grown on both sides round-trips with scalars and bytes intact.
6. `ddsketch_rejects_foreign_kind_id` — a real Count-Min envelope, and a crafted DDSketch metadata+payload under kind_id `0x02 0x00`, are both rejected.
7. `dd_metadata_rejects_unknown_keys` — `deny_unknown_fields`.
8. `dd_metadata_rejects_a_missing_alpha_key` — a required key can never be silently defaulted.
9. `ddsketch_rejects_alpha_outside_the_unit_interval` — `0.0`, `1.0`, `-0.5`, `2.0`, NaN, inf all rejected; the in-range control decodes.
10. `ddsketch_rejects_a_store_span_past_i32` — a declared offset near `i32::MAX` is rejected from the offset and array length alone, before the store is rebuilt, and does not panic; the shorter control decodes.
11. `ddsketch_rejects_a_nonzero_offset_on_an_empty_store` — the empty store's single encoding.
12. `ddsketch_rejects_a_total_count_overflow` — `[u64::MAX, 1]` is rejected rather than wrapping.
13. `ddsketch_rejects_inconsistent_scalars` — six crafted combinations (populated store with the empty sentinels, `min > max`, non-positive `min`, `sum < min`, empty store with a non-zero sum, all-zero buckets with populated-store scalars).
14. `ddsketch_rejects_serializing_a_store_span_past_i32` and `ddsketch_rejects_serializing_an_overflowing_bucket_total` — encode-side: a sketch in a state the decoder would refuse does not serialize.

`dds_serialization_round_trip` in `src/sketches/ddsketch.rs` now asserts exact equality on `count` / `sum` / `min` / `max` and on every quantile, replacing the α-tolerance bands the lossy recovery needed. This is what `docs/tests.md` already claims for it.

## CI

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --all-features --locked --verbose` — pass (781 lib tests plus every integration suite, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
