### PR TITLE
feat(topk): ASAPv1 wire payloads for CMSHeap (0x03 0x00) and CSHeap (0x0a 0x00)

### DIFF
--- a/docs/api/api_cms_heap.md
+++ b/docs/api/api_cms_heap.md
@@ -45,7 +45,33 @@ fn merge(&mut self, other: &Self)
 
 ## Serialization
 
-Not currently provided as a dedicated public API.
+```rust
+fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError>
+fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
+```
+
+These produce/consume the **ASAPv1** wire envelope (kind `0x03 0x00`) — see the
+[ASAPv1 wire format spec](../asapv1_wire_format.md). They are **not** available
+on every `CMSHeap`: the impl exists only for wire-eligible configs
+`CMSHeap<Vector2D<T>, Mode, H>` where `T` is `i64` or `f64` (`CmsWireCounter`),
+`Mode` is `FastPath` or `RegularPath` (`CmsWireMode`), and `H: HashProfile`. An
+`i32`, `i128` or non-`Vector2D` sketch must be converted first (only you know if
+the mapping is lossless).
+
+A sketch travels as the base matrix plus the heap's entries: the metadata
+carries `rows`, `cols`, `counter_type`, `mode`, the heap capacity `k` and the
+heap's `key_type`, and the payload is `[counts, keys, heap_counts]`. The heap's
+digest index is rebuilt on load, so no index reaches the wire, and `k` never
+sizes an allocation on decode.
+
+Heap keys are `HeapItem`s, so the key type is a runtime property: `key_type`
+names the **exact** variant (`"i32"` stays `"i32"`, never widened to `"i64"`)
+and the `keys` array is homogeneous in it. A heap whose keys mix variants, or
+holds an `I128` / `U128` key, does not serialize. An empty heap emits
+`key_type = "u64"`.
+
+Entries are emitted in descending count, ties broken by a total order over the
+key, so a decoded sketch re-serializes byte-identically.
 
 ## Examples
 

--- a/docs/api/api_cs_heap.md
+++ b/docs/api/api_cs_heap.md
@@ -45,7 +45,37 @@ fn merge(&mut self, other: &Self)
 
 ## Serialization
 
-Not currently provided as a dedicated public API.
+```rust
+fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError>
+fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
+```
+
+These produce/consume the **ASAPv1** wire envelope (kind `0x0a 0x00`) — see the
+[ASAPv1 wire format spec](../asapv1_wire_format.md). They are **not** available
+on every `CSHeap`: the impl exists only for wire-eligible configs
+`CSHeap<Vector2D<T>, Mode, H>` where `T` is `i32` or `i64` (`CsWireCounter`),
+`Mode` is `FastPath` or `RegularPath` (`CsWireMode`), and `H: HashProfile`. Count Sketch
+counters must be signed and negatable, so there is no `f64` counterpart to
+Count-Min's; an `i128` or non-`Vector2D` sketch must be converted first (only
+you know if the mapping is lossless).
+
+A sketch travels as the base matrix plus the heap's entries: the metadata
+carries `rows`, `cols`, `counter_type`, `mode`, the heap capacity `k` and the
+heap's `key_type`, and the payload is `[counts, keys, heap_counts]`. The heap's
+digest index is rebuilt on load, so no index reaches the wire, and `k` never
+sizes an allocation on decode.
+
+Heap keys are `HeapItem`s, so the key type is a runtime property: `key_type`
+names the **exact** variant (`"i32"` stays `"i32"`, never widened to `"i64"`)
+and the `keys` array is homogeneous in it. A heap whose keys mix variants, or
+holds an `I128` / `U128` key, does not serialize. An empty heap emits
+`key_type = "u64"`.
+
+Entries are emitted in descending count, ties broken by a total order over the
+key, so a decoded sketch re-serializes byte-identically.
+
+`CountL2HH` is a different algorithm and has no ASAPv1 payload yet; its own
+`serialize_to_bytes` is the Rust-internal `portable` form.
 
 ## Examples
 

--- a/src/common/heap.rs
+++ b/src/common/heap.rs
@@ -6,6 +6,7 @@
 //! whatever the capacity.
 
 use crate::common::input::HHItem;
+use crate::common::structures::heap::PREALLOCATED_SLOTS;
 use crate::common::{CommonHeap, DigestBuildHasher, KeepSmallest};
 use crate::{DataInput, HeapItem, hash_item64_seeded, hash64_seeded, input_to_owned};
 use serde::{Deserialize, Serialize};
@@ -59,8 +60,11 @@ impl HHHeap {
     pub fn new(k: usize) -> Self {
         HHHeap {
             heap: CommonHeap::new_min(k),
-            slots: Vec::with_capacity(k),
-            positions: Index::with_capacity_and_hasher(k, DigestBuildHasher::default()),
+            slots: Vec::with_capacity(k.min(PREALLOCATED_SLOTS)),
+            positions: Index::with_capacity_and_hasher(
+                k.min(PREALLOCATED_SLOTS),
+                DigestBuildHasher::default(),
+            ),
             k,
         }
     }

--- a/src/common/structures/heap.rs
+++ b/src/common/structures/heap.rs
@@ -54,11 +54,14 @@ pub struct CommonHeap<T, O: CommonHeapOrder<T>> {
     order: O,
 }
 
+/// Slots reserved up front. A heap whose capacity is larger grows on demand.
+pub(crate) const PREALLOCATED_SLOTS: usize = 1024;
+
 impl<T, O: CommonHeapOrder<T>> CommonHeap<T, O> {
     /// Creates a new heap with the specified capacity and ordering.
     pub fn with_capacity(capacity: usize, order: O) -> Self {
         Self {
-            data: Vec::with_capacity(capacity),
+            data: Vec::with_capacity(capacity.min(PREALLOCATED_SLOTS)),
             size: capacity,
             order,
         }

--- a/src/sketches/countminsketch_topk.rs
+++ b/src/sketches/countminsketch_topk.rs
@@ -10,6 +10,9 @@ use crate::{
     SketchHasher, Vector2D, heap_item_to_sketch_input,
 };
 
+pub(crate) mod heap_wire;
+mod wire;
+
 const DEFAULT_TOP_K: usize = 32;
 
 /// A Count-Min Sketch paired with a top-k heavy-hitter heap.

--- a/src/sketches/countminsketch_topk/heap_wire.rs
+++ b/src/sketches/countminsketch_topk/heap_wire.rs
@@ -1,0 +1,618 @@
+//! ASAPv1 wire pieces shared by the heap-backed top-k sketches.
+//!
+//! [`CMSHeap`](super::CMSHeap) (kind_id `0x03 0x00`) and
+//! [`CSHeap`](crate::sketches::countsketch_topk::CSHeap) (kind_id `0x0a 0x00`)
+//! are each a matrix sketch plus an [`HHHeap`], so both carry the same
+//! descriptor metadata and the same positional payload
+//! `[counts, keys, heap_counts]`. This module is the one place that encoding
+//! lives: the metadata DTO, the payload DTO, the `key_type` mapping, the
+//! emitted order, and the heap rebuild. See `docs/asapv1_wire_format.md` §3.2,
+//! §3.5 and §3.6 for the pieces it follows.
+//!
+//! ## `key_type` names the exact `HeapItem` variant
+//!
+//! A heap key's type is a **runtime** property: keys are [`HeapItem`]s, a
+//! 16-variant enum, and one heap's keys are whatever the caller inserted. One
+//! metadata `key_type` names the exact variant and the payload's `keys` array
+//! is homogeneous in it. The variant is never widened (an `i32` key is `"i32"`,
+//! not `"i64"`) because `HeapItem`'s equality against a query `DataInput`
+//! discriminates on the variant while the digest does not: a widened key lands
+//! in the same index slot and then silently fails equality.
+//! `HeapItem::I128` / `U128` have no msgpack integer form and are not wire
+//! types, so a heap holding one refuses to serialize — as does one whose keys
+//! mix variants.
+//!
+//! ## Emitted order (byte-stable round trips)
+//!
+//! The heap's array order follows the sift path and does not survive a rebuild,
+//! so the payload is **order-defined**: descending count, ties broken by
+//! [`key_order`], a total order over [`HeapItem`] (variant tag first, then the
+//! value). Two heaps holding the same entries emit the same bytes whatever
+//! order they were seated in, and re-serializing a decoded sketch reproduces
+//! its bytes exactly.
+//!
+//! ## What the heap does not put on the wire
+//!
+//! `HHHeap`'s `slots` and `positions` are `#[serde(skip)]` and are rebuilt from
+//! the entries, so no index reaches the wire and no crafted payload can point
+//! one out of bounds or into a cycle. `k` is construction config, so it lives
+//! in the metadata; it never sizes an allocation on decode.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::{HHHeap, HashProfile, HeapItem};
+
+/// Metadata `key_type` of a heap that holds nothing. A heap with no entries has
+/// no variant to report, so the wire pins one: empty heaps have one encoding.
+pub(crate) const EMPTY_KEY_TYPE: &str = "u64";
+
+/// The metadata `key_type` naming a key's exact [`HeapItem`] variant, or `None`
+/// for the 128-bit variants, which are not wire types.
+pub(crate) fn key_type_of(key: &HeapItem) -> Option<&'static str> {
+    Some(match key {
+        HeapItem::I8(_) => "i8",
+        HeapItem::I16(_) => "i16",
+        HeapItem::I32(_) => "i32",
+        HeapItem::I64(_) => "i64",
+        HeapItem::ISIZE(_) => "isize",
+        HeapItem::U8(_) => "u8",
+        HeapItem::U16(_) => "u16",
+        HeapItem::U32(_) => "u32",
+        HeapItem::U64(_) => "u64",
+        HeapItem::USIZE(_) => "usize",
+        HeapItem::F32(_) => "f32",
+        HeapItem::F64(_) => "f64",
+        HeapItem::String(_) => "string",
+        HeapItem::I128(_) | HeapItem::U128(_) => return None,
+    })
+}
+
+/// A total order over keys: variant tag first, then the value.
+fn key_order(key: &HeapItem) -> (u8, u128, &str) {
+    match key {
+        HeapItem::I8(v) => (0, *v as i128 as u128, ""),
+        HeapItem::I16(v) => (1, *v as i128 as u128, ""),
+        HeapItem::I32(v) => (2, *v as i128 as u128, ""),
+        HeapItem::I64(v) => (3, *v as i128 as u128, ""),
+        HeapItem::I128(v) => (4, *v as u128, ""),
+        HeapItem::ISIZE(v) => (5, *v as i128 as u128, ""),
+        HeapItem::U8(v) => (6, u128::from(*v), ""),
+        HeapItem::U16(v) => (7, u128::from(*v), ""),
+        HeapItem::U32(v) => (8, u128::from(*v), ""),
+        HeapItem::U64(v) => (9, u128::from(*v), ""),
+        HeapItem::U128(v) => (10, *v, ""),
+        HeapItem::USIZE(v) => (11, *v as u128, ""),
+        HeapItem::F32(v) => (12, u128::from(v.to_bits()), ""),
+        HeapItem::F64(v) => (13, u128::from(v.to_bits()), ""),
+        HeapItem::String(v) => (14, 0, v.as_str()),
+    }
+}
+
+/// Top-k descriptor metadata (ASAPv1 §2), a msgpack **map** (`to_vec_named`)
+/// with keys in this declaration order — the canonical order the wire spec
+/// fixes (Go must mirror it). Hash-spec fields first, then the base sketch's
+/// structural params `rows` / `cols` / `counter_type` / `mode`, then the heap's
+/// `k` / `key_type`.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TopKMetadata {
+    pub(crate) metadata_version: u8,
+    pub(crate) hash_profile_id: String,
+    pub(crate) hash_algorithm: String,
+    pub(crate) seed_derivation: String,
+    pub(crate) input_encoding: String,
+    pub(crate) seed_list: Vec<u64>,
+    pub(crate) matrix_seed_index: u32,
+    pub(crate) rows: u32,
+    pub(crate) cols: u32,
+    pub(crate) counter_type: String,
+    pub(crate) mode: String,
+    pub(crate) k: u32,
+    pub(crate) key_type: String,
+}
+
+/// Builds the descriptor metadata from the hasher's [`HashProfile`], so the wire
+/// bytes truthfully describe how the sketch was hashed. `rows` / `cols` /
+/// `counter_type` / `mode` describe the base matrix; `k` is the heap capacity
+/// and `key_type` the exact [`HeapItem`] variant the `keys` array carries.
+pub(crate) fn topk_metadata<H: HashProfile>(
+    rows: u32,
+    cols: u32,
+    counter_type: &str,
+    mode: &str,
+    k: u32,
+    key_type: &str,
+) -> TopKMetadata {
+    TopKMetadata {
+        metadata_version: 1,
+        hash_profile_id: H::PROFILE_ID.to_string(),
+        hash_algorithm: H::ALGORITHM.to_string(),
+        seed_derivation: H::SEED_DERIVATION.to_string(),
+        input_encoding: H::INPUT_ENCODING.to_string(),
+        seed_list: H::seed_list(),
+        matrix_seed_index: H::MATRIX_SEED_INDEX,
+        rows,
+        cols,
+        counter_type: counter_type.to_string(),
+        mode: mode.to_string(),
+        k,
+        key_type: key_type.to_string(),
+    }
+}
+
+/// Top-k payload, a msgpack **array** (`to_vec`, positional):
+/// `[counts, keys, heap_counts]`. `counts` is the base matrix packed row-major
+/// with the element type the metadata `counter_type` fixes; `keys` and
+/// `heap_counts` are the heap's entries, parallel and equal-length, with `keys`
+/// typed by the metadata `key_type`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct TopKPayload<C, K> {
+    pub(crate) counts: Vec<C>,
+    pub(crate) keys: Vec<K>,
+    pub(crate) heap_counts: Vec<i64>,
+}
+
+/// The heap's entries in emitted order: descending count, ties broken by
+/// [`key_order`]. Independent of the heap array's sift order, so the bytes are
+/// stable across a round trip.
+pub(crate) fn heap_entries(heap: &HHHeap) -> Vec<(&HeapItem, i64)> {
+    let mut entries: Vec<(&HeapItem, i64)> = heap
+        .heap()
+        .iter()
+        .map(|item| (&item.key, item.count))
+        .collect();
+    entries.sort_unstable_by(|a, b| {
+        b.1.cmp(&a.1)
+            .then_with(|| key_order(a.0).cmp(&key_order(b.0)))
+    });
+    entries
+}
+
+/// The `key_type` the payload will be written in, taken from the first key in
+/// emitted order. Rejects a 128-bit key outright; the homogeneity of the rest is
+/// enforced by [`encode_payload`].
+pub(crate) fn wire_key_type(entries: &[(&HeapItem, i64)]) -> Result<&'static str, RmpEncodeError> {
+    match entries.first() {
+        None => Ok(EMPTY_KEY_TYPE),
+        Some((key, _)) => key_type_of(key).ok_or_else(|| {
+            RmpEncodeError::Syntax("ASAPv1 top-k heap: 128-bit keys are not wire types".to_string())
+        }),
+    }
+}
+
+fn mixed_variant_error(key_type: &str, key: &HeapItem) -> RmpEncodeError {
+    RmpEncodeError::Syntax(format!(
+        "ASAPv1 top-k heap: keys mix variants — key_type is {key_type}, but a {} key is held",
+        key_type_of(key).unwrap_or("128-bit")
+    ))
+}
+
+/// Packs the base counters and the emitted heap entries into the positional
+/// payload, with `keys` typed by `key_type`. Any key that is not of that variant
+/// fails the encode.
+pub(crate) fn encode_payload<C: Serialize>(
+    key_type: &str,
+    counts: Vec<C>,
+    entries: &[(&HeapItem, i64)],
+) -> Result<Vec<u8>, RmpEncodeError> {
+    let heap_counts: Vec<i64> = entries.iter().map(|entry| entry.1).collect();
+
+    macro_rules! pack {
+        ($variant:ident) => {{
+            let mut keys = Vec::with_capacity(entries.len());
+            for (key, _) in entries {
+                match key {
+                    HeapItem::$variant(value) => keys.push(*value),
+                    _ => return Err(mixed_variant_error(key_type, key)),
+                }
+            }
+            rmp_serde::to_vec(&TopKPayload {
+                counts,
+                keys,
+                heap_counts,
+            })
+        }};
+    }
+
+    match key_type {
+        "i8" => pack!(I8),
+        "i16" => pack!(I16),
+        "i32" => pack!(I32),
+        "i64" => pack!(I64),
+        "isize" => pack!(ISIZE),
+        "u8" => pack!(U8),
+        "u16" => pack!(U16),
+        "u32" => pack!(U32),
+        "u64" => pack!(U64),
+        "usize" => pack!(USIZE),
+        "f32" => pack!(F32),
+        "f64" => pack!(F64),
+        "string" => {
+            let mut keys = Vec::with_capacity(entries.len());
+            for (key, _) in entries {
+                match key {
+                    HeapItem::String(value) => keys.push(value.clone()),
+                    _ => return Err(mixed_variant_error(key_type, key)),
+                }
+            }
+            rmp_serde::to_vec(&TopKPayload {
+                counts,
+                keys,
+                heap_counts,
+            })
+        }
+        other => Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 top-k heap: key_type {other:?} is not a wire key type"
+        ))),
+    }
+}
+
+/// The base counters and the heap entries one payload decodes into.
+pub(crate) type DecodedTopK<C> = (Vec<C>, Vec<(HeapItem, i64)>);
+
+/// Reads the payload with `keys` typed by the metadata `key_type`, returning the
+/// base counters and the heap entries. Rejects an unknown `key_type` and
+/// parallel arrays of unequal length; a `keys` array whose msgpack types do not
+/// match `key_type` fails in `from_slice`.
+pub(crate) fn decode_payload<C>(
+    key_type: &str,
+    payload: &[u8],
+) -> Result<DecodedTopK<C>, RmpDecodeError>
+where
+    C: for<'de> Deserialize<'de>,
+{
+    macro_rules! unpack {
+        ($variant:ident, $ty:ty) => {{
+            let decoded: TopKPayload<C, $ty> = from_slice(payload)?;
+            (
+                decoded.counts,
+                decoded
+                    .keys
+                    .into_iter()
+                    .map(HeapItem::$variant)
+                    .collect::<Vec<HeapItem>>(),
+                decoded.heap_counts,
+            )
+        }};
+    }
+
+    let (counts, keys, heap_counts) = match key_type {
+        "i8" => unpack!(I8, i8),
+        "i16" => unpack!(I16, i16),
+        "i32" => unpack!(I32, i32),
+        "i64" => unpack!(I64, i64),
+        "isize" => unpack!(ISIZE, isize),
+        "u8" => unpack!(U8, u8),
+        "u16" => unpack!(U16, u16),
+        "u32" => unpack!(U32, u32),
+        "u64" => unpack!(U64, u64),
+        "usize" => unpack!(USIZE, usize),
+        "f32" => unpack!(F32, f32),
+        "f64" => unpack!(F64, f64),
+        "string" => unpack!(String, String),
+        other => {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "ASAPv1 top-k heap: key_type {other:?} is not a wire key type"
+            )));
+        }
+    };
+
+    if keys.len() != heap_counts.len() {
+        return Err(RmpDecodeError::Uncategorized(format!(
+            "ASAPv1 top-k heap: {} keys against {} counts",
+            keys.len(),
+            heap_counts.len()
+        )));
+    }
+    Ok((counts, keys.into_iter().zip(heap_counts).collect()))
+}
+
+/// Seats the decoded entries into a heap of capacity `k`, rebuilding the index
+/// as it goes. `k` is checked against the entry count first, so a declared
+/// capacity never sizes an allocation on its own.
+pub(crate) fn rebuild_heap(
+    k: usize,
+    entries: Vec<(HeapItem, i64)>,
+) -> Result<HHHeap, RmpDecodeError> {
+    if entries.len() > k {
+        return Err(RmpDecodeError::Uncategorized(format!(
+            "ASAPv1 top-k heap: {} entries over a k of {k}",
+            entries.len()
+        )));
+    }
+    let mut heap = HHHeap::new(k);
+    let seated = entries.len();
+    for (key, count) in entries {
+        heap.update_heap_item(&key, count);
+    }
+    if heap.len() != seated {
+        return Err(RmpDecodeError::Uncategorized(
+            "ASAPv1 top-k heap: the same key appears twice".to_string(),
+        ));
+    }
+    Ok(heap)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message_pack_format::envelope;
+    use crate::{DataInput, DefaultXxHasher, RegularPath, Vector2D};
+
+    use super::super::CMSHeap;
+
+    /// CMSHeap's kind_id, so the shared-heap tests can build real envelopes.
+    const KIND: &[u8] = &[0x03, 0x00];
+
+    fn sketch_with(keys: &[(DataInput, i64)]) -> CMSHeap<Vector2D<i64>, RegularPath> {
+        let mut sketch = CMSHeap::<Vector2D<i64>, RegularPath>::new(2, 8, 8);
+        for (key, count) in keys {
+            sketch.heap_mut().update(key, *count);
+        }
+        sketch
+    }
+
+    /// The complaint a crafted envelope draws, with no `Debug` bound on the
+    /// sketch.
+    fn decode_error(bytes: &[u8]) -> String {
+        match CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(bytes) {
+            Ok(_) => panic!("a crafted envelope must be rejected, not decoded"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    fn metadata_of(bytes: &[u8]) -> TopKMetadata {
+        let (_, metadata, _) = envelope::split(bytes).expect("split");
+        from_slice(metadata).expect("metadata")
+    }
+
+    /// Every wire-eligible key family round-trips under its own name, and the
+    /// decoded key still answers to the caller's original `DataInput`. A widened
+    /// `key_type` would keep the digest but rebuild a different variant.
+    #[test]
+    fn heap_every_key_type_round_trips_and_keeps_its_variant() {
+        fn check(expected: &str, values: &[DataInput]) {
+            let entries: Vec<(DataInput, i64)> = values
+                .iter()
+                .enumerate()
+                .map(|(i, value)| (value.clone(), 3 * (i as i64 + 1)))
+                .collect();
+            let sketch = sketch_with(&entries);
+            assert_eq!(
+                sketch.heap().len(),
+                values.len(),
+                "{expected}: keys collided"
+            );
+
+            let bytes = sketch.serialize_to_bytes().expect("serialize");
+            assert_eq!(metadata_of(&bytes).key_type, expected);
+
+            let decoded = CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes)
+                .expect("decode");
+            assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), bytes);
+            for (i, value) in values.iter().enumerate() {
+                let index = decoded
+                    .heap()
+                    .find(value)
+                    .unwrap_or_else(|| panic!("{expected}: {value:?} lost its variant"));
+                assert_eq!(decoded.heap().heap()[index].count, 3 * (i as i64 + 1));
+            }
+        }
+
+        check("i8", &[DataInput::I8(-3), DataInput::I8(120)]);
+        check("i16", &[DataInput::I16(-3000), DataInput::I16(9)]);
+        check("i32", &[DataInput::I32(-7), DataInput::I32(65_537)]);
+        check("i64", &[DataInput::I64(-1), DataInput::I64(1 << 40)]);
+        check("isize", &[DataInput::ISIZE(-11), DataInput::ISIZE(11)]);
+        check("u8", &[DataInput::U8(0), DataInput::U8(255)]);
+        check("u16", &[DataInput::U16(1), DataInput::U16(65_535)]);
+        check("u32", &[DataInput::U32(7), DataInput::U32(u32::MAX)]);
+        check("u64", &[DataInput::U64(9), DataInput::U64(u64::MAX)]);
+        check("usize", &[DataInput::USIZE(4), DataInput::USIZE(1 << 33)]);
+        check("f32", &[DataInput::F32(-0.5), DataInput::F32(3.25)]);
+        check("f64", &[DataInput::F64(2.5), DataInput::F64(-1e300)]);
+        check("string", &[DataInput::Str("alpha"), DataInput::Str("beta")]);
+    }
+
+    #[test]
+    fn heap_refuses_mixed_and_128_bit_keys() {
+        let mixed = sketch_with(&[(DataInput::I32(1), 5), (DataInput::I64(2), 3)]);
+        let problem = mixed
+            .serialize_to_bytes()
+            .expect_err("a heap mixing key variants must not serialize")
+            .to_string();
+        assert!(problem.contains("keys mix variants"), "got {problem}");
+        assert!(problem.contains("key_type is i32"), "got {problem}");
+
+        for key in [DataInput::I128(1), DataInput::U128(2)] {
+            let wide = sketch_with(&[(key.clone(), 5)]);
+            let problem = wide
+                .serialize_to_bytes()
+                .expect_err("a 128-bit key is not a wire type")
+                .to_string();
+            assert!(problem.contains("128-bit"), "got {problem}");
+        }
+
+        // A 128-bit key behind a wire-eligible one is caught on the way into the
+        // payload rather than by the first-key check.
+        let trailing = sketch_with(&[(DataInput::U64(1), 9), (DataInput::U128(2), 1)]);
+        assert!(trailing.serialize_to_bytes().is_err());
+    }
+
+    #[test]
+    fn heap_empty_emits_the_pinned_key_type_and_round_trips() {
+        let sketch = CMSHeap::<Vector2D<i64>, RegularPath>::new(2, 8, 8);
+        let bytes = sketch.serialize_to_bytes().expect("serialize");
+        let meta = metadata_of(&bytes);
+        assert_eq!(meta.key_type, EMPTY_KEY_TYPE);
+        assert_eq!(meta.k, 8);
+
+        let decoded =
+            CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).expect("decode");
+        assert_eq!(decoded.heap().len(), 0);
+        assert_eq!(decoded.heap().capacity(), 8);
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), bytes);
+    }
+
+    /// The emitted order is fixed by (count, key_order), not by the sift path,
+    /// so the same entries always produce the same bytes. Both count ties below
+    /// are broken only by the key.
+    #[test]
+    fn heap_emitted_order_is_independent_of_seat_order() {
+        let entries = [
+            (DataInput::U64(3), 5i64),
+            (DataInput::U64(1), 9),
+            (DataInput::U64(2), 5),
+            (DataInput::U64(4), 9),
+        ];
+        let mut reversed = entries.clone();
+        reversed.reverse();
+
+        let seated = sketch_with(&entries);
+        let reseated = sketch_with(&reversed);
+        let bytes = seated.serialize_to_bytes().expect("serialize");
+        assert_eq!(
+            bytes,
+            reseated.serialize_to_bytes().expect("serialize"),
+            "the emitted order followed the seat order"
+        );
+
+        let (_, _, payload) = envelope::split(&bytes).expect("split");
+        let emitted: TopKPayload<i64, u64> = from_slice(payload).expect("payload");
+        assert_eq!(emitted.heap_counts, vec![9, 9, 5, 5], "not descending");
+        assert_eq!(emitted.keys, vec![1, 4, 2, 3], "ties not broken by key");
+
+        let decoded =
+            CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).expect("decode");
+        assert_eq!(
+            decoded.serialize_to_bytes().expect("re-serialize"),
+            bytes,
+            "a decoded heap re-serialized to different bytes"
+        );
+    }
+
+    /// The `keys` array is read **as** the declared type, so string-keyed bytes
+    /// relabelled `"u64"` do not decode.
+    #[test]
+    fn heap_rejects_a_key_type_the_payload_does_not_carry() {
+        let strings = sketch_with(&[(DataInput::Str("alpha"), 5)]);
+        let string_bytes = strings.serialize_to_bytes().expect("serialize");
+        let (_, _, string_payload) = envelope::split(&string_bytes).expect("split");
+
+        let numbers = sketch_with(&[(DataInput::U64(11), 5)]);
+        let number_bytes = numbers.serialize_to_bytes().expect("serialize");
+        let (_, _, number_payload) = envelope::split(&number_bytes).expect("split");
+
+        for (claimed, payload) in [("u64", string_payload), ("string", number_payload)] {
+            let metadata = rmp_serde::to_vec_named(&topk_metadata::<DefaultXxHasher>(
+                2, 8, "i64", "regular", 8, claimed,
+            ))
+            .expect("metadata");
+            let forged = envelope::encode(KIND, &metadata, payload);
+            assert!(
+                CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&forged).is_err(),
+                "a payload relabelled {claimed} must be rejected"
+            );
+        }
+    }
+
+    /// `slots` and `positions` are rebuilt on decode: an update that moves an
+    /// entry lands the same way on the decoded heap as on the original.
+    #[test]
+    fn heap_index_is_rebuilt_so_updates_still_move_entries() {
+        let mut original = sketch_with(&[
+            (DataInput::U64(1), 9),
+            (DataInput::U64(2), 7),
+            (DataInput::U64(3), 5),
+            (DataInput::U64(4), 3),
+        ]);
+        let bytes = original.serialize_to_bytes().expect("serialize");
+        let mut decoded =
+            CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).expect("decode");
+
+        // Rescore the root up, then seat a new key that displaces nothing.
+        original.heap_mut().update(&DataInput::U64(4), 40);
+        decoded.heap_mut().update(&DataInput::U64(4), 40);
+        original.heap_mut().update(&DataInput::U64(5), 20);
+        decoded.heap_mut().update(&DataInput::U64(5), 20);
+
+        assert_eq!(
+            decoded.serialize_to_bytes().expect("re-serialize"),
+            original.serialize_to_bytes().expect("serialize"),
+            "the decoded heap diverged after an update"
+        );
+        for key in 1..=5u64 {
+            let probe = DataInput::U64(key);
+            let found = decoded.heap().find(&probe).expect("key");
+            assert_eq!(
+                decoded.heap().heap()[found].count,
+                original.heap().heap()[original.heap().find(&probe).expect("key")].count
+            );
+        }
+    }
+
+    /// A declared `k` is metadata, never an allocation size.
+    #[test]
+    fn heap_does_not_allocate_a_declared_k() {
+        let metadata = rmp_serde::to_vec_named(&topk_metadata::<DefaultXxHasher>(
+            2,
+            4,
+            "i64",
+            "regular",
+            u32::MAX,
+            "u64",
+        ))
+        .expect("metadata");
+        let payload = rmp_serde::to_vec(&TopKPayload {
+            counts: vec![0i64; 8],
+            keys: vec![7u64, 8],
+            heap_counts: vec![9i64, 4],
+        })
+        .expect("payload");
+        let bytes = envelope::encode(KIND, &metadata, &payload);
+
+        let decoded =
+            CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).expect("decode");
+        assert_eq!(decoded.heap().capacity(), u32::MAX as usize);
+        assert_eq!(decoded.heap().len(), 2);
+    }
+
+    /// More entries than `k`, and the same key twice, are both states the heap
+    /// could not have reached.
+    #[test]
+    fn heap_rejects_crafted_entry_sets() {
+        let crafted = |k: u32, keys: Vec<u64>, heap_counts: Vec<i64>| {
+            let metadata = rmp_serde::to_vec_named(&topk_metadata::<DefaultXxHasher>(
+                2, 4, "i64", "regular", k, "u64",
+            ))
+            .expect("metadata");
+            let payload = rmp_serde::to_vec(&TopKPayload {
+                counts: vec![0i64; 8],
+                keys,
+                heap_counts,
+            })
+            .expect("payload");
+            envelope::encode(KIND, &metadata, &payload)
+        };
+
+        let cases = [
+            (
+                crafted(1, vec![1, 2], vec![5, 4]),
+                "2 entries over a k of 1",
+            ),
+            (
+                crafted(4, vec![1, 1], vec![5, 4]),
+                "the same key appears twice",
+            ),
+            (crafted(4, vec![1, 2], vec![5]), "2 keys against 1 counts"),
+        ];
+        for (bytes, expected) in cases {
+            let problem = decode_error(&bytes);
+            assert!(
+                problem.contains(expected),
+                "expected a complaint about {expected}, got {problem}"
+            );
+        }
+    }
+}

--- a/src/sketches/countminsketch_topk/wire.rs
+++ b/src/sketches/countminsketch_topk/wire.rs
@@ -1,0 +1,543 @@
+//! ASAPv1 wire serialization for CMSHeap.
+//!
+//! Child submodule of [`crate::sketches::countminsketch_topk`]: it holds the
+//! kind_id constant and the `serialize_to_bytes` / `deserialize_from_bytes`
+//! impls while the algorithm lives in the parent module file. Being a
+//! descendant module, it reads the sketch's private `cms` / `heap` fields
+//! directly without widening any field visibility. The metadata DTO, the
+//! payload DTO and the heap encoding are shared with CSHeap and live in
+//! [`super::heap_wire`].
+//!
+//! CMSHeap is one algorithm — a single kind_id `0x03 0x00`. The structural
+//! parameters — the matrix dimensions (`rows` / `cols`), the base **counter
+//! type** (i64/f64), the column-derivation **mode** (fast/regular), the heap
+//! capacity `k` and the heap's `key_type` — all live in the metadata, so the
+//! payload is `[counts, keys, heap_counts]`: the base matrix packed row-major
+//! followed by the heap's entries.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+use crate::sketches::countminsketch::{CmsWireCounter, CmsWireMode};
+use crate::{CountMin, HashProfile, SketchHasher, Vector2D};
+
+use super::CMSHeap;
+use super::heap_wire::{
+    TopKMetadata, decode_payload, encode_payload, heap_entries, rebuild_heap, topk_metadata,
+    wire_key_type,
+};
+
+/// CMSHeap kind_id: family `0x03`, single algorithm variant `0x00`.
+const CMS_HEAP_KIND: &[u8] = &[0x03, 0x00];
+
+// Wire serialization for the canonical CMSHeap configs only. `wire` is a
+// descendant of the sketch module, so this impl reads the private fields
+// directly.
+impl<T, Mode, H> CMSHeap<Vector2D<T>, Mode, H>
+where
+    // `AddAssign` is required for `Vector2D<T>: MatrixStorage` (the struct's
+    // bound), not by the bodies below.
+    T: CmsWireCounter + std::ops::AddAssign + Serialize + for<'de> Deserialize<'de>,
+    Mode: CmsWireMode,
+    H: SketchHasher + HashProfile,
+{
+    /// Serializes the sketch into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x03 0x00`). The metadata is derived from the hasher's
+    /// [`HashProfile`], so it truthfully describes how the sketch was hashed.
+    ///
+    /// Fails when the matrix's cell count disagrees with its own dimensions,
+    /// when the heap's keys mix `HeapItem` variants or hold a 128-bit key, or
+    /// when `k` overflows the metadata's `u32` field.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let rows = self.cms.rows();
+        let cols = self.cms.cols();
+        let counts = self.cms.as_storage().as_slice();
+        if counts.len() != rows.saturating_mul(cols) {
+            return Err(RmpEncodeError::Syntax(format!(
+                "ASAPv1 CMSHeap envelope: counts length {} != rows*cols {}",
+                counts.len(),
+                rows.saturating_mul(cols)
+            )));
+        }
+        let k = u32::try_from(self.heap.capacity()).map_err(|_| {
+            RmpEncodeError::Syntax(format!(
+                "ASAPv1 CMSHeap envelope: heap k {} exceeds the u32 metadata field",
+                self.heap.capacity()
+            ))
+        })?;
+        let entries = heap_entries(&self.heap);
+        let key_type = wire_key_type(&entries)?;
+        let metadata = rmp_serde::to_vec_named(&topk_metadata::<H>(
+            rows as u32,
+            cols as u32,
+            T::COUNTER_TYPE,
+            Mode::MODE,
+            k,
+            key_type,
+        ))?;
+        let payload = encode_payload(key_type, counts.to_vec(), &entries)?;
+        Ok(envelope::encode(CMS_HEAP_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The matrix
+    /// dimensions, `k` and `key_type` are structural (they are properties of
+    /// the stored sketch, not of the target), so they are echoed back into the
+    /// expected metadata; the hash spec, counter type and mode are pinned
+    /// against this target.
+    ///
+    /// Every state the algorithm could not have produced is rejected with an
+    /// error rather than a panic, and neither the declared geometry nor `k`
+    /// sizes an allocation before the payload is measured against it.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != CMS_HEAP_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "CMSHeap kind_id mismatch: stored {kind_id:?}, expected {CMS_HEAP_KIND:?}"
+            )));
+        }
+        let meta: TopKMetadata = from_slice(metadata)?;
+        if meta
+            != topk_metadata::<H>(
+                meta.rows,
+                meta.cols,
+                T::COUNTER_TYPE,
+                Mode::MODE,
+                meta.k,
+                &meta.key_type,
+            )
+        {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 CMSHeap envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let (rows, cols) = (meta.rows as usize, meta.cols as usize);
+        // Reject zero dimensions before building the matrix: `Vector2D::from_fn`
+        // derives its mask via `cols.ilog2()`, which panics on `cols == 0`.
+        if rows == 0 || cols == 0 {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "CMSHeap dimensions must be non-zero: rows={rows}, cols={cols}"
+            )));
+        }
+        let (counts, entries) = decode_payload::<T>(&meta.key_type, payload)?;
+        // Length check precedes the allocation, so crafted dimensions cannot
+        // drive `from_fn` into a huge reserve.
+        if counts.len() != rows.saturating_mul(cols) {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "CMSHeap counts length {} != rows*cols {}",
+                counts.len(),
+                rows.saturating_mul(cols)
+            )));
+        }
+        let heap = rebuild_heap(meta.k as usize, entries)?;
+        let storage = Vector2D::from_fn(rows, cols, |r, c| counts[r * cols + c]);
+        Ok(CMSHeap {
+            cms: CountMin::from_storage(storage),
+            heap,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sketches::countminsketch_topk::heap_wire::TopKPayload;
+    use crate::{CANONICAL_HASH_SEED, DataInput, DefaultXxHasher, FastPath, RegularPath};
+
+    fn populated() -> CMSHeap<Vector2D<i64>, RegularPath> {
+        let mut sketch = CMSHeap::<Vector2D<i64>, RegularPath>::new(3, 8, 4);
+        for (key, weight) in [(1u64, 9i64), (2, 5), (3, 7)] {
+            sketch.insert_many(&DataInput::U64(key), weight);
+        }
+        sketch
+    }
+
+    /// The complaint a crafted envelope draws, with no `Debug` bound on the
+    /// sketch.
+    fn decode_error(bytes: &[u8]) -> String {
+        match CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(bytes) {
+            Ok(_) => panic!("a crafted envelope must be rejected, not decoded"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    fn metadata_of(bytes: &[u8]) -> TopKMetadata {
+        let (_, metadata, _) = envelope::split(bytes).expect("split");
+        from_slice(metadata).expect("metadata")
+    }
+
+    #[test]
+    fn cms_heap_round_trip_serialization() {
+        let sketch = populated();
+        let encoded = sketch.serialize_to_bytes().expect("serialize CMSHeap");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x03, 0x00]); // kind_id_len=2, kind_id=[0x03,0x00]
+
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.metadata_version, 1);
+        assert_eq!((meta.rows, meta.cols), (3, 8));
+        assert_eq!(meta.counter_type, "i64");
+        assert_eq!(meta.mode, "regular");
+        assert_eq!(meta.k, 4);
+        assert_eq!(meta.key_type, "u64");
+
+        let decoded = CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&encoded)
+            .expect("deserialize CMSHeap");
+        assert_eq!(sketch.rows(), decoded.rows());
+        assert_eq!(sketch.cols(), decoded.cols());
+        assert_eq!(
+            sketch.cms().as_storage().as_slice(),
+            decoded.cms().as_storage().as_slice()
+        );
+        assert_eq!(decoded.heap().len(), 3);
+        assert_eq!(decoded.heap().capacity(), 4);
+        for key in 1..=3u64 {
+            let probe = DataInput::U64(key);
+            assert_eq!(decoded.estimate(&probe), sketch.estimate(&probe));
+            let seat = decoded.heap().find(&probe).expect("heap key");
+            assert_eq!(
+                decoded.heap().heap()[seat].count,
+                sketch.heap().heap()[sketch.heap().find(&probe).expect("heap key")].count
+            );
+        }
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// The `f64` base counter is a Count-Min wire type, so a float-counter
+    /// CMSHeap serializes as well.
+    #[test]
+    fn cms_heap_f64_counters_round_trip() {
+        let mut sketch = CMSHeap::<Vector2D<f64>, RegularPath>::from_storage(
+            Vector2D::from_fn(2, 4, |r, c| (r * 4 + c) as f64 + 0.5),
+            4,
+        );
+        sketch.heap_mut().update(&DataInput::Str("flow"), 11);
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        assert_eq!(metadata_of(&encoded).counter_type, "f64");
+        assert_eq!(metadata_of(&encoded).key_type, "string");
+
+        let decoded = CMSHeap::<Vector2D<f64>, RegularPath>::deserialize_from_bytes(&encoded)
+            .expect("decode");
+        assert_eq!(
+            sketch.cms().as_storage().as_slice(),
+            decoded.cms().as_storage().as_slice()
+        );
+        assert!(decoded.heap().find(&DataInput::Str("flow")).is_some());
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// The base counter type is pinned by the target: i64 bytes must not decode
+    /// into an f64 sketch or the reverse.
+    #[test]
+    fn cms_heap_counter_type_is_pinned_by_the_target() {
+        let wide = CMSHeap::<Vector2D<i64>, RegularPath>::from_storage(
+            Vector2D::from_fn(2, 4, |r, c| (r * 4 + c) as i64),
+            4,
+        );
+        let floating = CMSHeap::<Vector2D<f64>, RegularPath>::from_storage(
+            Vector2D::from_fn(2, 4, |r, c| (r * 4 + c) as f64),
+            4,
+        );
+        let wide_bytes = wide.serialize_to_bytes().expect("serialize i64");
+        let floating_bytes = floating.serialize_to_bytes().expect("serialize f64");
+        assert_ne!(wide_bytes, floating_bytes);
+        assert!(
+            CMSHeap::<Vector2D<f64>, RegularPath>::deserialize_from_bytes(&wide_bytes).is_err(),
+            "i64 bytes must not decode as an f64 sketch"
+        );
+        assert!(
+            CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&floating_bytes).is_err(),
+            "f64 bytes must not decode as an i64 sketch"
+        );
+    }
+
+    #[test]
+    fn cms_heap_mode_in_metadata_round_trips() {
+        let mut sketch = CMSHeap::<Vector2D<i64>, FastPath>::new(4, 16, 8);
+        sketch.insert_many(&DataInput::U64(1), 5);
+        sketch.insert_many(&DataInput::U64(2), 3);
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        assert_eq!(metadata_of(&encoded).mode, "fast");
+        let decoded = CMSHeap::<Vector2D<i64>, FastPath>::deserialize_from_bytes(&encoded)
+            .expect("deserialize");
+        assert_eq!(
+            sketch.cms().as_storage().as_slice(),
+            decoded.cms().as_storage().as_slice()
+        );
+
+        // Mode is pinned by the target: a fast payload must not decode into a
+        // regular sketch.
+        assert!(CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&encoded).is_err());
+    }
+
+    /// CMSHeap, CSHeap and the two base sketches all carry different kind_ids;
+    /// a foreign envelope must not decode as a CMSHeap.
+    #[test]
+    fn cms_heap_rejects_foreign_kind_ids() {
+        let cs_heap = crate::CSHeap::<Vector2D<i64>, RegularPath>::new(3, 8, 4);
+        let cms = crate::CountMin::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8);
+        let count = crate::Count::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8);
+
+        for (bytes, what) in [
+            (cs_heap.serialize_to_bytes().expect("CSHeap"), "CSHeap"),
+            (cms.serialize_to_bytes().expect("CMS"), "Count-Min"),
+            (count.serialize_to_bytes().expect("Count"), "Count Sketch"),
+        ] {
+            assert!(
+                CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).is_err(),
+                "{what} bytes must not decode as a CMSHeap"
+            );
+        }
+    }
+
+    /// Builds a well-framed envelope around crafted metadata and a `u64`-keyed
+    /// payload.
+    fn crafted(rows: u32, cols: u32, k: u32, counts: Vec<i64>) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(&topk_metadata::<DefaultXxHasher>(
+            rows, cols, "i64", "regular", k, "u64",
+        ))
+        .expect("metadata");
+        let payload = rmp_serde::to_vec(&TopKPayload::<i64, u64> {
+            counts,
+            keys: Vec::new(),
+            heap_counts: Vec::new(),
+        })
+        .expect("payload");
+        envelope::encode(CMS_HEAP_KIND, &metadata, &payload)
+    }
+
+    /// Fail closed (not panic) on a crafted envelope with a zero dimension:
+    /// `Vector2D::from_fn` derives its mask via `cols.ilog2()`, which panics on
+    /// `cols == 0`.
+    #[test]
+    fn cms_heap_rejects_zero_dimension_payload() {
+        let bytes = crafted(4, 0, 4, Vec::new());
+        let problem = decode_error(&bytes);
+        assert!(problem.contains("must be non-zero"), "got {problem}");
+    }
+
+    /// Crafted dimensions must not drive a huge allocation: the length check
+    /// runs before `Vector2D::from_fn`.
+    #[test]
+    fn cms_heap_rejects_dimension_length_mismatch() {
+        let bytes = crafted(1024, 1024, 4, vec![1, 2, 3]);
+        let problem = decode_error(&bytes);
+        assert!(problem.contains("!= rows*cols"), "got {problem}");
+    }
+
+    /// An unpopulated matrix carries dimensions its cells do not match.
+    /// Serializing it must fail rather than emit bytes the decoder refuses.
+    #[test]
+    fn cms_heap_rejects_serializing_an_unfilled_matrix() {
+        let sketch =
+            CMSHeap::<Vector2D<i64>, RegularPath>::from_storage(Vector2D::<i64>::init(2, 4), 4);
+        assert!(
+            sketch.serialize_to_bytes().is_err(),
+            "a matrix whose cell count disagrees with its dimensions must not serialize"
+        );
+    }
+
+    /// Fail closed on an unexpected metadata key.
+    #[test]
+    fn cms_heap_metadata_rejects_unknown_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            matrix_seed_index: u32,
+            rows: u32,
+            cols: u32,
+            counter_type: String,
+            mode: String,
+            k: u32,
+            key_type: String,
+            bogus_field: u8, // key not in TopKMetadata
+        }
+        let m = topk_metadata::<DefaultXxHasher>(2, 4, "i64", "regular", 4, "u64");
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            matrix_seed_index: m.matrix_seed_index,
+            rows: m.rows,
+            cols: m.cols,
+            counter_type: m.counter_type.clone(),
+            mode: m.mode.clone(),
+            k: m.k,
+            key_type: m.key_type.clone(),
+            bogus_field: 7,
+        };
+        let bytes = rmp_serde::to_vec_named(&extra).expect("encode");
+        assert!(
+            from_slice::<TopKMetadata>(&bytes).is_err(),
+            "an unexpected metadata key must be rejected"
+        );
+    }
+
+    /// `k` is required: a metadata map missing it does not decode, so the heap
+    /// capacity can never be silently defaulted.
+    #[test]
+    fn cms_heap_metadata_rejects_a_missing_k_key() {
+        #[derive(Serialize)]
+        struct WithoutK {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            matrix_seed_index: u32,
+            rows: u32,
+            cols: u32,
+            counter_type: String,
+            mode: String,
+            key_type: String,
+        }
+        let m = topk_metadata::<DefaultXxHasher>(2, 4, "i64", "regular", 4, "u64");
+        let without = WithoutK {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            matrix_seed_index: m.matrix_seed_index,
+            rows: m.rows,
+            cols: m.cols,
+            counter_type: m.counter_type.clone(),
+            mode: m.mode.clone(),
+            key_type: m.key_type.clone(),
+        };
+        let bytes = rmp_serde::to_vec_named(&without).expect("encode");
+        assert!(
+            from_slice::<TopKMetadata>(&bytes).is_err(),
+            "a missing k must be rejected"
+        );
+    }
+
+    /// `i32` is a Count Sketch wire counter but not a Count-Min one, so its name
+    /// must not decode into a CMSHeap.
+    #[test]
+    fn cms_heap_rejects_a_foreign_counter_type_name() {
+        let metadata = rmp_serde::to_vec_named(&topk_metadata::<DefaultXxHasher>(
+            2, 4, "i32", "regular", 4, "u64",
+        ))
+        .expect("metadata");
+        let payload = rmp_serde::to_vec(&TopKPayload::<i64, u64> {
+            counts: vec![0; 8],
+            keys: Vec::new(),
+            heap_counts: Vec::new(),
+        })
+        .expect("payload");
+        let bytes = envelope::encode(CMS_HEAP_KIND, &metadata, &payload);
+        assert!(
+            CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).is_err(),
+            "an i64 sketch must reject an i32-labelled envelope"
+        );
+    }
+
+    // A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    // declares a DIFFERENT `HashProfile`. CMSHeap metadata is derived from the
+    // profile, so an `AltHasher` sketch serializes truthfully. (An *unprofiled*
+    // hasher cannot serialize at all — that is a compile-time guarantee, since
+    // the wire methods are bounded on `H: HashProfile`.)
+    #[derive(Clone, Debug)]
+    struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &crate::HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &crate::HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    #[test]
+    fn cms_heap_custom_hasher_profile_round_trips_and_is_self_describing() {
+        // (a) A CMSHeap built with a custom-profile hasher round-trips.
+        let mut alt = CMSHeap::<Vector2D<i64>, RegularPath, AltHasher>::new(3, 8, 4);
+        let mut std = CMSHeap::<Vector2D<i64>, RegularPath>::new(3, 8, 4);
+        for key in [42u64, 7] {
+            alt.insert(&DataInput::U64(key));
+            std.insert(&DataInput::U64(key));
+        }
+
+        let alt_bytes = alt.serialize_to_bytes().expect("alt serialize");
+        let decoded =
+            CMSHeap::<Vector2D<i64>, RegularPath, AltHasher>::deserialize_from_bytes(&alt_bytes)
+                .expect("alt decode");
+        assert_eq!(
+            alt.cms().as_storage().as_slice(),
+            decoded.cms().as_storage().as_slice()
+        );
+        assert_eq!(decoded.heap().len(), 2);
+
+        // (b) Bytes differ from the standard-profile sketch (metadata derived
+        // from the different profile).
+        let std_bytes = std.serialize_to_bytes().expect("std serialize");
+        assert_ne!(alt_bytes, std_bytes);
+
+        // (c) Standard-profile decode fails closed on custom-profile bytes.
+        assert!(
+            CMSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&alt_bytes).is_err(),
+            "standard-profile decode must reject custom-profile bytes"
+        );
+    }
+
+    /// A `k` past the metadata's `u32` field fails the encode rather than
+    /// emitting a truncated capacity.
+    #[test]
+    fn cms_heap_refuses_a_k_the_metadata_cannot_carry() {
+        let sketch = CMSHeap::<Vector2D<i64>, RegularPath>::from_storage(
+            Vector2D::from_fn(2, 4, |_, _| 0i64),
+            1usize << 40,
+        );
+        let problem = sketch
+            .serialize_to_bytes()
+            .expect_err("an oversized k must not serialize")
+            .to_string();
+        assert!(
+            problem.contains("exceeds the u32 metadata field"),
+            "got {problem}"
+        );
+    }
+}

--- a/src/sketches/countsketch_topk.rs
+++ b/src/sketches/countsketch_topk.rs
@@ -20,6 +20,8 @@ use crate::{
     SketchHasher, Vector1D, Vector2D, compute_median_inline_f64, heap_item_to_sketch_input,
 };
 
+mod wire;
+
 const DEFAULT_TOP_K: usize = 32;
 const DEFAULT_ROW_NUM: usize = 3;
 const DEFAULT_COL_NUM: usize = 4096;

--- a/src/sketches/countsketch_topk/wire.rs
+++ b/src/sketches/countsketch_topk/wire.rs
@@ -1,0 +1,569 @@
+//! ASAPv1 wire serialization for CSHeap.
+//!
+//! Child submodule of [`crate::sketches::countsketch_topk`]: it holds the
+//! kind_id constant and the `serialize_to_bytes` / `deserialize_from_bytes`
+//! impls while the algorithm lives in the parent module file. Being a
+//! descendant module, it reads the sketch's private `cs` / `heap` fields
+//! directly without widening any field visibility. The metadata DTO, the
+//! payload DTO and the heap encoding are shared with CMSHeap and live in
+//! [`crate::sketches::countminsketch_topk::heap_wire`].
+//!
+//! CSHeap is one algorithm — a single kind_id `0x0a 0x00`. The structural
+//! parameters — the matrix dimensions (`rows` / `cols`), the base **counter
+//! type** (i32/i64), the column-derivation **mode** (fast/regular), the heap
+//! capacity `k` and the heap's `key_type` — all live in the metadata, so the
+//! payload is `[counts, keys, heap_counts]`: the base matrix packed row-major
+//! followed by the heap's entries.
+//!
+//! [`CountL2HH`](super::CountL2HH) is a different algorithm and is not covered
+//! here.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+use crate::sketches::countminsketch_topk::heap_wire::{
+    TopKMetadata, decode_payload, encode_payload, heap_entries, rebuild_heap, topk_metadata,
+    wire_key_type,
+};
+use crate::sketches::countsketch::{CountSketchCounter, CsWireCounter, CsWireMode};
+use crate::{Count, HashProfile, SketchHasher, Vector2D};
+
+use super::CSHeap;
+
+/// CSHeap kind_id: family `0x0a`, single algorithm variant `0x00`.
+const CS_HEAP_KIND: &[u8] = &[0x0a, 0x00];
+
+// Wire serialization for the canonical CSHeap configs only. `wire` is a
+// descendant of the sketch module, so this impl reads the private fields
+// directly.
+impl<T, Mode, H> CSHeap<Vector2D<T>, Mode, H>
+where
+    // `CountSketchCounter` is required by `Count::from_storage`; `AddAssign` by
+    // `Vector2D<T>: MatrixStorage`. Neither is used by the bodies below.
+    T: CsWireCounter
+        + CountSketchCounter
+        + std::ops::AddAssign
+        + Serialize
+        + for<'de> Deserialize<'de>,
+    Mode: CsWireMode,
+    H: SketchHasher + HashProfile,
+{
+    /// Serializes the sketch into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x0a 0x00`). The metadata is derived from the hasher's
+    /// [`HashProfile`], so it truthfully describes how the sketch was hashed.
+    ///
+    /// Fails when the matrix's cell count disagrees with its own dimensions,
+    /// when the heap's keys mix `HeapItem` variants or hold a 128-bit key, or
+    /// when `k` overflows the metadata's `u32` field.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let rows = self.cs.rows();
+        let cols = self.cs.cols();
+        let counts = self.cs.as_storage().as_slice();
+        if counts.len() != rows.saturating_mul(cols) {
+            return Err(RmpEncodeError::Syntax(format!(
+                "ASAPv1 CSHeap envelope: counts length {} != rows*cols {}",
+                counts.len(),
+                rows.saturating_mul(cols)
+            )));
+        }
+        let k = u32::try_from(self.heap.capacity()).map_err(|_| {
+            RmpEncodeError::Syntax(format!(
+                "ASAPv1 CSHeap envelope: heap k {} exceeds the u32 metadata field",
+                self.heap.capacity()
+            ))
+        })?;
+        let entries = heap_entries(&self.heap);
+        let key_type = wire_key_type(&entries)?;
+        let metadata = rmp_serde::to_vec_named(&topk_metadata::<H>(
+            rows as u32,
+            cols as u32,
+            T::COUNTER_TYPE,
+            Mode::MODE,
+            k,
+            key_type,
+        ))?;
+        let payload = encode_payload(key_type, counts.to_vec(), &entries)?;
+        Ok(envelope::encode(CS_HEAP_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The matrix
+    /// dimensions, `k` and `key_type` are structural (they are properties of
+    /// the stored sketch, not of the target), so they are echoed back into the
+    /// expected metadata; the hash spec, counter type and mode are pinned
+    /// against this target.
+    ///
+    /// Every state the algorithm could not have produced is rejected with an
+    /// error rather than a panic, and neither the declared geometry nor `k`
+    /// sizes an allocation before the payload is measured against it.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != CS_HEAP_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "CSHeap kind_id mismatch: stored {kind_id:?}, expected {CS_HEAP_KIND:?}"
+            )));
+        }
+        let meta: TopKMetadata = from_slice(metadata)?;
+        if meta
+            != topk_metadata::<H>(
+                meta.rows,
+                meta.cols,
+                T::COUNTER_TYPE,
+                Mode::MODE,
+                meta.k,
+                &meta.key_type,
+            )
+        {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 CSHeap envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let (rows, cols) = (meta.rows as usize, meta.cols as usize);
+        // Reject zero dimensions before building the matrix: `Vector2D::from_fn`
+        // derives its mask via `cols.ilog2()`, which panics on `cols == 0`.
+        if rows == 0 || cols == 0 {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "CSHeap dimensions must be non-zero: rows={rows}, cols={cols}"
+            )));
+        }
+        let (counts, entries) = decode_payload::<T>(&meta.key_type, payload)?;
+        // Length check precedes the allocation, so crafted dimensions cannot
+        // drive `from_fn` into a huge reserve.
+        if counts.len() != rows.saturating_mul(cols) {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "CSHeap counts length {} != rows*cols {}",
+                counts.len(),
+                rows.saturating_mul(cols)
+            )));
+        }
+        let heap = rebuild_heap(meta.k as usize, entries)?;
+        let storage = Vector2D::from_fn(rows, cols, |r, c| counts[r * cols + c]);
+        Ok(CSHeap {
+            cs: Count::from_storage(storage),
+            heap,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sketches::countminsketch_topk::heap_wire::TopKPayload;
+    use crate::{CANONICAL_HASH_SEED, DataInput, DefaultXxHasher, FastPath, RegularPath};
+
+    fn populated() -> CSHeap<Vector2D<i64>, RegularPath> {
+        let mut sketch = CSHeap::<Vector2D<i64>, RegularPath>::new(3, 8, 4);
+        for (key, weight) in [(1u64, 9i64), (2, 5), (3, 7)] {
+            sketch.insert_many(&DataInput::U64(key), weight);
+        }
+        sketch
+    }
+
+    /// The complaint a crafted envelope draws, with no `Debug` bound on the
+    /// sketch.
+    fn decode_error(bytes: &[u8]) -> String {
+        match CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(bytes) {
+            Ok(_) => panic!("a crafted envelope must be rejected, not decoded"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    fn metadata_of(bytes: &[u8]) -> TopKMetadata {
+        let (_, metadata, _) = envelope::split(bytes).expect("split");
+        from_slice(metadata).expect("metadata")
+    }
+
+    #[test]
+    fn cs_heap_round_trip_serialization() {
+        let sketch = populated();
+        let encoded = sketch.serialize_to_bytes().expect("serialize CSHeap");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x0a, 0x00]); // kind_id_len=2, kind_id=[0x0a,0x00]
+
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.metadata_version, 1);
+        assert_eq!((meta.rows, meta.cols), (3, 8));
+        assert_eq!(meta.counter_type, "i64");
+        assert_eq!(meta.mode, "regular");
+        assert_eq!(meta.k, 4);
+        assert_eq!(meta.key_type, "u64");
+
+        let decoded = CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&encoded)
+            .expect("deserialize CSHeap");
+        assert_eq!(sketch.rows(), decoded.rows());
+        assert_eq!(sketch.cols(), decoded.cols());
+        assert_eq!(
+            sketch.cs().as_storage().as_slice(),
+            decoded.cs().as_storage().as_slice()
+        );
+        assert_eq!(decoded.heap().len(), 3);
+        assert_eq!(decoded.heap().capacity(), 4);
+        for key in 1..=3u64 {
+            let probe = DataInput::U64(key);
+            assert_eq!(decoded.estimate(&probe), sketch.estimate(&probe));
+            let seat = decoded.heap().find(&probe).expect("heap key");
+            assert_eq!(
+                decoded.heap().heap()[seat].count,
+                sketch.heap().heap()[sketch.heap().find(&probe).expect("heap key")].count
+            );
+        }
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// Count Sketch cells are signed — the payload must carry negatives through
+    /// unchanged.
+    #[test]
+    fn cs_heap_negative_counters_round_trip() {
+        let mut sketch = CSHeap::<Vector2D<i64>, RegularPath>::from_storage(
+            Vector2D::from_fn(2, 4, |r, c| {
+                let v = (r * 4 + c) as i64;
+                if v % 2 == 0 { v } else { -v }
+            }),
+            4,
+        );
+        sketch.heap_mut().update(&DataInput::Str("flow"), 11);
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        assert_eq!(metadata_of(&encoded).key_type, "string");
+        let decoded =
+            CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&encoded).expect("decode");
+        assert_eq!(
+            sketch.cs().as_storage().as_slice(),
+            decoded.cs().as_storage().as_slice()
+        );
+        assert!(decoded.cs().as_storage().as_slice().iter().any(|&v| v < 0));
+        assert!(decoded.heap().find(&DataInput::Str("flow")).is_some());
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// The `i32` wire config round-trips, and the counter type is pinned by the
+    /// target: i32 bytes must not decode into an i64 sketch or the reverse.
+    #[test]
+    fn cs_heap_i32_round_trips_and_is_pinned_by_counter_type() {
+        let cells = |r: usize, c: usize| {
+            let v = (r * 4 + c) as i32;
+            if v % 2 == 0 { v } else { -v }
+        };
+        let narrow =
+            CSHeap::<Vector2D<i32>, RegularPath>::from_storage(Vector2D::from_fn(2, 4, cells), 4);
+        let wide = CSHeap::<Vector2D<i64>, RegularPath>::from_storage(
+            Vector2D::from_fn(2, 4, |r, c| cells(r, c) as i64),
+            4,
+        );
+
+        let narrow_bytes = narrow.serialize_to_bytes().expect("serialize i32");
+        assert_eq!(metadata_of(&narrow_bytes).counter_type, "i32");
+        let decoded = CSHeap::<Vector2D<i32>, RegularPath>::deserialize_from_bytes(&narrow_bytes)
+            .expect("decode i32");
+        assert_eq!(
+            narrow.cs().as_storage().as_slice(),
+            decoded.cs().as_storage().as_slice()
+        );
+
+        // The two sketches hold numerically equal cells, so only the metadata
+        // `counter_type` separates their bytes.
+        let wide_bytes = wide.serialize_to_bytes().expect("serialize i64");
+        assert_ne!(narrow_bytes, wide_bytes);
+        assert!(
+            CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&narrow_bytes).is_err(),
+            "i32 bytes must not decode as an i64 sketch"
+        );
+        assert!(
+            CSHeap::<Vector2D<i32>, RegularPath>::deserialize_from_bytes(&wide_bytes).is_err(),
+            "i64 bytes must not decode as an i32 sketch"
+        );
+    }
+
+    #[test]
+    fn cs_heap_mode_in_metadata_round_trips() {
+        let mut sketch = CSHeap::<Vector2D<i64>, FastPath>::new(4, 16, 8);
+        sketch.insert_many(&DataInput::U64(1), 5);
+        sketch.insert_many(&DataInput::U64(2), 3);
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        assert_eq!(metadata_of(&encoded).mode, "fast");
+        let decoded = CSHeap::<Vector2D<i64>, FastPath>::deserialize_from_bytes(&encoded)
+            .expect("deserialize");
+        assert_eq!(
+            sketch.cs().as_storage().as_slice(),
+            decoded.cs().as_storage().as_slice()
+        );
+
+        // Mode is pinned by the target: a fast payload must not decode into a
+        // regular sketch.
+        assert!(CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&encoded).is_err());
+    }
+
+    /// CSHeap, CMSHeap and the two base sketches all carry different kind_ids;
+    /// a foreign envelope must not decode as a CSHeap.
+    #[test]
+    fn cs_heap_rejects_foreign_kind_ids() {
+        let cms_heap = crate::CMSHeap::<Vector2D<i64>, RegularPath>::new(3, 8, 4);
+        let cms = crate::CountMin::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8);
+        let count = crate::Count::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8);
+
+        for (bytes, what) in [
+            (cms_heap.serialize_to_bytes().expect("CMSHeap"), "CMSHeap"),
+            (cms.serialize_to_bytes().expect("CMS"), "Count-Min"),
+            (count.serialize_to_bytes().expect("Count"), "Count Sketch"),
+        ] {
+            assert!(
+                CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).is_err(),
+                "{what} bytes must not decode as a CSHeap"
+            );
+        }
+    }
+
+    /// Builds a well-framed envelope around crafted metadata and a `u64`-keyed
+    /// payload.
+    fn crafted(rows: u32, cols: u32, k: u32, counts: Vec<i64>) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(&topk_metadata::<DefaultXxHasher>(
+            rows, cols, "i64", "regular", k, "u64",
+        ))
+        .expect("metadata");
+        let payload = rmp_serde::to_vec(&TopKPayload::<i64, u64> {
+            counts,
+            keys: Vec::new(),
+            heap_counts: Vec::new(),
+        })
+        .expect("payload");
+        envelope::encode(CS_HEAP_KIND, &metadata, &payload)
+    }
+
+    /// Fail closed (not panic) on a crafted envelope with a zero dimension:
+    /// `Vector2D::from_fn` derives its mask via `cols.ilog2()`, which panics on
+    /// `cols == 0`.
+    #[test]
+    fn cs_heap_rejects_zero_dimension_payload() {
+        let bytes = crafted(4, 0, 4, Vec::new());
+        let problem = decode_error(&bytes);
+        assert!(problem.contains("must be non-zero"), "got {problem}");
+    }
+
+    /// Crafted dimensions must not drive a huge allocation: the length check
+    /// runs before `Vector2D::from_fn`.
+    #[test]
+    fn cs_heap_rejects_dimension_length_mismatch() {
+        let bytes = crafted(1024, 1024, 4, vec![1, 2, 3]);
+        let problem = decode_error(&bytes);
+        assert!(problem.contains("!= rows*cols"), "got {problem}");
+    }
+
+    /// An unpopulated matrix carries dimensions its cells do not match.
+    /// Serializing it must fail rather than emit bytes the decoder refuses.
+    #[test]
+    fn cs_heap_rejects_serializing_an_unfilled_matrix() {
+        let sketch =
+            CSHeap::<Vector2D<i64>, RegularPath>::from_storage(Vector2D::<i64>::init(2, 4), 4);
+        assert!(
+            sketch.serialize_to_bytes().is_err(),
+            "a matrix whose cell count disagrees with its dimensions must not serialize"
+        );
+    }
+
+    /// Fail closed on an unexpected metadata key.
+    #[test]
+    fn cs_heap_metadata_rejects_unknown_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            matrix_seed_index: u32,
+            rows: u32,
+            cols: u32,
+            counter_type: String,
+            mode: String,
+            k: u32,
+            key_type: String,
+            bogus_field: u8, // key not in TopKMetadata
+        }
+        let m = topk_metadata::<DefaultXxHasher>(2, 4, "i64", "regular", 4, "u64");
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            matrix_seed_index: m.matrix_seed_index,
+            rows: m.rows,
+            cols: m.cols,
+            counter_type: m.counter_type.clone(),
+            mode: m.mode.clone(),
+            k: m.k,
+            key_type: m.key_type.clone(),
+            bogus_field: 7,
+        };
+        let bytes = rmp_serde::to_vec_named(&extra).expect("encode");
+        assert!(
+            from_slice::<TopKMetadata>(&bytes).is_err(),
+            "an unexpected metadata key must be rejected"
+        );
+    }
+
+    /// `key_type` is required: a metadata map missing it does not decode, so the
+    /// heap's key variant can never be silently defaulted.
+    #[test]
+    fn cs_heap_metadata_rejects_a_missing_key_type_key() {
+        #[derive(Serialize)]
+        struct WithoutKeyType {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            matrix_seed_index: u32,
+            rows: u32,
+            cols: u32,
+            counter_type: String,
+            mode: String,
+            k: u32,
+        }
+        let m = topk_metadata::<DefaultXxHasher>(2, 4, "i64", "regular", 4, "u64");
+        let without = WithoutKeyType {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            matrix_seed_index: m.matrix_seed_index,
+            rows: m.rows,
+            cols: m.cols,
+            counter_type: m.counter_type.clone(),
+            mode: m.mode.clone(),
+            k: m.k,
+        };
+        let bytes = rmp_serde::to_vec_named(&without).expect("encode");
+        assert!(
+            from_slice::<TopKMetadata>(&bytes).is_err(),
+            "a missing key_type must be rejected"
+        );
+    }
+
+    /// `f64` is a Count-Min wire counter but not a Count Sketch one, so its name
+    /// must not decode into either wire-eligible type.
+    #[test]
+    fn cs_heap_rejects_a_foreign_counter_type_name() {
+        let metadata = rmp_serde::to_vec_named(&topk_metadata::<DefaultXxHasher>(
+            2, 4, "f64", "regular", 4, "u64",
+        ))
+        .expect("metadata");
+        let payload = rmp_serde::to_vec(&TopKPayload::<i64, u64> {
+            counts: vec![0; 8],
+            keys: Vec::new(),
+            heap_counts: Vec::new(),
+        })
+        .expect("payload");
+        let bytes = envelope::encode(CS_HEAP_KIND, &metadata, &payload);
+        assert!(
+            CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&bytes).is_err(),
+            "an i64 sketch must reject an f64-labelled envelope"
+        );
+        assert!(
+            CSHeap::<Vector2D<i32>, RegularPath>::deserialize_from_bytes(&bytes).is_err(),
+            "an i32 sketch must reject an f64-labelled envelope"
+        );
+    }
+
+    // A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    // declares a DIFFERENT `HashProfile`. CSHeap metadata is derived from the
+    // profile, so an `AltHasher` sketch serializes truthfully. (An *unprofiled*
+    // hasher cannot serialize at all — that is a compile-time guarantee, since
+    // the wire methods are bounded on `H: HashProfile`.)
+    #[derive(Clone, Debug)]
+    struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &crate::HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &crate::HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    #[test]
+    fn cs_heap_custom_hasher_profile_round_trips_and_is_self_describing() {
+        // (a) A CSHeap built with a custom-profile hasher round-trips.
+        let mut alt = CSHeap::<Vector2D<i64>, RegularPath, AltHasher>::new(3, 8, 4);
+        let mut std = CSHeap::<Vector2D<i64>, RegularPath>::new(3, 8, 4);
+        for key in [42u64, 7] {
+            alt.insert(&DataInput::U64(key));
+            std.insert(&DataInput::U64(key));
+        }
+
+        let alt_bytes = alt.serialize_to_bytes().expect("alt serialize");
+        let decoded =
+            CSHeap::<Vector2D<i64>, RegularPath, AltHasher>::deserialize_from_bytes(&alt_bytes)
+                .expect("alt decode");
+        assert_eq!(
+            alt.cs().as_storage().as_slice(),
+            decoded.cs().as_storage().as_slice()
+        );
+        assert_eq!(decoded.heap().len(), 2);
+
+        // (b) Bytes differ from the standard-profile sketch (metadata derived
+        // from the different profile).
+        let std_bytes = std.serialize_to_bytes().expect("std serialize");
+        assert_ne!(alt_bytes, std_bytes);
+
+        // (c) Standard-profile decode fails closed on custom-profile bytes.
+        assert!(
+            CSHeap::<Vector2D<i64>, RegularPath>::deserialize_from_bytes(&alt_bytes).is_err(),
+            "standard-profile decode must reject custom-profile bytes"
+        );
+    }
+
+    /// A `k` past the metadata's `u32` field fails the encode rather than
+    /// emitting a truncated capacity.
+    #[test]
+    fn cs_heap_refuses_a_k_the_metadata_cannot_carry() {
+        let sketch = CSHeap::<Vector2D<i64>, RegularPath>::from_storage(
+            Vector2D::from_fn(2, 4, |_, _| 0i64),
+            1usize << 40,
+        );
+        let problem = sketch
+            .serialize_to_bytes()
+            .expect_err("an oversized k must not serialize")
+            .to_string();
+        assert!(
+            problem.contains("exceeds the u32 metadata field"),
+            "got {problem}"
+        );
+    }
+}


### PR DESCRIPTION
Designs and implements the ASAPv1 wire payloads for **CMSHeap** (`0x03 0x00`) and **CSHeap** (`0x0a 0x00`). Both kind_ids were already allocated in the Section 1 registry; neither is changed here.

The two sketches are each a matrix sketch plus an `HHHeap`, so there is exactly **one** heap encoding across them: one metadata schema, one positional payload, one `key_type` rule, one emitted order.

No golden fixtures this round, and `docs/asapv1_wire_format.md` is untouched — the two §3.x drafts below are written for a later agent to harvest into it. Section numbers are provisional (they slot in ahead of the current §3.7 "payloads not yet designed" table).

---

# §3.7: The top-k heap sub-payload (shared by `0x03 0x00` and `0x0a 0x00`)

`HHHeap` is a capacity-bounded min-heap of `(key, count)` entries beside a digest→position index. **None of that index reaches the wire.** `slots` and `positions` are `#[serde(skip)]` in the type itself and are rebuilt from the entries on load, so the sub-payload carries the entries only — the same argument §3.5 makes for Space-Saving's arenas, and with the same benefit: with no index on the wire, no crafted payload can point one out of bounds or into a cycle.

The sub-payload is two parallel arrays, positioned by the enclosing payload:

| Field | Type | Notes |
| ----- | ---- | ----- |
| `keys` | array | one key per heap entry; element type = `key_type`; homogeneous |
| `heap_counts` | array | i64 count, parallel to `keys` |

The number of entries is `len(keys)` (derived, so not stored). The heap's array order, its digest index and its `is_full` state are all recomputed from the entries.

**Metadata vs payload.** The heap's one sizing parameter, `k`, is chosen at construction, so per the config→metadata rule it belongs in the descriptor (like HLL's `precision`, Count-Min's `rows`/`cols`, or Space-Saving's `capacity`). `key_type` is a structural param in the Count-Min `counter_type` / KLL `item_type` sense: it fixes the element type of `keys`, and the sub-payload cannot be read without it.

**`key_type` names the exact key variant, and is never widened.** Identical to §3.5's rule, reused verbatim. Count-Min's counter type is a Rust type parameter fixed at compile time; a heap key's type is a **runtime** property, because keys are stored as `HeapItem`, a 16-variant enum, and one heap's keys are whatever the caller inserted. So one `key_type` names the exact variant present and `keys` is homogeneous in it:

| `key_type` | `HeapItem` variant | msgpack element type |
| ---------- | ------------------ | -------------------- |
| `"i8"` / `"i16"` / `"i32"` / `"i64"` / `"isize"` | `I8` / `I16` / `I32` / `I64` / `ISIZE` | integer, family + width per Section 4 |
| `"u8"` / `"u16"` / `"u32"` / `"u64"` / `"usize"` | `U8` / `U16` / `U32` / `U64` / `USIZE` | integer, family + width per Section 4 |
| `"f32"` | `F32` | float32 (`0xca`) |
| `"f64"` | `F64` | float64 (`0xcb`) |
| `"string"` | `String` | `str` |

`"f32"` is the one place a float is *not* widened to float64: the key's variant is the identity, so narrowing or widening it would change which key it is. Section 4's "always float64" rule governs *counter* and *sample* values, which have no identity to preserve.

**Why not widen (e.g. `i32` to `i64`, as Count-Min does for counters).** A counter is a number and widening it is lossless. A heap key is an *identity*, and the variant is part of it. `HeapItem`'s equality against a query `DataInput` is variant-exact — `HeapItem::I64(5)` does **not** equal `DataInput::I32(5)`. The digest, however, is variant-blind: `hash_item64_seeded` hashes the whole signed family widened to `u64`, so a widened key lands in the **same index slot** and then fails the equality check. The result is not an error; it is a lookup returning nothing for a key the heap is holding, with nothing anywhere to indicate a problem. So the wire records the variant exactly and the decoder rebuilds it exactly.

Two heaps have no encoding and **fail to serialize** rather than being coerced:

- **Mixed variants.** A heap whose keys are of different `HeapItem` variants has no single `key_type`. Coercing them would silently break the keys that were coerced, so the encode fails with an error naming the mismatch.
- **128-bit keys.** `HeapItem::I128` / `U128` have no msgpack integer form (msgpack integers stop at 64 bits), so they are not wire types — the same line Count-Min draws at `i128` counters. Convert to a wire-eligible key type first; only the owner knows whether the mapping is lossless (Section 5).

**Empty heap.** A heap that holds nothing has no variant to report. It emits `key_type = "u64"` with two empty arrays, so an empty heap has exactly one encoding rather than one per producer.

**Emitted order (cross-language contract).** The sub-payload is **order-defined**: entries are written in **descending `heap_counts`**, ties broken by a **total order over the key** (variant tag first, then the value; strings after every numeric family). This is **required, not cosmetic**: the heap's in-memory array order follows the sift path taken while it filled, and that order does not survive a rebuild, so an unordered payload would re-serialize to different bytes than it decoded from. With the order pinned, two heaps holding the same entries emit the same bytes whatever order they were seated in, and re-serializing a decoded sketch reproduces its bytes exactly. Go must mirror the same comparator.

**Decode rules.** Fail **closed** on each, with an error and never a panic:

1. `key_type` is one of the thirteen names above; anything else is rejected. The `keys` array is then read **as** that type, so a payload whose keys are not of the declared type is rejected by the msgpack decode itself — string-keyed bytes relabelled `"u64"` do not decode as a `u64`-keyed heap.
2. `keys` and `heap_counts` have equal length.
3. `len(keys) <= k`.
4. No key appears twice.
5. `k` **never sizes an allocation.** Rule 3 is checked first and the heap is then filled entry by entry, so a payload declaring `k = 2^32 - 1` with two entries costs two entries.

`slots`, `positions` and the heap array are then recomputed from the validated entries; nothing about them is trusted from the wire.

---

# §3.8: CMSHeap payload (`0x03 0x00`)

`CMSHeap` is a Count-Min sketch (§3.2) paired with an `HHHeap`. The base sketch's counters are **inlined** into this payload rather than nested in an envelope of their own (see "Inline, not nest" below), so the payload is Count-Min's `counts` array followed by the §3.7 heap sub-payload:

| Pos | Field | Type | Notes |
| --- | ----- | ---- | ----- |
| 0 | `counts` | array | the Count-Min matrix, packed **row-major**, `rows*cols` cells; element type = `counter_type` |
| 1 | `keys` | array | heap keys; element type = `key_type`; homogeneous (§3.7) |
| 2 | `heap_counts` | array | i64 heap count, parallel to `keys` (§3.7) |

**Metadata vs payload.** Everything the payload's structure depends on is configuration and lives in the metadata, in this canonical order (hash-spec group first, then structural params — Go must mirror it verbatim):

```
metadata_version, hash_profile_id, hash_algorithm, seed_derivation, input_encoding,
seed_list, matrix_seed_index, rows, cols, counter_type, mode, k, key_type
```

`rows` / `cols` / `counter_type` / `mode` are exactly Count-Min's (§3.2, Q-CMS-DIMS), in exactly Count-Min's order; `k` and `key_type` are the heap's (§3.7) and follow them. Nothing derivable is carried: the heap's entry count is `len(keys)`, and the heap's index and array order are rebuilt.

Wire counter types are those of the base Count-Min: **`"i64"` and `"f64"`**. `mode` records `RegularPath` vs `FastPath` because they place a key in different columns. A counter type other than i64/f64, or non-`Vector2D` storage, must be converted first (Section 5).

**Decode rules** (all fail closed, per Section 1's decoder rules):

1. `kind_id` is `0x03 0x00`; any other id is rejected — including `0x02 0x00` (a plain Count-Min) and `0x0a 0x00` (a CSHeap), which carry a compatible-looking metadata map.
2. The metadata's hash spec, `counter_type` and `mode` must equal the target type's own, with `rows` / `cols` / `k` / `key_type` echoed back since those are properties of the stored sketch rather than of the target. Every key is required: a map missing one, or carrying an unknown one, does not decode.
3. `rows` and `cols` are both non-zero, checked **before** the matrix is built: the column mask is derived from `cols.ilog2()`, which panics on `cols == 0`.
4. `len(counts) == rows * cols` exactly, checked **before** the allocation, so crafted dimensions cannot drive a huge reserve.
5. The heap sub-payload passes §3.7's decode rules 1-5.

Rule 4 is enforced on the **encode** side too: a matrix whose cell count disagrees with its own dimensions (`Vector2D::init` reserves without filling) fails to serialize, so the format never emits bytes it would refuse to read back. So is the `k` bound: a heap capacity past the metadata's `u32` field fails the encode rather than being truncated.

---

# §3.9: CSHeap payload (`0x0a 0x00`)

`CSHeap` is a Count Sketch (§3.6) paired with an `HHHeap`, and its payload is §3.8's with the Count Sketch counter domain:

| Pos | Field | Type | Notes |
| --- | ----- | ---- | ----- |
| 0 | `counts` | array | the Count Sketch matrix, packed **row-major**, `rows*cols` cells; element type = `counter_type`, **signed** |
| 1 | `keys` | array | heap keys; element type = `key_type`; homogeneous (§3.7) |
| 2 | `heap_counts` | array | i64 heap count, parallel to `keys` (§3.7) |

**Metadata vs payload.** Identical to §3.8, with the same canonical key order:

```
metadata_version, hash_profile_id, hash_algorithm, seed_derivation, input_encoding,
seed_list, matrix_seed_index, rows, cols, counter_type, mode, k, key_type
```

Wire counter types are those of the base Count Sketch: **`"i32"` and `"i64"`** (§3.6, Q-CS). Count Sketch counters must be signed and negatable, so Count-Min's `f64` has no counterpart here, and `i128` has no msgpack integer form. `i32` is carried at its own width, never widened, and the decoder pins it: i32 bytes do not decode into an i64 sketch, or the reverse. Cells carry a sign — a decoder must not assume monotonicity.

**Decode rules** (all fail closed, per Section 1's decoder rules):

1. `kind_id` is `0x0a 0x00`; any other id is rejected — including `0x04 0x00` (a plain Count Sketch) and `0x03 0x00` (a CMSHeap).
2. The metadata's hash spec, `counter_type` and `mode` must equal the target type's own, with `rows` / `cols` / `k` / `key_type` echoed back. Every key is required; `"f64"` is not a CSHeap `counter_type` and does not decode into either wire-eligible type.
3. `rows` and `cols` are both non-zero, checked before the matrix is built.
4. `len(counts) == rows * cols` exactly, checked **before** the allocation.
5. The heap sub-payload passes §3.7's decode rules 1-5.

Rules 4 and the `k` bound are enforced on the **encode** side too, as in §3.8.

`CountL2HH`, which also lives in `countsketch_topk.rs`, is a different algorithm; its kind_id (`0x19 0x00`) is being allocated separately and it is **not** serialized here.

---

# Recorded decisions

### Inline, not nest — the base sketch's counters are inlined (both sketches)

The payload is a **flat positional array** `[counts, keys, heap_counts]`. It does **not** nest a complete ASAPv1 envelope for the base Count-Min / Count Sketch.

Inlining is the straight read of §3's "raw state only, the kind_id already fixes the structure" rule. By the time a decoder reaches the payload it has read `kind_id = 0x03 0x00` and the metadata, and together those fix the shape completely — there is nothing left for a nested envelope to describe. A nested envelope would repeat a magic sentinel, an envelope version, a `kind_id`, two length prefixes and a whole metadata map whose hash spec, `rows`, `cols`, `counter_type` and `mode` the outer metadata already carries verbatim; it would also create a second place where those values live, so a decoder would have to cross-check inner against outer and decide what to do when they disagree. Two truths for one fact is exactly what §3 forbids. Nesting also buys nothing here: unlike Hydra-KLL, which holds *many* base sketches whose count is data, a CMSHeap holds exactly one, at a fixed position.

The same choice is used for **both** sketches, so the two payloads differ only in the element type of position 0.

### One shared heap encoding, in one module

The shared pieces — `TopKMetadata` + `topk_metadata::<H>`, `TopKPayload<C, K>`, `key_type_of`, `key_order`, `heap_entries`, `wire_key_type`, `encode_payload`, `decode_payload`, `rebuild_heap` — live in **`src/sketches/countminsketch_topk/heap_wire.rs`**, declared `pub(crate) mod heap_wire;` in `src/sketches/countminsketch_topk.rs`. `src/sketches/countsketch_topk/wire.rs` imports them by path.

It is a child of `countminsketch_topk` (the lower of the two kind_ids) because that is the only home reachable from both without editing a `mod.rs` outside this PR's file set, and `pub(crate)` keeps it off the public API. Each sketch's `wire.rs` then holds only its kind_id constant and its two impls.

### The metadata schema is shared too, not just the payload

Both sketches carry the identical field set in the identical order, so they share one `#[serde(deny_unknown_fields)]` struct. Cross-decoding is prevented by `kind_id` and by the `counter_type` / `mode` / hash-spec pinning, not by having two structurally identical Rust types; sharing removes the drift risk between them.

### `k` in metadata, entries in payload

`k` is construction config (`HHHeap::new(k)`), so it is metadata, like `capacity` in §3.5. It is a `u32`; a heap whose `k` exceeds that fails the encode rather than emitting a truncated capacity that no decode would accept.

### `k` never sizes an allocation — one small change in `CommonHeap`'s module

To honour "a declared size never sizes an allocation", `CommonHeap::with_capacity` and `HHHeap::new` now cap the slots they **reserve up front** at 1024 (`PREALLOCATED_SLOTS`); the declared capacity is unchanged and the structures still grow to it on demand. Without this, a decode of `k = u32::MAX` would have asked for a multi-gigabyte `Vec` and `HashMap` before a single entry was seated. This is the only edit outside the two `_topk` trees, it is two lines plus a constant, and it changes no observable behaviour (`capacity()` still returns the declared `k`).

### `wire` reads private fields; no visibility widened for it

Each `wire.rs` is a descendant of its sketch's module, so it reads the private `cms` / `cs` / `heap` fields and constructs the struct literal directly. No field visibility was widened. The only new visibility is `pub(crate)` on the shared `heap_wire` module.

### No native `MessagePackCodec` shim

Neither Bloom (§3.4) nor Space-Saving (§3.5) added one when their payloads landed, and `src/message_pack_format/native/mod.rs` is outside this PR's file set. `native/countsketch_topk.rs` keeps its existing `CountL2HH` impl unchanged.

---

# Tests

**Shared heap encoding** (`countminsketch_topk/heap_wire.rs`, 7 tests):

- `heap_every_key_type_round_trips_and_keeps_its_variant` — all thirteen `key_type` names round-trip under their own name (every integer width, both floats, `"string"`), re-serialize byte-identically, and each decoded key still matches the caller's original `DataInput`.
- `heap_refuses_mixed_and_128_bit_keys` — a mixed-variant heap fails to serialize with an error naming the mismatch; an `I128` / `U128` key fails to serialize, whether it is the first key or behind a wire-eligible one.
- `heap_empty_emits_the_pinned_key_type_and_round_trips` — an empty heap emits `key_type = "u64"` and round-trips.
- `heap_emitted_order_is_independent_of_seat_order` — two heaps holding the same entries seated in opposite orders emit the same bytes; the emitted counts are descending and the ties are broken by key; a decoded heap re-serializes byte-identically.
- `heap_rejects_a_key_type_the_payload_does_not_carry` — a `"string"`-keyed payload relabelled `"u64"` does not decode, and the reverse.
- `heap_index_is_rebuilt_so_updates_still_move_entries` — after a decode, an update that rescores an entry and one that seats a new key land the same way as on the original.
- `heap_rejects_crafted_entry_sets` — more entries than `k`, a duplicate key, and unequal-length arrays are each rejected with a naming error; a declared `k = u32::MAX` decodes without allocating for it.

**CMSHeap** (`countminsketch_topk/wire.rs`, 12 tests): round trip (asserts `b"ASAPv1"`, `kind_id_len = 2`, `kind_id = [0x03, 0x00]`, every metadata field, and a byte-identical re-serialize); `f64` counters; counter type pinned by the target (i64 ↔ f64); mode in metadata, pinned; foreign kind_ids rejected (CSHeap, plain Count-Min, plain Count Sketch); zero dimension rejected without a panic; dimension/length mismatch rejected before allocation; encode-side rejection of an unfilled matrix; unknown metadata key rejected; missing `k` key rejected; foreign `counter_type` name (`"i32"`) rejected; encode-side rejection of a `k` past the `u32` field; plus the `AltHasher` custom-`HashProfile` three-part test.

**CSHeap** (`countsketch_topk/wire.rs`, 12 tests): the same twelve, with the Count Sketch specifics — negative counters round-trip; `i32` round-trips and is pinned against `i64` both ways; foreign kind_ids rejected (CMSHeap, plain Count-Min, plain Count Sketch); missing `key_type` key rejected; foreign `counter_type` name (`"f64"`) rejected by both the i64 and the i32 target; plus its own `AltHasher` three-part test.

No `.hex` fixtures were added and `tests/asapv1_golden.rs` is untouched.

# CI

Run locally against `main` as of `4ddf9f9`, all three green:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean.
- `cargo test --all-features --locked --verbose` — 800 lib tests + all integration and doc tests pass, 0 failures.

The local toolchain may be older than CI's `dtolnay/rust-toolchain@stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
