### PR TITLE
feat(univmon): ASAPv1 wire payloads for CountL2HH, UnivMon, UnivMon Optimized and UnivMon-Q

### DIFF
--- a/docs/api/api_count_sketch.md
+++ b/docs/api/api_count_sketch.md
@@ -81,6 +81,16 @@ Sketch (the variant `HydraCounter` and `EHSketchList` hold) round-trip back into
 its own type. `rows`/`cols` and the `mode` are carried in the metadata too; the
 payload is just `[counts]`, packed row-major with signed cells.
 
+`CountL2HH` has its own ASAPv1 kind (`0x19 0x00`) and the same two methods,
+available for any `H: HashProfile`. Its counters are always `i64` and its
+column derivation is fixed by the algorithm, so the metadata carries no
+`counter_type` and no `mode` — only `seed_index`, `rows` and `cols`. The
+payload is `[counts, l2]`: the matrix packed row-major, then one L2
+accumulator per row. `l2` is carried rather than recomputed, because
+`fast_insert_with_count_without_l2_and_hash` moves counters without it and the
+accumulator saturates one way. The same `(counts, l2)` pair is what a `UnivMon`
+layer inlines into its own payload.
+
 ## Examples
 
 ```rust

--- a/docs/api/api_cs_heap.md
+++ b/docs/api/api_cs_heap.md
@@ -74,8 +74,8 @@ holds an `I128` / `U128` key, does not serialize. An empty heap emits
 Entries are emitted in descending count, ties broken by a total order over the
 key, so a decoded sketch re-serializes byte-identically.
 
-`CountL2HH` is a different algorithm and has no ASAPv1 payload yet; its own
-`serialize_to_bytes` is the Rust-internal `portable` form.
+`CountL2HH` is a different algorithm with its own ASAPv1 kind (`0x19 0x00`);
+see [the Count Sketch API doc](./api_count_sketch.md).
 
 ## Examples
 

--- a/docs/api/api_univmon.md
+++ b/docs/api/api_univmon.md
@@ -57,6 +57,23 @@ fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError>
 fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
 ```
 
+These produce/consume the **ASAPv1** wire envelope (kind `0x10 0x00`) — see the
+[ASAPv1 wire format spec](../asapv1_wire_format.md). UnivMon hashes through the
+crate's default hasher, so its metadata carries that profile and no seed index:
+the bottom-layer finder's seed is fixed by the algorithm, and layer `i`'s
+counter hashes at seed index `i`.
+
+The pyramid shape (`layer_size`, `sketch_row`, `sketch_col`, `heap_size`) and
+the heaps' `key_type` live in the metadata; the payload is
+`[counts, l2, heap_lens, keys, heap_counts, candidate_complete, bucket_size,
+update_mode]`. Each layer's `CountL2HH` state is inlined rather than nested in
+an envelope of its own, and the heap indexes are rebuilt on load, so no index
+reaches the wire. Heap entries are emitted layer by layer, each layer in
+descending count with ties broken by a total order over the key, so a decoded
+pyramid re-serializes byte-identically. `update_mode` and `candidate_complete`
+are carried: they are acquired from the stream, and a decoder that guessed them
+would pick the wrong query recurrence or report a widened threshold as zero.
+
 ## Examples
 
 ```rust

--- a/docs/api/api_univmon_optimized.md
+++ b/docs/api/api_univmon_optimized.md
@@ -65,7 +65,22 @@ fn merge(&mut self, other: &UnivMonPyramid)
 
 ## Serialization
 
-No dedicated serialization API.
+```rust
+fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError>
+fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
+```
+
+These produce/consume the **ASAPv1** wire envelope (kind `0x11 0x00`) — see the
+[ASAPv1 wire format spec](../asapv1_wire_format.md). `UnivMonPyramid` shares
+[`UnivMon`](./api_univmon.md)'s payload and differs only in its metadata: the
+two-tier layout (`layer_size`, `elephant_layers`, `elephant_row`,
+`elephant_col`, `mouse_row`, `mouse_col`, `heap_size`) plus the heaps'
+`key_type`. Layer `i` takes the elephant dimensions while `i < elephant_layers`
+and the mouse dimensions after, so every per-layer geometry is derived and none
+is stored.
+
+`UnivSketchPool` is a free-list of scratch `UnivMon`s rather than a sketch, and
+has no wire kind.
 
 ## Examples
 

--- a/docs/api/api_univmon_q.md
+++ b/docs/api/api_univmon_q.md
@@ -237,11 +237,26 @@ fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError>
 fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
 ```
 
-These helpers exist for `UnivMonQ<DefaultXxHasher>` and use a validated native
-MessagePack v2 DTO containing occurrence and source metadata. A v1 state with
-a nonempty distinct-key ordered sample is rejected because discarded
-occurrence identities cannot be reconstructed. No ASAPv1 kind id or
-cross-language protobuf contract has been assigned yet.
+These produce/consume the **ASAPv1** wire envelope (kind `0x1a 0x00`) — see the
+[ASAPv1 wire format spec](../asapv1_wire_format.md). They exist for any
+`H: HashProfile`, so a decode of one profile's bytes into another profile's
+sketch is rejected.
+
+The whole `UnivMonQConfig` is construction config and lives in the metadata
+(`seed_index`, `levels`, `width`, `width_halving_period`, `depth`,
+`counter_type`, `candidates`, `ordered_samples`), so every per-level width, the
+hash layout and each level's candidate capacity are derived and none is stored.
+The payload is `[counters, candidate_lens, candidate_keys, candidate_scores,
+ever_evicted, count, min, max, source_id, next_sequence,
+occurrence_priority_high, occurrence_priority_low, occurrence_keys]`.
+
+Both heaps — a level's candidate min-heap and the ordered sample — are rebuilt
+on decode, so the payload pins an order instead: candidates ascending by key,
+occurrences ascending by `(priority_high, priority_low, key)`. `source_id` and
+`next_sequence` are carried so a decoded sketch continues the same occurrence
+draw sequence; `min` and `max` travel as msgpack nil when the sketch is empty.
+`ever_evicted` is carried too — a full candidate table does not say whether it
+ever displaced anything.
 
 ## Example
 

--- a/examples/evaluate_univmon_q_skew.rs
+++ b/examples/evaluate_univmon_q_skew.rs
@@ -15,7 +15,8 @@ use std::mem::size_of;
 use std::time::{Duration, Instant};
 
 use asap_sketchlib::{
-    BOTTOM_LAYER_FINDER, DataInput, HeapItem, UnivMon, UnivMonQ, UnivMonQConfig, hash64_seeded,
+    BOTTOM_LAYER_FINDER, DataInput, DefaultXxHasher, HeapItem, UnivMon, UnivMonQ, UnivMonQConfig,
+    hash64_seeded,
 };
 
 const SKEWS: [f64; 7] = [0.0, 0.5, 0.9, 1.1, 1.3, 1.6, 2.0];
@@ -330,7 +331,7 @@ fn evaluate_trial(
     }
 
     let q_wire = q_merged_tree.serialize_to_bytes().unwrap();
-    let q_decoded = UnivMonQ::deserialize_from_bytes(&q_wire).unwrap();
+    let q_decoded = UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&q_wire).unwrap();
     if !equivalent_queries(&q_merged_tree, &q_decoded, truth) {
         q_violations += 1;
     }

--- a/src/message_pack_format/native/countsketch_topk.rs
+++ b/src/message_pack_format/native/countsketch_topk.rs
@@ -1,10 +1,10 @@
 //! Native MessagePack codec impl for [`crate::sketches::countsketch_topk::CountL2HH`].
 
-use crate::SketchHasher;
 use crate::message_pack_format::{Error, MessagePackCodec};
 use crate::sketches::countsketch_topk::CountL2HH;
+use crate::{HashProfile, SketchHasher};
 
-impl<H: SketchHasher> MessagePackCodec for CountL2HH<H> {
+impl<H: SketchHasher + HashProfile> MessagePackCodec for CountL2HH<H> {
     fn to_msgpack(&self) -> Result<Vec<u8>, Error> {
         Ok(self.serialize_to_bytes()?)
     }

--- a/src/sketch_framework/univmon.rs
+++ b/src/sketch_framework/univmon.rs
@@ -31,11 +31,10 @@ use crate::common::{
 use crate::common::{L2HH, Vector1D};
 use crate::octo_delta::LayeredCountDelta;
 use crate::sketches::countsketch_topk::CountL2HH;
-use rmp_serde::{
-    decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice, to_vec_named,
-};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+
+pub(crate) mod wire;
 
 const DEFAULT_SKETCH_ROW: usize = 5;
 const DEFAULT_SKETCH_COL: usize = 2048;
@@ -533,29 +532,6 @@ impl UnivMon {
     /// Returns the heap for one layer.
     pub fn heap_at_layer(&mut self, layer: usize) -> &mut HHHeap {
         &mut self.hh_layers[layer]
-    }
-
-    /// Serializes the UnivMon sketch into MessagePack bytes.
-    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
-        to_vec_named(self)
-    }
-
-    /// Deserializes a UnivMon sketch from MessagePack bytes.
-    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
-        let mut sketch: Self = from_slice(bytes)?;
-        if sketch.bucket_size > 0 && sketch.update_mode == UnivMonUpdateMode::Unset {
-            // Named-map payloads written before update modes existed contain
-            // cumulative sampled layers, i.e. the standard UnivMon layout.
-            sketch.update_mode = UnivMonUpdateMode::Standard;
-        }
-        if sketch.candidate_complete.len() != sketch.layer_size {
-            sketch.candidate_complete = sketch
-                .hh_layers
-                .iter()
-                .map(|heap| heap.len() < sketch.heap_size)
-                .collect();
-        }
-        Ok(sketch)
     }
 }
 

--- a/src/sketch_framework/univmon/wire.rs
+++ b/src/sketch_framework/univmon/wire.rs
@@ -1,0 +1,1001 @@
+//! ASAPv1 wire serialization for [`UnivMon`], plus the pyramid payload
+//! [`UnivMonPyramid`] reuses.
+//!
+//! Child submodule of [`crate::sketch_framework::univmon`]: it holds the
+//! metadata/payload DTOs, the kind_id constant and the `serialize_to_bytes` /
+//! `deserialize_from_bytes` impls, while the algorithm lives in the parent
+//! module file. Being a descendant module, it reads the private `update_mode`
+//! and `candidate_complete` fields directly without widening any field
+//! visibility. See `docs/asapv1_wire_format.md`.
+//!
+//! UnivMon is one algorithm — a single kind_id `0x10 0x00`. The pyramid shape
+//! (`layer_size`, `sketch_row`, `sketch_col`, `heap_size`) and the heaps'
+//! `key_type` are construction config and live in the metadata, so the payload
+//! carries the layers' raw state.
+//!
+//! ## Layers are inlined, not nested
+//!
+//! Each layer is a `CountL2HH` plus an `HHHeap`. Their state is written
+//! straight into UnivMon's own positional array through
+//! [`l2hh_wire::layer_state`] and [`heap_entries`]; no layer carries an
+//! envelope, a magic or a metadata map of its own.
+//!
+//! ## The hash profile is the crate default
+//!
+//! UnivMon hashes through `hash64_seeded` / `hash_item64_seeded` and holds
+//! `CountL2HH<DefaultXxHasher>` layers, so it has no hasher type parameter and
+//! its metadata is derived from [`DefaultXxHasher`]'s [`HashProfile`].
+//!
+//! It carries no seed-index key: the bottom-layer finder hashes at
+//! `BOTTOM_LAYER_FINDER` unconditionally — a fixed part of the algorithm, not
+//! a profile choice — and layer `i`'s counter hashes at seed index `i`, which
+//! the layer's position already gives.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+use crate::sketches::countminsketch_topk::heap_wire::{
+    EMPTY_KEY_TYPE, heap_entries, key_type_of, rebuild_heap,
+};
+use crate::sketches::countsketch_topk::l2hh_wire;
+use crate::{DefaultXxHasher, HHHeap, HashProfile, HeapItem, L2HH, Vector1D};
+
+use super::{UnivMon, UnivMonUpdateMode};
+
+/// UnivMon kind_id: family `0x10`, single algorithm variant `0x00`.
+const UNIVMON_KIND: &[u8] = &[0x10, 0x00];
+
+/// UnivMon descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`) with keys in this declaration order — the canonical order
+/// the wire spec fixes (Go must mirror it). Hash-spec fields first, then the
+/// structural params `layer_size` / `sketch_row` / `sketch_col` / `heap_size`
+/// / `key_type`.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct UnivMonMetadata {
+    pub(crate) metadata_version: u8,
+    pub(crate) hash_profile_id: String,
+    pub(crate) hash_algorithm: String,
+    pub(crate) seed_derivation: String,
+    pub(crate) input_encoding: String,
+    pub(crate) seed_list: Vec<u64>,
+    pub(crate) layer_size: u32,
+    pub(crate) sketch_row: u32,
+    pub(crate) sketch_col: u32,
+    pub(crate) heap_size: u32,
+    pub(crate) key_type: String,
+}
+
+/// Builds the UnivMon descriptor metadata from the hasher's [`HashProfile`],
+/// so the wire bytes truthfully describe how the sketch was hashed. Every
+/// layer shares the same dimensions and heap capacity.
+pub(crate) fn univmon_metadata<H: HashProfile>(
+    layer_size: u32,
+    sketch_row: u32,
+    sketch_col: u32,
+    heap_size: u32,
+    key_type: &str,
+) -> UnivMonMetadata {
+    UnivMonMetadata {
+        metadata_version: 1,
+        hash_profile_id: H::PROFILE_ID.to_string(),
+        hash_algorithm: H::ALGORITHM.to_string(),
+        seed_derivation: H::SEED_DERIVATION.to_string(),
+        input_encoding: H::INPUT_ENCODING.to_string(),
+        seed_list: H::seed_list(),
+        layer_size,
+        sketch_row,
+        sketch_col,
+        heap_size,
+        key_type: key_type.to_string(),
+    }
+}
+
+/// The pyramid payload both UnivMon kinds share, a msgpack **array**
+/// (`to_vec`, positional):
+/// `[counts, l2, heap_lens, keys, heap_counts, candidate_complete,
+/// bucket_size, update_mode]`.
+///
+/// `counts` and `l2` concatenate the layers' `CountL2HH` state in layer order;
+/// `heap_lens` cuts the parallel `keys` / `heap_counts` arrays into per-layer
+/// runs, with `keys` typed by the metadata `key_type`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct PyramidPayload<K> {
+    pub(crate) counts: Vec<i64>,
+    pub(crate) l2: Vec<i64>,
+    pub(crate) heap_lens: Vec<u32>,
+    pub(crate) keys: Vec<K>,
+    pub(crate) heap_counts: Vec<i64>,
+    pub(crate) candidate_complete: Vec<bool>,
+    pub(crate) bucket_size: u64,
+    pub(crate) update_mode: u8,
+}
+
+/// Wire tag of the update mode: `0` unset, `1` standard, `2` terminal-only.
+/// The mode is acquired from the stream rather than configured, and it selects
+/// the query recurrence, so it is payload state.
+pub(crate) fn update_mode_tag(mode: UnivMonUpdateMode) -> u8 {
+    match mode {
+        UnivMonUpdateMode::Unset => 0,
+        UnivMonUpdateMode::Standard => 1,
+        UnivMonUpdateMode::Terminal => 2,
+    }
+}
+
+/// Reads the update-mode tag, rejecting any value outside the three modes.
+pub(crate) fn update_mode_of(tag: u8) -> Result<UnivMonUpdateMode, RmpDecodeError> {
+    match tag {
+        0 => Ok(UnivMonUpdateMode::Unset),
+        1 => Ok(UnivMonUpdateMode::Standard),
+        2 => Ok(UnivMonUpdateMode::Terminal),
+        other => Err(RmpDecodeError::Uncategorized(format!(
+            "ASAPv1 UnivMon envelope: update_mode {other} is not a wire mode"
+        ))),
+    }
+}
+
+/// The layers' state in emitted order, ready to be packed.
+pub(crate) struct PyramidState<'a> {
+    pub(crate) counts: Vec<i64>,
+    pub(crate) l2: Vec<i64>,
+    pub(crate) heap_lens: Vec<u32>,
+    pub(crate) entries: Vec<(&'a HeapItem, i64)>,
+    pub(crate) candidate_complete: Vec<bool>,
+    pub(crate) bucket_size: u64,
+    pub(crate) update_mode: u8,
+}
+
+/// Reads every layer's counters, accumulators and heap entries in the emitted
+/// order: layers ascending, and within a layer the heap's own emitted order
+/// (descending count, ties by the total order over the key).
+///
+/// Fails when a layer's geometry disagrees with the declared one, when a
+/// layer's seed index is not its position, or when the heaps hold more entries
+/// than `u32` can name.
+pub(crate) fn pyramid_state<'a>(
+    sketches: &'a Vector1D<L2HH>,
+    heaps: &'a Vector1D<HHHeap>,
+    geometry: &[(usize, usize)],
+    bucket_size: usize,
+    update_mode: u8,
+    candidate_complete: &[bool],
+) -> Result<PyramidState<'a>, RmpEncodeError> {
+    let layer_size = geometry.len();
+    if sketches.len() != layer_size || heaps.len() != layer_size {
+        return Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 UnivMon envelope: {} counters and {} heaps over {layer_size} layers",
+            sketches.len(),
+            heaps.len()
+        )));
+    }
+    if candidate_complete.len() != layer_size {
+        return Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 UnivMon envelope: {} candidate flags over {layer_size} layers",
+            candidate_complete.len()
+        )));
+    }
+    let bucket_size = u64::try_from(bucket_size).map_err(|_| {
+        RmpEncodeError::Syntax(
+            "ASAPv1 UnivMon envelope: bucket_size exceeds the u64 payload field".to_string(),
+        )
+    })?;
+    let mut state = PyramidState {
+        counts: Vec::new(),
+        l2: Vec::new(),
+        heap_lens: Vec::with_capacity(layer_size),
+        entries: Vec::new(),
+        candidate_complete: candidate_complete.to_vec(),
+        bucket_size,
+        update_mode,
+    };
+    for (layer, &(rows, cols)) in geometry.iter().enumerate() {
+        let L2HH::COUNT(counter) = &sketches[layer];
+        if (counter.rows(), counter.cols()) != (rows, cols) {
+            return Err(RmpEncodeError::Syntax(format!(
+                "ASAPv1 UnivMon envelope: layer {layer} is {}x{} against the declared {rows}x{cols}",
+                counter.rows(),
+                counter.cols()
+            )));
+        }
+        if counter.seed_idx() != layer {
+            return Err(RmpEncodeError::Syntax(format!(
+                "ASAPv1 UnivMon envelope: layer {layer} hashes at seed index {}",
+                counter.seed_idx()
+            )));
+        }
+        let (counts, l2) = l2hh_wire::layer_state(counter)?;
+        state.counts.extend_from_slice(counts);
+        state.l2.extend_from_slice(l2);
+        let entries = heap_entries(&heaps[layer]);
+        state
+            .heap_lens
+            .push(u32::try_from(entries.len()).map_err(|_| {
+                RmpEncodeError::Syntax(format!(
+                    "ASAPv1 UnivMon envelope: layer {layer} holds more entries than u32 can name"
+                ))
+            })?);
+        state.entries.extend(entries);
+    }
+    Ok(state)
+}
+
+/// The `key_type` the payload will be written in, taken from the first key in
+/// emitted order across every layer. Rejects a 128-bit key outright; the
+/// homogeneity of the rest is enforced by [`encode_pyramid`].
+pub(crate) fn pyramid_key_type(
+    entries: &[(&HeapItem, i64)],
+) -> Result<&'static str, RmpEncodeError> {
+    match entries.first() {
+        None => Ok(EMPTY_KEY_TYPE),
+        Some((key, _)) => key_type_of(key).ok_or_else(|| {
+            RmpEncodeError::Syntax("ASAPv1 UnivMon: 128-bit keys are not wire types".to_string())
+        }),
+    }
+}
+
+fn mixed_variant_error(key_type: &str, key: &HeapItem) -> RmpEncodeError {
+    RmpEncodeError::Syntax(format!(
+        "ASAPv1 UnivMon: keys mix variants — key_type is {key_type}, but a {} key is held",
+        key_type_of(key).unwrap_or("128-bit")
+    ))
+}
+
+/// Packs the layers into the positional payload, with `keys` typed by
+/// `key_type`. Any key that is not of that variant fails the encode.
+pub(crate) fn encode_pyramid(
+    key_type: &str,
+    state: PyramidState<'_>,
+) -> Result<Vec<u8>, RmpEncodeError> {
+    let heap_counts: Vec<i64> = state.entries.iter().map(|entry| entry.1).collect();
+
+    macro_rules! pack {
+        ($variant:ident) => {{
+            let mut keys = Vec::with_capacity(state.entries.len());
+            for (key, _) in &state.entries {
+                match key {
+                    HeapItem::$variant(value) => keys.push(*value),
+                    _ => return Err(mixed_variant_error(key_type, key)),
+                }
+            }
+            rmp_serde::to_vec(&PyramidPayload {
+                counts: state.counts,
+                l2: state.l2,
+                heap_lens: state.heap_lens,
+                keys,
+                heap_counts,
+                candidate_complete: state.candidate_complete,
+                bucket_size: state.bucket_size,
+                update_mode: state.update_mode,
+            })
+        }};
+    }
+
+    match key_type {
+        "i8" => pack!(I8),
+        "i16" => pack!(I16),
+        "i32" => pack!(I32),
+        "i64" => pack!(I64),
+        "isize" => pack!(ISIZE),
+        "u8" => pack!(U8),
+        "u16" => pack!(U16),
+        "u32" => pack!(U32),
+        "u64" => pack!(U64),
+        "usize" => pack!(USIZE),
+        "f32" => pack!(F32),
+        "f64" => pack!(F64),
+        "string" => {
+            let mut keys = Vec::with_capacity(state.entries.len());
+            for (key, _) in &state.entries {
+                match key {
+                    HeapItem::String(value) => keys.push(value.clone()),
+                    _ => return Err(mixed_variant_error(key_type, key)),
+                }
+            }
+            rmp_serde::to_vec(&PyramidPayload {
+                counts: state.counts,
+                l2: state.l2,
+                heap_lens: state.heap_lens,
+                keys,
+                heap_counts,
+                candidate_complete: state.candidate_complete,
+                bucket_size: state.bucket_size,
+                update_mode: state.update_mode,
+            })
+        }
+        other => Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 UnivMon: key_type {other:?} is not a wire key type"
+        ))),
+    }
+}
+
+/// The layer state one pyramid payload decodes into.
+pub(crate) struct DecodedPyramid {
+    pub(crate) counts: Vec<i64>,
+    pub(crate) l2: Vec<i64>,
+    pub(crate) heap_lens: Vec<u32>,
+    pub(crate) entries: Vec<(HeapItem, i64)>,
+    pub(crate) candidate_complete: Vec<bool>,
+    pub(crate) bucket_size: u64,
+    pub(crate) update_mode: u8,
+}
+
+/// Reads the payload with `keys` typed by the metadata `key_type`. Rejects an
+/// unknown `key_type` and parallel arrays of unequal length; a `keys` array
+/// whose msgpack types do not match `key_type` fails in `from_slice`.
+pub(crate) fn decode_pyramid(
+    key_type: &str,
+    payload: &[u8],
+) -> Result<DecodedPyramid, RmpDecodeError> {
+    macro_rules! unpack {
+        ($variant:ident, $ty:ty) => {{
+            let decoded: PyramidPayload<$ty> = from_slice(payload)?;
+            (
+                decoded
+                    .keys
+                    .into_iter()
+                    .map(HeapItem::$variant)
+                    .collect::<Vec<HeapItem>>(),
+                DecodedPyramid {
+                    counts: decoded.counts,
+                    l2: decoded.l2,
+                    heap_lens: decoded.heap_lens,
+                    entries: Vec::new(),
+                    candidate_complete: decoded.candidate_complete,
+                    bucket_size: decoded.bucket_size,
+                    update_mode: decoded.update_mode,
+                },
+                decoded.heap_counts,
+            )
+        }};
+    }
+
+    let (keys, mut decoded, heap_counts) = match key_type {
+        "i8" => unpack!(I8, i8),
+        "i16" => unpack!(I16, i16),
+        "i32" => unpack!(I32, i32),
+        "i64" => unpack!(I64, i64),
+        "isize" => unpack!(ISIZE, isize),
+        "u8" => unpack!(U8, u8),
+        "u16" => unpack!(U16, u16),
+        "u32" => unpack!(U32, u32),
+        "u64" => unpack!(U64, u64),
+        "usize" => unpack!(USIZE, usize),
+        "f32" => unpack!(F32, f32),
+        "f64" => unpack!(F64, f64),
+        "string" => unpack!(String, String),
+        other => {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "ASAPv1 UnivMon: key_type {other:?} is not a wire key type"
+            )));
+        }
+    };
+
+    if keys.len() != heap_counts.len() {
+        return Err(RmpDecodeError::Uncategorized(format!(
+            "ASAPv1 UnivMon: {} keys against {} heap counts",
+            keys.len(),
+            heap_counts.len()
+        )));
+    }
+    decoded.entries = keys.into_iter().zip(heap_counts).collect();
+    Ok(decoded)
+}
+
+/// The counters and heaps one decoded pyramid rebuilds into.
+pub(crate) type DecodedLayers = (Vector1D<L2HH>, Vector1D<HHHeap>, Vec<bool>, usize, u8);
+
+/// Seats the decoded layers, rebuilding every counter matrix and heap index.
+///
+/// Each declared length is measured against what the payload actually carries
+/// before anything is sized from it, so neither a crafted geometry nor a
+/// crafted `heap_size` drives an allocation.
+pub(crate) fn rebuild_layers(
+    geometry: &[(usize, usize)],
+    heap_size: usize,
+    decoded: DecodedPyramid,
+) -> Result<DecodedLayers, RmpDecodeError> {
+    let layer_size = geometry.len();
+    let complain = |problem: String| RmpDecodeError::Uncategorized(problem);
+    if decoded.heap_lens.len() != layer_size {
+        return Err(complain(format!(
+            "UnivMon heap_lens length {} != layer_size {layer_size}",
+            decoded.heap_lens.len()
+        )));
+    }
+    if decoded.candidate_complete.len() != layer_size {
+        return Err(complain(format!(
+            "UnivMon candidate_complete length {} != layer_size {layer_size}",
+            decoded.candidate_complete.len()
+        )));
+    }
+    let mut cells = 0usize;
+    let mut accumulators = 0usize;
+    for &(rows, cols) in geometry {
+        l2hh_wire::check_dimensions(rows, cols).map_err(&complain)?;
+        cells = cells
+            .checked_add(rows.checked_mul(cols).ok_or_else(|| {
+                complain(format!("UnivMon layer geometry {rows}x{cols} overflows"))
+            })?)
+            .ok_or_else(|| complain("UnivMon total counter count overflows".to_string()))?;
+        accumulators = accumulators
+            .checked_add(rows)
+            .ok_or_else(|| complain("UnivMon total accumulator count overflows".to_string()))?;
+    }
+    if decoded.counts.len() != cells {
+        return Err(complain(format!(
+            "UnivMon counts length {} != the declared layers' {cells} cells",
+            decoded.counts.len()
+        )));
+    }
+    if decoded.l2.len() != accumulators {
+        return Err(complain(format!(
+            "UnivMon l2 length {} != the declared layers' {accumulators} rows",
+            decoded.l2.len()
+        )));
+    }
+    let mut seated = 0usize;
+    for &len in &decoded.heap_lens {
+        seated = seated
+            .checked_add(len as usize)
+            .ok_or_else(|| complain("UnivMon total heap entry count overflows".to_string()))?;
+    }
+    if decoded.entries.len() != seated {
+        return Err(complain(format!(
+            "UnivMon carries {} heap entries against the declared {seated}",
+            decoded.entries.len()
+        )));
+    }
+
+    let mut sketches = Vec::with_capacity(layer_size);
+    let mut heaps = Vec::with_capacity(layer_size);
+    let mut entries = decoded.entries.into_iter();
+    let (mut cell, mut accumulator) = (0usize, 0usize);
+    for (layer, &(rows, cols)) in geometry.iter().enumerate() {
+        let next_cell = cell + rows * cols;
+        let next_accumulator = accumulator + rows;
+        sketches.push(L2HH::COUNT(l2hh_wire::rebuild_layer::<DefaultXxHasher>(
+            rows,
+            cols,
+            layer,
+            &decoded.counts[cell..next_cell],
+            &decoded.l2[accumulator..next_accumulator],
+        )?));
+        cell = next_cell;
+        accumulator = next_accumulator;
+        let run: Vec<(HeapItem, i64)> = entries
+            .by_ref()
+            .take(decoded.heap_lens[layer] as usize)
+            .collect();
+        heaps.push(rebuild_heap(heap_size, run)?);
+    }
+    let bucket_size = usize::try_from(decoded.bucket_size)
+        .map_err(|_| complain("UnivMon bucket_size exceeds this target's usize".to_string()))?;
+    Ok((
+        Vector1D::from_vec(sketches),
+        Vector1D::from_vec(heaps),
+        decoded.candidate_complete,
+        bucket_size,
+        decoded.update_mode,
+    ))
+}
+
+// Wire serialization for UnivMon. `wire` is a descendant of the sketch module,
+// so this impl reads the private fields directly.
+impl UnivMon {
+    /// Serializes the pyramid into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x10 0x00`). The metadata is derived from
+    /// [`DefaultXxHasher`]'s [`HashProfile`], the hasher UnivMon is built on.
+    ///
+    /// Fails when a layer's geometry or seed index disagrees with the declared
+    /// pyramid, when the heaps' keys mix `HeapItem` variants or hold a 128-bit
+    /// key, or when a structural parameter overflows its `u32` metadata field.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let geometry = vec![(self.sketch_row, self.sketch_col); self.layer_size];
+        let state = pyramid_state(
+            &self.l2_sketch_layers,
+            &self.hh_layers,
+            &geometry,
+            self.bucket_size,
+            update_mode_tag(self.update_mode),
+            &self.candidate_complete,
+        )?;
+        let key_type = pyramid_key_type(&state.entries)?;
+        let field = |name: &str, value: usize| {
+            u32::try_from(value).map_err(|_| {
+                RmpEncodeError::Syntax(format!(
+                    "ASAPv1 UnivMon envelope: {name} {value} exceeds the u32 metadata field"
+                ))
+            })
+        };
+        let metadata = rmp_serde::to_vec_named(&univmon_metadata::<DefaultXxHasher>(
+            field("layer_size", self.layer_size)?,
+            field("sketch_row", self.sketch_row)?,
+            field("sketch_col", self.sketch_col)?,
+            field("heap_size", self.heap_size)?,
+            key_type,
+        ))?;
+        let payload = encode_pyramid(key_type, state)?;
+        Ok(envelope::encode(UNIVMON_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a pyramid from an ASAPv1 MessagePack envelope. The shape
+    /// and `key_type` are structural (they are properties of the stored
+    /// sketch), so they are echoed back into the expected metadata; the hash
+    /// spec is pinned against [`DefaultXxHasher`].
+    ///
+    /// Every state the algorithm could not have produced is rejected with an
+    /// error rather than a panic, and no declared count sizes an allocation
+    /// before the payload is measured against it.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != UNIVMON_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UnivMon kind_id mismatch: stored {kind_id:?}, expected {UNIVMON_KIND:?}"
+            )));
+        }
+        let meta: UnivMonMetadata = from_slice(metadata)?;
+        if meta
+            != univmon_metadata::<DefaultXxHasher>(
+                meta.layer_size,
+                meta.sketch_row,
+                meta.sketch_col,
+                meta.heap_size,
+                &meta.key_type,
+            )
+        {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 UnivMon envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let (layer_size, sketch_row, sketch_col, heap_size) = (
+            meta.layer_size as usize,
+            meta.sketch_row as usize,
+            meta.sketch_col as usize,
+            meta.heap_size as usize,
+        );
+        if layer_size == 0 || heap_size == 0 {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UnivMon layer_size and heap_size must be non-zero: layer_size={layer_size}, heap_size={heap_size}"
+            )));
+        }
+        let decoded = decode_pyramid(&meta.key_type, payload)?;
+        // The declared layer count is measured against the accumulators the
+        // payload actually carries before the geometry is built from it.
+        if sketch_row.checked_mul(layer_size) != Some(decoded.l2.len()) {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UnivMon declares {layer_size} layers of {sketch_row} rows against a payload carrying {} accumulators",
+                decoded.l2.len()
+            )));
+        }
+        let geometry = vec![(sketch_row, sketch_col); layer_size];
+        let (l2_sketch_layers, hh_layers, candidate_complete, bucket_size, mode_tag) =
+            rebuild_layers(&geometry, heap_size, decoded)?;
+        Ok(UnivMon {
+            l2_sketch_layers,
+            hh_layers,
+            layer_size,
+            sketch_row,
+            sketch_col,
+            heap_size,
+            bucket_size,
+            update_mode: update_mode_of(mode_tag)?,
+            candidate_complete,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CANONICAL_HASH_SEED, DataInput, RegularPath, SketchHasher, Vector2D};
+
+    fn populated() -> UnivMon {
+        let mut um = UnivMon::init_univmon(4, 2, 16, 3);
+        for (key, weight) in [("alpha", 5i64), ("beta", 7), ("gamma", 9), ("delta", 11)] {
+            um.insert(&DataInput::Str(key), weight);
+        }
+        um
+    }
+
+    fn metadata_of(bytes: &[u8]) -> UnivMonMetadata {
+        let (_, metadata, _) = envelope::split(bytes).expect("split");
+        from_slice(metadata).expect("metadata")
+    }
+
+    fn crafted<K: Serialize>(meta: &UnivMonMetadata, payload: &PyramidPayload<K>) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(meta).expect("metadata");
+        let payload = rmp_serde::to_vec(payload).expect("payload");
+        envelope::encode(UNIVMON_KIND, &metadata, &payload)
+    }
+
+    fn payload_of<K: for<'de> Deserialize<'de>>(bytes: &[u8]) -> PyramidPayload<K> {
+        let (_, _, payload) = envelope::split(bytes).expect("split");
+        from_slice(payload).expect("payload")
+    }
+
+    #[test]
+    fn univmon_round_trip_serialization() {
+        let um = populated();
+        let encoded = um.serialize_to_bytes().expect("serialize UnivMon");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x10, 0x00]); // kind_id_len=2, kind_id=[0x10,0x00]
+
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.metadata_version, 1);
+        assert_eq!(
+            (
+                meta.layer_size,
+                meta.sketch_row,
+                meta.sketch_col,
+                meta.heap_size
+            ),
+            (3, 2, 16, 4)
+        );
+        assert_eq!(meta.key_type, "string");
+
+        let decoded = UnivMon::deserialize_from_bytes(&encoded).expect("deserialize UnivMon");
+        assert_eq!(decoded.layer_size, um.layer_size);
+        assert_eq!(decoded.bucket_size, um.bucket_size);
+        assert_eq!(decoded.calc_l1(), um.calc_l1());
+        assert_eq!(decoded.calc_l2(), um.calc_l2());
+        assert_eq!(decoded.calc_card(), um.calc_card());
+        assert_eq!(decoded.calc_entropy(), um.calc_entropy());
+        assert_eq!(decoded.candidates_complete(), um.candidates_complete());
+        assert_eq!(
+            decoded.serialize_to_bytes().expect("re-serialize"),
+            encoded,
+            "a decoded pyramid re-serialized to different bytes"
+        );
+    }
+
+    /// Layers hold different numbers of entries: each layer's heap contents
+    /// and emitted order survive the round trip.
+    #[test]
+    fn univmon_layers_with_different_heap_loads_round_trip() {
+        let mut um = UnivMon::init_univmon(8, 2, 16, 4);
+        for key in 0..40u64 {
+            um.insert(&DataInput::U64(key), 1 + (key as i64 % 5));
+        }
+        let loads: Vec<usize> = (0..um.layer_size).map(|i| um.hh_layers[i].len()).collect();
+        assert!(
+            loads.windows(2).any(|pair| pair[0] != pair[1]),
+            "expected layers of different heap loads, got {loads:?}"
+        );
+
+        let encoded = um.serialize_to_bytes().expect("serialize");
+        let decoded = UnivMon::deserialize_from_bytes(&encoded).expect("decode");
+        for layer in 0..um.layer_size {
+            let (original, rebuilt) = (&um.hh_layers[layer], &decoded.hh_layers[layer]);
+            assert_eq!(original.len(), rebuilt.len(), "layer {layer} lost entries");
+            assert_eq!(rebuilt.capacity(), 8);
+            for item in original.heap() {
+                let found = rebuilt
+                    .find_heap_item(&item.key)
+                    .unwrap_or_else(|| panic!("layer {layer} lost {:?}", item.key));
+                assert_eq!(rebuilt.heap()[found].count, item.count);
+            }
+        }
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// `update_mode` and `candidate_complete` are state, not derived: a
+    /// terminal-only pyramid and an incomplete candidate set both survive.
+    #[test]
+    fn univmon_carries_update_mode_and_candidate_flags() {
+        let mut terminal = UnivMon::init_univmon(2, 2, 8, 3);
+        for key in 0..20u64 {
+            terminal.fast_insert(&DataInput::U64(key), 3);
+        }
+        assert!(
+            terminal.candidates_complete().iter().any(|&flag| !flag),
+            "expected an evicting layer"
+        );
+        let encoded = terminal.serialize_to_bytes().expect("serialize");
+        assert_eq!(payload_of::<u64>(&encoded).update_mode, 2);
+
+        let decoded = UnivMon::deserialize_from_bytes(&encoded).expect("decode");
+        assert_eq!(
+            decoded.candidates_complete(),
+            terminal.candidates_complete()
+        );
+        assert_eq!(decoded.calc_card(), terminal.calc_card());
+        assert_eq!(decoded.calc_entropy(), terminal.calc_entropy());
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+
+        // A layer marked incomplete keeps its widened threshold: flipping the
+        // flag changes what the pyramid reports.
+        let mut forged = payload_of::<u64>(&encoded);
+        forged.candidate_complete.fill(true);
+        let meta = metadata_of(&encoded);
+        let relaxed = UnivMon::deserialize_from_bytes(&crafted(&meta, &forged)).expect("decode");
+        assert_ne!(
+            relaxed.calc_card(),
+            terminal.calc_card(),
+            "candidate_complete had no effect on a query"
+        );
+    }
+
+    /// An empty pyramid has exactly one encoding, and its heaps decode empty.
+    #[test]
+    fn univmon_empty_has_one_encoding() {
+        let left = UnivMon::init_univmon(4, 2, 16, 3);
+        let mut right = UnivMon::init_univmon(4, 2, 16, 3);
+        right.insert(&DataInput::Str("alpha"), 5);
+        right.free();
+
+        let encoded = left.serialize_to_bytes().expect("serialize");
+        assert_eq!(right.serialize_to_bytes().expect("serialize"), encoded);
+        assert_eq!(metadata_of(&encoded).key_type, EMPTY_KEY_TYPE);
+
+        let decoded = UnivMon::deserialize_from_bytes(&encoded).expect("decode");
+        assert!((0..3).all(|layer| decoded.hh_layers[layer].is_empty()));
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    // A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    // declares a DIFFERENT `HashProfile`.
+    #[derive(Clone, Debug)]
+    struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    /// UnivMon hashes through the crate default, so it has one truthful
+    /// profile: (a) it emits that profile, (b) a custom-profile envelope is
+    /// different bytes, and (c) decode fails closed on it.
+    #[test]
+    fn univmon_pins_its_hash_profile() {
+        let um = populated();
+        let encoded = um.serialize_to_bytes().expect("serialize");
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.hash_profile_id, DefaultXxHasher::PROFILE_ID);
+        assert_eq!(meta.seed_list, DefaultXxHasher::seed_list());
+
+        let alt = univmon_metadata::<AltHasher>(
+            meta.layer_size,
+            meta.sketch_row,
+            meta.sketch_col,
+            meta.heap_size,
+            &meta.key_type,
+        );
+        let (_, _, payload) = envelope::split(&encoded).expect("split");
+        let forged = envelope::encode(
+            UNIVMON_KIND,
+            &rmp_serde::to_vec_named(&alt).expect("metadata"),
+            payload,
+        );
+        assert_ne!(forged, encoded);
+        assert!(
+            UnivMon::deserialize_from_bytes(&forged).is_err(),
+            "a custom-profile envelope must be rejected"
+        );
+    }
+
+    /// Each family's envelope is rejected by the other three, and by a plain
+    /// Count Sketch envelope.
+    #[test]
+    fn univmon_rejects_foreign_kind_ids() {
+        let count_sketch = crate::Count::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8)
+            .serialize_to_bytes()
+            .expect("serialize Count Sketch");
+        let count_l2hh =
+            crate::sketches::countsketch_topk::CountL2HH::<DefaultXxHasher>::with_dimensions(2, 8)
+                .serialize_to_bytes()
+                .expect("serialize CountL2HH");
+        let pyramid = crate::UnivMonPyramid::new(4, 1, 2, 8, 2, 4, 2)
+            .serialize_to_bytes()
+            .expect("serialize UnivMonPyramid");
+        let univmon_q = crate::UnivMonQ::new(crate::UnivMonQConfig {
+            levels: 2,
+            width: 8,
+            depth: 3,
+            candidates: 4,
+            ordered_samples: 4,
+            ..Default::default()
+        })
+        .expect("config")
+        .serialize_to_bytes()
+        .expect("serialize UnivMonQ");
+
+        for foreign in [count_sketch, count_l2hh, pyramid, univmon_q] {
+            assert!(
+                UnivMon::deserialize_from_bytes(&foreign).is_err(),
+                "a foreign envelope must not decode as a UnivMon"
+            );
+        }
+    }
+
+    /// Fail closed (not panic) on crafted geometry, layer counts and heap
+    /// capacities, including a `layer_size` far larger than the payload
+    /// carries. Every check precedes an allocation.
+    #[test]
+    fn univmon_rejects_crafted_shapes() {
+        let encoded = populated().serialize_to_bytes().expect("serialize");
+        let base = metadata_of(&encoded);
+        let payload = payload_of::<String>(&encoded);
+
+        let shaped = |layer_size, sketch_row, sketch_col, heap_size| UnivMonMetadata {
+            layer_size,
+            sketch_row,
+            sketch_col,
+            heap_size,
+            ..univmon_metadata::<DefaultXxHasher>(0, 0, 0, 0, &base.key_type)
+        };
+        let cases = [
+            shaped(u32::MAX, 2, 16, 4),
+            shaped(3, 2, 0, 4),
+            shaped(0, 2, 16, 4),
+            shaped(3, 2, 16, 0),
+            shaped(3, 4096, 4096, 4),
+            shaped(3, 2, 16, 1),
+        ];
+        for meta in cases {
+            assert!(
+                UnivMon::deserialize_from_bytes(&crafted(&meta, &payload)).is_err(),
+                "a crafted shape must be rejected, not decoded"
+            );
+        }
+
+        // Parallel arrays and per-layer runs must agree with the declared
+        // pyramid.
+        let mut short = payload_of::<String>(&encoded);
+        short.heap_counts.pop();
+        assert!(UnivMon::deserialize_from_bytes(&crafted(&base, &short)).is_err());
+
+        let mut flags = payload_of::<String>(&encoded);
+        flags.candidate_complete.pop();
+        assert!(UnivMon::deserialize_from_bytes(&crafted(&base, &flags)).is_err());
+
+        let mut mode = payload_of::<String>(&encoded);
+        mode.update_mode = 7;
+        assert!(UnivMon::deserialize_from_bytes(&crafted(&base, &mode)).is_err());
+    }
+
+    /// A pyramid whose layers disagree with their declared geometry, seed
+    /// index or key variants must not serialize.
+    #[test]
+    fn univmon_rejects_serializing_an_inconsistent_pyramid() {
+        let mut wrong_layer = UnivMon::init_univmon(4, 2, 16, 3);
+        wrong_layer.l2_sketch_layers[1] = L2HH::COUNT(
+            crate::sketches::countsketch_topk::CountL2HH::with_dimensions_and_seed(2, 16, 1),
+        );
+        assert!(wrong_layer.serialize_to_bytes().is_ok());
+
+        wrong_layer.l2_sketch_layers[1] = L2HH::COUNT(
+            crate::sketches::countsketch_topk::CountL2HH::with_dimensions_and_seed(2, 32, 1),
+        );
+        assert!(
+            wrong_layer.serialize_to_bytes().is_err(),
+            "a layer that is not the declared size must not serialize"
+        );
+
+        let mut wrong_seed = UnivMon::init_univmon(4, 2, 16, 3);
+        wrong_seed.l2_sketch_layers[1] = L2HH::COUNT(
+            crate::sketches::countsketch_topk::CountL2HH::with_dimensions_and_seed(2, 16, 5),
+        );
+        assert!(
+            wrong_seed.serialize_to_bytes().is_err(),
+            "a layer hashing at another layer's seed index must not serialize"
+        );
+
+        let mut mixed = UnivMon::init_univmon(4, 2, 16, 3);
+        mixed.hh_layers[0].update(&DataInput::U64(1), 5);
+        mixed.hh_layers[0].update(&DataInput::Str("two"), 3);
+        let problem = mixed
+            .serialize_to_bytes()
+            .expect_err("a pyramid mixing key variants must not serialize")
+            .to_string();
+        assert!(problem.contains("keys mix variants"), "got {problem}");
+
+        let mut wide = UnivMon::init_univmon(4, 2, 16, 3);
+        wide.hh_layers[0].update(&DataInput::U128(1), 5);
+        assert!(
+            wide.serialize_to_bytes().is_err(),
+            "a 128-bit key is not a wire type"
+        );
+    }
+    /// Fail closed on an unexpected metadata key, and on a missing required
+    /// one.
+    #[test]
+    fn univmon_metadata_rejects_unknown_and_missing_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            layer_size: u32,
+            sketch_row: u32,
+            sketch_col: u32,
+            heap_size: u32,
+            key_type: String,
+            bogus_field: u8, // key not in UnivMonMetadata
+        }
+        #[derive(Serialize)]
+        struct WithoutKeyType {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            layer_size: u32,
+            sketch_row: u32,
+            sketch_col: u32,
+            heap_size: u32,
+        }
+        let m = univmon_metadata::<DefaultXxHasher>(3, 2, 16, 4, "u64");
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            layer_size: m.layer_size,
+            sketch_row: m.sketch_row,
+            sketch_col: m.sketch_col,
+            heap_size: m.heap_size,
+            key_type: m.key_type.clone(),
+            bogus_field: 7,
+        };
+        let without = WithoutKeyType {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            layer_size: m.layer_size,
+            sketch_row: m.sketch_row,
+            sketch_col: m.sketch_col,
+            heap_size: m.heap_size,
+        };
+        assert!(
+            from_slice::<UnivMonMetadata>(&rmp_serde::to_vec_named(&extra).unwrap()).is_err(),
+            "an unknown metadata key must be rejected"
+        );
+        assert!(
+            from_slice::<UnivMonMetadata>(&rmp_serde::to_vec_named(&without).unwrap()).is_err(),
+            "a missing required key must be rejected"
+        );
+    }
+}

--- a/src/sketch_framework/univmon_optimized.rs
+++ b/src/sketch_framework/univmon_optimized.rs
@@ -16,6 +16,8 @@ use crate::sketch_framework::univmon::UnivMonUpdateMode;
 use crate::sketches::countsketch_topk::CountL2HH;
 use std::collections::{HashMap, HashSet};
 
+mod wire;
+
 /// Object pool for `UnivMon` sketches.
 ///
 /// Maintains a free-list of pre-allocated sketches. Callers take ownership

--- a/src/sketch_framework/univmon_optimized/wire.rs
+++ b/src/sketch_framework/univmon_optimized/wire.rs
@@ -1,0 +1,676 @@
+//! ASAPv1 wire serialization for [`UnivMonPyramid`].
+//!
+//! Child submodule of [`crate::sketch_framework::univmon_optimized`]: it holds
+//! the metadata DTO, the kind_id constant and the `serialize_to_bytes` /
+//! `deserialize_from_bytes` impls, while the algorithm lives in the parent
+//! module file. Being a descendant module, it reads the private `update_mode`
+//! and `candidate_complete` fields directly without widening any field
+//! visibility. See `docs/asapv1_wire_format.md`.
+//!
+//! UnivMon Optimized is one algorithm — a single kind_id `0x11 0x00`. It
+//! shares [`UnivMon`](crate::UnivMon)'s payload
+//! (`[counts, l2, heap_lens, keys, heap_counts, candidate_complete,
+//! bucket_size, update_mode]`) and differs only in its metadata: the two-tier
+//! layout gives layer `i` the elephant dimensions while `i < elephant_layers`
+//! and the mouse dimensions after, so every per-layer geometry is derived and
+//! none is stored.
+//!
+//! [`UnivSketchPool`](super::UnivSketchPool) is a free-list of scratch
+//! `UnivMon`s rather than a sketch, and has no wire kind.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+use crate::sketch_framework::univmon::wire::{
+    decode_pyramid, encode_pyramid, pyramid_key_type, pyramid_state, rebuild_layers,
+    update_mode_of, update_mode_tag,
+};
+use crate::{DefaultXxHasher, HashProfile};
+
+use super::UnivMonPyramid;
+
+/// UnivMon Optimized kind_id: family `0x11`, single algorithm variant `0x00`.
+const PYRAMID_KIND: &[u8] = &[0x11, 0x00];
+
+/// UnivMonPyramid descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`) with keys in this declaration order — the canonical order
+/// the wire spec fixes (Go must mirror it). Hash-spec fields first, then the
+/// two-tier layout and the heaps' `key_type`.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PyramidMetadata {
+    pub(crate) metadata_version: u8,
+    pub(crate) hash_profile_id: String,
+    pub(crate) hash_algorithm: String,
+    pub(crate) seed_derivation: String,
+    pub(crate) input_encoding: String,
+    pub(crate) seed_list: Vec<u64>,
+    pub(crate) layer_size: u32,
+    pub(crate) elephant_layers: u32,
+    pub(crate) elephant_row: u32,
+    pub(crate) elephant_col: u32,
+    pub(crate) mouse_row: u32,
+    pub(crate) mouse_col: u32,
+    pub(crate) heap_size: u32,
+    pub(crate) key_type: String,
+}
+
+/// The five layout fields, in the order the metadata carries them.
+pub(crate) struct PyramidLayout {
+    pub(crate) elephant_layers: u32,
+    pub(crate) elephant_row: u32,
+    pub(crate) elephant_col: u32,
+    pub(crate) mouse_row: u32,
+    pub(crate) mouse_col: u32,
+}
+
+/// Builds the UnivMonPyramid descriptor metadata from the hasher's
+/// [`HashProfile`], so the wire bytes truthfully describe how the sketch was
+/// hashed.
+pub(crate) fn pyramid_metadata<H: HashProfile>(
+    layer_size: u32,
+    layout: &PyramidLayout,
+    heap_size: u32,
+    key_type: &str,
+) -> PyramidMetadata {
+    PyramidMetadata {
+        metadata_version: 1,
+        hash_profile_id: H::PROFILE_ID.to_string(),
+        hash_algorithm: H::ALGORITHM.to_string(),
+        seed_derivation: H::SEED_DERIVATION.to_string(),
+        input_encoding: H::INPUT_ENCODING.to_string(),
+        seed_list: H::seed_list(),
+        layer_size,
+        elephant_layers: layout.elephant_layers,
+        elephant_row: layout.elephant_row,
+        elephant_col: layout.elephant_col,
+        mouse_row: layout.mouse_row,
+        mouse_col: layout.mouse_col,
+        heap_size,
+        key_type: key_type.to_string(),
+    }
+}
+
+/// Per-layer `(rows, cols)`: elephant while `layer < elephant_layers`, mouse
+/// after.
+fn geometry_of(layer_size: usize, layout: &PyramidLayout) -> Vec<(usize, usize)> {
+    (0..layer_size)
+        .map(|layer| {
+            if layer < layout.elephant_layers as usize {
+                (layout.elephant_row as usize, layout.elephant_col as usize)
+            } else {
+                (layout.mouse_row as usize, layout.mouse_col as usize)
+            }
+        })
+        .collect()
+}
+
+/// Total accumulators the declared layout implies, one per row per layer.
+fn accumulator_count(layer_size: usize, layout: &PyramidLayout) -> Option<usize> {
+    let elephants = layer_size.min(layout.elephant_layers as usize);
+    let mice = layer_size - elephants;
+    elephants
+        .checked_mul(layout.elephant_row as usize)?
+        .checked_add(mice.checked_mul(layout.mouse_row as usize)?)
+}
+
+// Wire serialization for UnivMonPyramid. `wire` is a descendant of the sketch
+// module, so this impl reads the private fields directly.
+impl UnivMonPyramid {
+    /// Serializes the pyramid into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x11 0x00`). The metadata is derived from
+    /// [`DefaultXxHasher`]'s [`HashProfile`], the hasher the pyramid is built
+    /// on.
+    ///
+    /// Fails when a layer's geometry or seed index disagrees with the declared
+    /// layout, when the heaps' keys mix `HeapItem` variants or hold a 128-bit
+    /// key, or when a structural parameter overflows its `u32` metadata field.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let field = |name: &str, value: usize| {
+            u32::try_from(value).map_err(|_| {
+                RmpEncodeError::Syntax(format!(
+                    "ASAPv1 UnivMonPyramid envelope: {name} {value} exceeds the u32 metadata field"
+                ))
+            })
+        };
+        let layout = PyramidLayout {
+            elephant_layers: field("elephant_layers", self.elephant_layers)?,
+            elephant_row: field("elephant_row", self.elephant_row)?,
+            elephant_col: field("elephant_col", self.elephant_col)?,
+            mouse_row: field("mouse_row", self.mouse_row)?,
+            mouse_col: field("mouse_col", self.mouse_col)?,
+        };
+        let geometry = geometry_of(self.layer_size, &layout);
+        let state = pyramid_state(
+            &self.l2_sketch_layers,
+            &self.hh_layers,
+            &geometry,
+            self.bucket_size,
+            update_mode_tag(self.update_mode),
+            &self.candidate_complete,
+        )?;
+        let key_type = pyramid_key_type(&state.entries)?;
+        let metadata = rmp_serde::to_vec_named(&pyramid_metadata::<DefaultXxHasher>(
+            field("layer_size", self.layer_size)?,
+            &layout,
+            field("heap_size", self.heap_size)?,
+            key_type,
+        ))?;
+        let payload = encode_pyramid(key_type, state)?;
+        Ok(envelope::encode(PYRAMID_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a pyramid from an ASAPv1 MessagePack envelope. The layout
+    /// and `key_type` are structural (they are properties of the stored
+    /// sketch), so they are echoed back into the expected metadata; the hash
+    /// spec is pinned against [`DefaultXxHasher`].
+    ///
+    /// Every state the algorithm could not have produced is rejected with an
+    /// error rather than a panic, and no declared count sizes an allocation
+    /// before the payload is measured against it.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != PYRAMID_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UnivMonPyramid kind_id mismatch: stored {kind_id:?}, expected {PYRAMID_KIND:?}"
+            )));
+        }
+        let meta: PyramidMetadata = from_slice(metadata)?;
+        let layout = PyramidLayout {
+            elephant_layers: meta.elephant_layers,
+            elephant_row: meta.elephant_row,
+            elephant_col: meta.elephant_col,
+            mouse_row: meta.mouse_row,
+            mouse_col: meta.mouse_col,
+        };
+        if meta
+            != pyramid_metadata::<DefaultXxHasher>(
+                meta.layer_size,
+                &layout,
+                meta.heap_size,
+                &meta.key_type,
+            )
+        {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 UnivMonPyramid envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let (layer_size, heap_size) = (meta.layer_size as usize, meta.heap_size as usize);
+        if layer_size == 0 || heap_size == 0 {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UnivMonPyramid layer_size and heap_size must be non-zero: layer_size={layer_size}, heap_size={heap_size}"
+            )));
+        }
+        let decoded = decode_pyramid(&meta.key_type, payload)?;
+        // The declared layout is measured against the accumulators the payload
+        // actually carries before the geometry is built from it.
+        if accumulator_count(layer_size, &layout) != Some(decoded.l2.len()) {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "UnivMonPyramid declares a layout the payload's {} accumulators do not match",
+                decoded.l2.len()
+            )));
+        }
+        let geometry = geometry_of(layer_size, &layout);
+        let (l2_sketch_layers, hh_layers, candidate_complete, bucket_size, mode_tag) =
+            rebuild_layers(&geometry, heap_size, decoded)?;
+        Ok(UnivMonPyramid {
+            l2_sketch_layers,
+            hh_layers,
+            layer_size,
+            elephant_layers: meta.elephant_layers as usize,
+            elephant_row: meta.elephant_row as usize,
+            elephant_col: meta.elephant_col as usize,
+            mouse_row: meta.mouse_row as usize,
+            mouse_col: meta.mouse_col as usize,
+            heap_size,
+            bucket_size,
+            update_mode: update_mode_of(mode_tag)?,
+            candidate_complete,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sketch_framework::univmon::wire::PyramidPayload;
+    use crate::sketches::countsketch_topk::CountL2HH;
+    use crate::{
+        CANONICAL_HASH_SEED, DataInput, HeapItem, L2HH, RegularPath, SketchHasher, Vector2D,
+    };
+
+    fn populated() -> UnivMonPyramid {
+        let mut pyramid = UnivMonPyramid::new(4, 2, 3, 16, 2, 8, 4);
+        for (key, weight) in [("alpha", 5i64), ("beta", 7), ("gamma", 9), ("delta", 11)] {
+            pyramid.insert(&DataInput::Str(key), weight);
+        }
+        pyramid
+    }
+
+    fn metadata_of(bytes: &[u8]) -> PyramidMetadata {
+        let (_, metadata, _) = envelope::split(bytes).expect("split");
+        from_slice(metadata).expect("metadata")
+    }
+
+    fn payload_of<K: for<'de> Deserialize<'de>>(bytes: &[u8]) -> PyramidPayload<K> {
+        let (_, _, payload) = envelope::split(bytes).expect("split");
+        from_slice(payload).expect("payload")
+    }
+
+    fn crafted<K: Serialize>(meta: &PyramidMetadata, payload: &PyramidPayload<K>) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(meta).expect("metadata");
+        let payload = rmp_serde::to_vec(payload).expect("payload");
+        envelope::encode(PYRAMID_KIND, &metadata, &payload)
+    }
+
+    #[test]
+    fn pyramid_round_trip_serialization() {
+        let pyramid = populated();
+        let encoded = pyramid.serialize_to_bytes().expect("serialize");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x11, 0x00]); // kind_id_len=2, kind_id=[0x11,0x00]
+
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.metadata_version, 1);
+        assert_eq!(
+            (
+                meta.layer_size,
+                meta.elephant_layers,
+                meta.elephant_row,
+                meta.elephant_col,
+                meta.mouse_row,
+                meta.mouse_col,
+                meta.heap_size,
+            ),
+            (4, 2, 3, 16, 2, 8, 4)
+        );
+        assert_eq!(meta.key_type, "string");
+
+        let decoded = UnivMonPyramid::deserialize_from_bytes(&encoded).expect("deserialize");
+        assert_eq!(decoded.bucket_size, pyramid.bucket_size);
+        assert_eq!(decoded.calc_l1(), pyramid.calc_l1());
+        assert_eq!(decoded.calc_l2(), pyramid.calc_l2());
+        assert_eq!(decoded.calc_card(), pyramid.calc_card());
+        assert_eq!(decoded.calc_entropy(), pyramid.calc_entropy());
+        assert_eq!(decoded.candidate_complete, pyramid.candidate_complete);
+        assert_eq!(
+            decoded.serialize_to_bytes().expect("re-serialize"),
+            encoded,
+            "a decoded pyramid re-serialized to different bytes"
+        );
+    }
+
+    /// The two tiers are derived from the layer's position: the elephant
+    /// layers keep their dimensions and the mouse layers keep theirs.
+    #[test]
+    fn pyramid_two_tier_geometry_survives() {
+        let pyramid = populated();
+        let encoded = pyramid.serialize_to_bytes().expect("serialize");
+        let decoded = UnivMonPyramid::deserialize_from_bytes(&encoded).expect("decode");
+        for layer in 0..pyramid.layer_size {
+            let L2HH::COUNT(original) = &pyramid.l2_sketch_layers[layer];
+            let L2HH::COUNT(rebuilt) = &decoded.l2_sketch_layers[layer];
+            let expected = if layer < 2 { (3, 16) } else { (2, 8) };
+            assert_eq!((rebuilt.rows(), rebuilt.cols()), expected);
+            assert_eq!(rebuilt.seed_idx(), layer);
+            assert_eq!(
+                original.as_storage().as_slice(),
+                rebuilt.as_storage().as_slice()
+            );
+        }
+    }
+
+    /// Layers hold different numbers of entries: each layer's heap contents
+    /// survive the round trip.
+    #[test]
+    fn pyramid_layers_with_different_heap_loads_round_trip() {
+        let mut pyramid = UnivMonPyramid::new(8, 2, 3, 32, 2, 16, 4);
+        for key in 0..40u64 {
+            pyramid.insert(&DataInput::U64(key), 1 + (key as i64 % 5));
+        }
+        let loads: Vec<usize> = (0..pyramid.layer_size)
+            .map(|i| pyramid.hh_layers[i].len())
+            .collect();
+        assert!(
+            loads.windows(2).any(|pair| pair[0] != pair[1]),
+            "expected layers of different heap loads, got {loads:?}"
+        );
+
+        let encoded = pyramid.serialize_to_bytes().expect("serialize");
+        let decoded = UnivMonPyramid::deserialize_from_bytes(&encoded).expect("decode");
+        for layer in 0..pyramid.layer_size {
+            let (original, rebuilt) = (&pyramid.hh_layers[layer], &decoded.hh_layers[layer]);
+            assert_eq!(original.len(), rebuilt.len(), "layer {layer} lost entries");
+            for item in original.heap() {
+                let found = rebuilt
+                    .find_heap_item(&item.key)
+                    .unwrap_or_else(|| panic!("layer {layer} lost {:?}", item.key));
+                assert_eq!(rebuilt.heap()[found].count, item.count);
+            }
+        }
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// A pyramid with no mouse layers is the one-tier case and still
+    /// round-trips.
+    #[test]
+    fn pyramid_without_mouse_layers_round_trips() {
+        let mut pyramid = UnivMonPyramid::new(4, 4, 2, 16, 2, 8, 3);
+        pyramid.insert(&DataInput::U64(7), 3);
+        let encoded = pyramid.serialize_to_bytes().expect("serialize");
+        let decoded = UnivMonPyramid::deserialize_from_bytes(&encoded).expect("decode");
+        for layer in 0..3 {
+            let L2HH::COUNT(rebuilt) = &decoded.l2_sketch_layers[layer];
+            assert_eq!((rebuilt.rows(), rebuilt.cols()), (2, 16));
+        }
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// An empty pyramid has exactly one encoding.
+    #[test]
+    fn pyramid_empty_has_one_encoding() {
+        let left = UnivMonPyramid::new(4, 2, 3, 16, 2, 8, 4);
+        let mut right = UnivMonPyramid::new(4, 2, 3, 16, 2, 8, 4);
+        right.insert(&DataInput::Str("alpha"), 5);
+        right.free();
+        let encoded = left.serialize_to_bytes().expect("serialize");
+        assert_eq!(right.serialize_to_bytes().expect("serialize"), encoded);
+        assert_eq!(metadata_of(&encoded).key_type, "u64");
+
+        let decoded = UnivMonPyramid::deserialize_from_bytes(&encoded).expect("decode");
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// `update_mode` and `candidate_complete` are state, not derived.
+    #[test]
+    fn pyramid_carries_update_mode_and_candidate_flags() {
+        let mut terminal = UnivMonPyramid::new(2, 1, 2, 8, 2, 8, 3);
+        for key in 0..20u64 {
+            terminal.fast_insert(&DataInput::U64(key), 3);
+        }
+        assert!(
+            terminal.candidate_complete.iter().any(|&flag| !flag),
+            "expected an evicting layer"
+        );
+        let encoded = terminal.serialize_to_bytes().expect("serialize");
+        assert_eq!(payload_of::<u64>(&encoded).update_mode, 2);
+
+        let decoded = UnivMonPyramid::deserialize_from_bytes(&encoded).expect("decode");
+        assert_eq!(decoded.candidate_complete, terminal.candidate_complete);
+        assert_eq!(decoded.calc_card(), terminal.calc_card());
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    // A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    // declares a DIFFERENT `HashProfile`.
+    #[derive(Clone, Debug)]
+    struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    /// The pyramid hashes through the crate default, so it has one truthful
+    /// profile: (a) it emits that profile, (b) a custom-profile envelope is
+    /// different bytes, and (c) decode fails closed on it.
+    #[test]
+    fn pyramid_pins_its_hash_profile() {
+        let encoded = populated().serialize_to_bytes().expect("serialize");
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.hash_profile_id, DefaultXxHasher::PROFILE_ID);
+        assert_eq!(meta.seed_list, DefaultXxHasher::seed_list());
+
+        let layout = PyramidLayout {
+            elephant_layers: meta.elephant_layers,
+            elephant_row: meta.elephant_row,
+            elephant_col: meta.elephant_col,
+            mouse_row: meta.mouse_row,
+            mouse_col: meta.mouse_col,
+        };
+        let alt =
+            pyramid_metadata::<AltHasher>(meta.layer_size, &layout, meta.heap_size, &meta.key_type);
+        let (_, _, payload) = envelope::split(&encoded).expect("split");
+        let forged = envelope::encode(
+            PYRAMID_KIND,
+            &rmp_serde::to_vec_named(&alt).expect("metadata"),
+            payload,
+        );
+        assert_ne!(forged, encoded);
+        assert!(
+            UnivMonPyramid::deserialize_from_bytes(&forged).is_err(),
+            "a custom-profile envelope must be rejected"
+        );
+    }
+
+    /// Each family's envelope is rejected by the other three, and by a plain
+    /// Count Sketch envelope.
+    #[test]
+    fn pyramid_rejects_foreign_kind_ids() {
+        let count_sketch = crate::Count::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8)
+            .serialize_to_bytes()
+            .expect("serialize Count Sketch");
+        let count_l2hh = CountL2HH::<DefaultXxHasher>::with_dimensions(2, 8)
+            .serialize_to_bytes()
+            .expect("serialize CountL2HH");
+        let univmon = crate::UnivMon::init_univmon(4, 2, 8, 2)
+            .serialize_to_bytes()
+            .expect("serialize UnivMon");
+        let univmon_q = crate::UnivMonQ::new(crate::UnivMonQConfig {
+            levels: 2,
+            width: 8,
+            depth: 3,
+            candidates: 4,
+            ordered_samples: 4,
+            ..Default::default()
+        })
+        .expect("config")
+        .serialize_to_bytes()
+        .expect("serialize UnivMonQ");
+
+        for foreign in [count_sketch, count_l2hh, univmon, univmon_q] {
+            assert!(
+                UnivMonPyramid::deserialize_from_bytes(&foreign).is_err(),
+                "a foreign envelope must not decode as a UnivMonPyramid"
+            );
+        }
+    }
+
+    /// Fail closed (not panic) on crafted layouts, layer counts and heap
+    /// capacities, including a `layer_size` far larger than the payload
+    /// carries.
+    #[test]
+    fn pyramid_rejects_crafted_shapes() {
+        let encoded = populated().serialize_to_bytes().expect("serialize");
+        let base = metadata_of(&encoded);
+        let payload = payload_of::<String>(&encoded);
+
+        let shaped = |layer_size, layout: PyramidLayout, heap_size| {
+            pyramid_metadata::<DefaultXxHasher>(layer_size, &layout, heap_size, &base.key_type)
+        };
+        let layout = || PyramidLayout {
+            elephant_layers: 2,
+            elephant_row: 3,
+            elephant_col: 16,
+            mouse_row: 2,
+            mouse_col: 8,
+        };
+        let cases = [
+            shaped(u32::MAX, layout(), 4),
+            shaped(0, layout(), 4),
+            shaped(4, layout(), 0),
+            shaped(
+                4,
+                PyramidLayout {
+                    elephant_col: 0,
+                    ..layout()
+                },
+                4,
+            ),
+            shaped(
+                4,
+                PyramidLayout {
+                    mouse_row: 4096,
+                    mouse_col: 4096,
+                    ..layout()
+                },
+                4,
+            ),
+            shaped(4, layout(), 1),
+        ];
+        for meta in cases {
+            assert!(
+                UnivMonPyramid::deserialize_from_bytes(&crafted(&meta, &payload)).is_err(),
+                "a crafted layout must be rejected, not decoded"
+            );
+        }
+
+        let mut short = payload_of::<String>(&encoded);
+        short.heap_lens.pop();
+        assert!(UnivMonPyramid::deserialize_from_bytes(&crafted(&base, &short)).is_err());
+
+        let mut mode = payload_of::<String>(&encoded);
+        mode.update_mode = 9;
+        assert!(UnivMonPyramid::deserialize_from_bytes(&crafted(&base, &mode)).is_err());
+    }
+
+    /// A pyramid whose layers disagree with their declared tier or seed index
+    /// must not serialize.
+    #[test]
+    fn pyramid_rejects_serializing_an_inconsistent_layout() {
+        let mut wrong_tier = UnivMonPyramid::new(4, 2, 3, 16, 2, 8, 4);
+        wrong_tier.l2_sketch_layers[3] = L2HH::COUNT(CountL2HH::with_dimensions_and_seed(3, 16, 3));
+        assert!(
+            wrong_tier.serialize_to_bytes().is_err(),
+            "a mouse layer holding elephant dimensions must not serialize"
+        );
+
+        let mut wrong_seed = UnivMonPyramid::new(4, 2, 3, 16, 2, 8, 4);
+        wrong_seed.l2_sketch_layers[3] = L2HH::COUNT(CountL2HH::with_dimensions_and_seed(2, 8, 0));
+        assert!(
+            wrong_seed.serialize_to_bytes().is_err(),
+            "a layer hashing at another layer's seed index must not serialize"
+        );
+    }
+    /// Fail closed on an unexpected metadata key, and on a missing required
+    /// one.
+    #[test]
+    fn pyramid_metadata_rejects_unknown_and_missing_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            layer_size: u32,
+            elephant_layers: u32,
+            elephant_row: u32,
+            elephant_col: u32,
+            mouse_row: u32,
+            mouse_col: u32,
+            heap_size: u32,
+            key_type: String,
+            bogus_field: u8, // key not in PyramidMetadata
+        }
+        #[derive(Serialize)]
+        struct WithoutMouseCol {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            layer_size: u32,
+            elephant_layers: u32,
+            elephant_row: u32,
+            elephant_col: u32,
+            mouse_row: u32,
+            heap_size: u32,
+            key_type: String,
+        }
+        let layout = PyramidLayout {
+            elephant_layers: 2,
+            elephant_row: 3,
+            elephant_col: 16,
+            mouse_row: 2,
+            mouse_col: 8,
+        };
+        let m = pyramid_metadata::<DefaultXxHasher>(4, &layout, 4, "u64");
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            layer_size: m.layer_size,
+            elephant_layers: m.elephant_layers,
+            elephant_row: m.elephant_row,
+            elephant_col: m.elephant_col,
+            mouse_row: m.mouse_row,
+            mouse_col: m.mouse_col,
+            heap_size: m.heap_size,
+            key_type: m.key_type.clone(),
+            bogus_field: 7,
+        };
+        let without = WithoutMouseCol {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            layer_size: m.layer_size,
+            elephant_layers: m.elephant_layers,
+            elephant_row: m.elephant_row,
+            elephant_col: m.elephant_col,
+            mouse_row: m.mouse_row,
+            heap_size: m.heap_size,
+            key_type: m.key_type.clone(),
+        };
+        assert!(
+            from_slice::<PyramidMetadata>(&rmp_serde::to_vec_named(&extra).unwrap()).is_err(),
+            "an unknown metadata key must be rejected"
+        );
+        assert!(
+            from_slice::<PyramidMetadata>(&rmp_serde::to_vec_named(&without).unwrap()).is_err(),
+            "a missing required key must be rejected"
+        );
+    }
+}

--- a/src/sketch_framework/univmon_q.rs
+++ b/src/sketch_framework/univmon_q.rs
@@ -21,14 +21,14 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 
 use rmp_serde::decode::Error as RmpDecodeError;
-use rmp_serde::encode::Error as RmpEncodeError;
 use serde::{Deserialize, Serialize};
+
+mod wire;
 
 use crate::common::input::data_input_to_f64;
 use crate::common::numerical::NumericalValue;
 use crate::{DataInput, DefaultXxHasher, SketchHasher};
 
-const WIRE_VERSION: u8 = 2;
 const OCCURRENCE_HASH_SEED_DOMAIN: usize = usize::MAX / 3;
 static NEXT_SOURCE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -1438,34 +1438,6 @@ impl<H: SketchHasher> UnivMonQ<H> {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-struct LevelWire {
-    sketch: PackedCountSketch,
-    candidates: Vec<(u64, u64)>,
-    #[serde(default)]
-    ever_evicted: Option<bool>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct UnivMonQWire {
-    version: u8,
-    config: UnivMonQConfig,
-    levels: Vec<LevelWire>,
-    count: u64,
-    min: Option<u64>,
-    max: Option<u64>,
-    #[serde(default)]
-    source_id: u64,
-    #[serde(default)]
-    next_sequence: u64,
-    #[serde(default)]
-    ordered_occurrences: Vec<OrderedOccurrence>,
-    /// Version-1 distinct-key sample. It cannot be upgraded to an occurrence
-    /// sample without the discarded occurrence identities.
-    #[serde(default)]
-    ordered_frequencies: Vec<(u64, u64)>,
-}
-
 impl UnivMonQ<DefaultXxHasher> {
     /// Creates an empty sketch using Sketchlib's default XXH3 hasher.
     ///
@@ -1485,135 +1457,6 @@ impl UnivMonQ<DefaultXxHasher> {
         source_id: u64,
     ) -> Result<Self, UnivMonQError> {
         Self::with_hasher_and_source_id(config, source_id)
-    }
-
-    /// Serializes the default-hasher sketch to native MessagePack bytes.
-    /// This is not yet an ASAPv1 cross-language wire kind.
-    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
-        let mut levels = Vec::with_capacity(self.levels.len());
-        for level in &self.levels {
-            let mut candidates: Vec<(u64, u64)> = level
-                .candidate_scores
-                .iter()
-                .map(|(&key, &count)| (key, count))
-                .collect();
-            candidates.sort_unstable();
-            levels.push(LevelWire {
-                sketch: level.sketch.clone(),
-                candidates,
-                ever_evicted: Some(level.ever_evicted),
-            });
-        }
-        let mut ordered_occurrences = self.ordered_heap.clone().into_vec();
-        ordered_occurrences.sort_unstable();
-        let wire = UnivMonQWire {
-            version: WIRE_VERSION,
-            config: self.config,
-            levels,
-            count: self.count,
-            min: self.min,
-            max: self.max,
-            source_id: self.source_id,
-            next_sequence: self.next_sequence,
-            ordered_occurrences,
-            ordered_frequencies: Vec::new(),
-        };
-        rmp_serde::to_vec_named(&wire)
-    }
-
-    /// Deserializes and validates native UnivMon-Q MessagePack state.
-    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
-        let wire: UnivMonQWire = rmp_serde::from_slice(bytes)?;
-        if wire.version != 1 && wire.version != WIRE_VERSION {
-            return Err(decode_error(format!(
-                "unsupported UnivMon-Q wire version {}",
-                wire.version
-            )));
-        }
-        if !wire.ordered_frequencies.is_empty() {
-            return Err(decode_error(
-                "version-1 distinct ordered samples cannot be upgraded to occurrence samples",
-            ));
-        }
-        let mut result = Self::new_with_source_id(wire.config, wire.source_id)
-            .map_err(|error| decode_error(error.to_string()))?;
-        if wire.levels.len() != result.config.levels {
-            return Err(decode_error("UnivMon-Q level count does not match config"));
-        }
-        let valid_extrema = if wire.count == 0 {
-            wire.min.is_none() && wire.max.is_none()
-        } else {
-            wire.min.is_some() && wire.max.is_some()
-        };
-        if !valid_extrema {
-            return Err(decode_error(
-                "UnivMon-Q count/min/max state is inconsistent",
-            ));
-        }
-        if wire.min.zip(wire.max).is_some_and(|(min, max)| min > max) {
-            return Err(decode_error("UnivMon-Q minimum exceeds maximum"));
-        }
-        for (index, (target, source)) in result.levels.iter_mut().zip(wire.levels).enumerate() {
-            if !source.sketch.matches(
-                level_width(result.config, index),
-                result.config.depth,
-                result.config.counter_bits,
-            ) {
-                return Err(decode_error(format!(
-                    "UnivMon-Q CountSketch layout mismatch at level {index}"
-                )));
-            }
-            if source.candidates.len() > result.config.candidates {
-                return Err(decode_error(format!(
-                    "UnivMon-Q candidate capacity exceeded at level {index}"
-                )));
-            }
-            let candidate_len = source.candidates.len();
-            let ever_evicted = source
-                .ever_evicted
-                .unwrap_or(candidate_len == result.config.candidates);
-            let candidates: HashMap<u64, u64> = source.candidates.into_iter().collect();
-            if candidates.len() != candidate_len {
-                return Err(decode_error("duplicate UnivMon-Q candidate keys"));
-            }
-            target.sketch = source.sketch;
-            target.candidate_scores = candidates;
-            target.ever_evicted = ever_evicted;
-            target.candidate_heap.clear();
-            for (&key, &count) in &target.candidate_scores {
-                target.candidate_heap.push(Reverse((count, key)));
-            }
-        }
-        for (index, level) in result.levels.iter().enumerate() {
-            if level
-                .candidate_scores
-                .keys()
-                .any(|key| result.sample_level(*key) != index)
-            {
-                return Err(decode_error(format!(
-                    "UnivMon-Q candidate stored in the wrong terminal level {index}"
-                )));
-            }
-        }
-        if wire.ordered_occurrences.len() > result.config.ordered_samples {
-            return Err(decode_error("UnivMon-Q ordered sample capacity exceeded"));
-        }
-        let occurrence_len = wire.ordered_occurrences.len();
-        let unique_occurrences: HashSet<_> = wire.ordered_occurrences.iter().copied().collect();
-        if unique_occurrences.len() != occurrence_len {
-            return Err(decode_error("duplicate UnivMon-Q ordered occurrences"));
-        }
-        if result.config.ordered_samples == 0 && !wire.ordered_occurrences.is_empty() {
-            return Err(decode_error(
-                "UnivMon-Q has ordered state while ordered sampling is disabled",
-            ));
-        }
-        result.count = wire.count;
-        result.min = wire.min;
-        result.max = wire.max;
-        result.next_sequence = wire.next_sequence;
-        result.ordered_heap = BinaryHeap::from(wire.ordered_occurrences);
-        Ok(result)
     }
 }
 
@@ -1760,23 +1603,6 @@ fn decode_error(message: impl Into<String>) -> RmpDecodeError {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[derive(Serialize)]
-    struct LegacyLevelWire {
-        sketch: PackedCountSketch,
-        candidates: Vec<(u64, u64)>,
-    }
-
-    #[derive(Serialize)]
-    struct LegacyUnivMonQWire {
-        version: u8,
-        config: UnivMonQConfig,
-        levels: Vec<LegacyLevelWire>,
-        count: u64,
-        min: Option<u64>,
-        max: Option<u64>,
-        ordered_frequencies: Vec<(u64, u64)>,
-    }
 
     fn tiny_config() -> UnivMonQConfig {
         UnivMonQConfig {
@@ -1939,7 +1765,7 @@ mod tests {
     }
 
     #[test]
-    fn native_messagepack_preserves_candidate_eviction_history() {
+    fn asapv1_envelope_preserves_candidate_eviction_history() {
         let config = UnivMonQConfig {
             levels: 2,
             candidates: 1,
@@ -1952,7 +1778,7 @@ mod tests {
         assert!(sketch.levels.iter().any(|level| level.ever_evicted));
 
         let bytes = sketch.serialize_to_bytes().unwrap();
-        let decoded = UnivMonQ::deserialize_from_bytes(&bytes).unwrap();
+        let decoded = UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&bytes).unwrap();
         let original: Vec<bool> = sketch
             .levels
             .iter()
@@ -1964,48 +1790,6 @@ mod tests {
             .map(|level| level.ever_evicted)
             .collect();
         assert_eq!(restored, original);
-    }
-
-    #[test]
-    fn legacy_full_candidate_table_decodes_as_possibly_evicted() {
-        let config = UnivMonQConfig {
-            levels: 2,
-            candidates: 1,
-            ordered_samples: 0,
-            ..tiny_config()
-        };
-        let mut sketch = UnivMonQ::new(config).unwrap();
-        sketch.update(&7.0);
-        let full_level = sketch
-            .levels
-            .iter()
-            .position(|level| level.candidate_scores.len() == config.candidates)
-            .unwrap();
-        assert!(!sketch.levels[full_level].ever_evicted);
-
-        let legacy = LegacyUnivMonQWire {
-            version: WIRE_VERSION,
-            config,
-            levels: sketch
-                .levels
-                .iter()
-                .map(|level| LegacyLevelWire {
-                    sketch: level.sketch.clone(),
-                    candidates: level
-                        .candidate_scores
-                        .iter()
-                        .map(|(&key, &score)| (key, score))
-                        .collect(),
-                })
-                .collect(),
-            count: sketch.count,
-            min: sketch.min,
-            max: sketch.max,
-            ordered_frequencies: Vec::new(),
-        };
-        let bytes = rmp_serde::to_vec_named(&legacy).unwrap();
-        let decoded = UnivMonQ::deserialize_from_bytes(&bytes).unwrap();
-        assert!(decoded.levels[full_level].ever_evicted);
     }
 
     #[test]
@@ -2291,13 +2075,13 @@ mod tests {
     }
 
     #[test]
-    fn native_messagepack_round_trip_preserves_queries() {
+    fn asapv1_round_trip_preserves_queries() {
         let mut sketch = UnivMonQ::new(tiny_config()).unwrap();
         for value in (0..1000).map(|value| (value % 97) as f64) {
             sketch.update(&value);
         }
         let bytes = sketch.serialize_to_bytes().unwrap();
-        let decoded = UnivMonQ::deserialize_from_bytes(&bytes).unwrap();
+        let decoded = UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(decoded.config(), sketch.config());
         assert_eq!(decoded.source_id(), sketch.source_id());
         assert_eq!(decoded.count(), sketch.count());
@@ -2306,7 +2090,7 @@ mod tests {
     }
 
     #[test]
-    fn messagepack_checkpoint_resume_preserves_occurrence_priorities() {
+    fn asapv1_checkpoint_resume_preserves_occurrence_priorities() {
         let config = UnivMonQConfig {
             candidates: 16,
             ordered_samples: 64,
@@ -2328,7 +2112,7 @@ mod tests {
             checkpointed.update(value);
         }
         let bytes = checkpointed.serialize_to_bytes().unwrap();
-        let mut resumed = UnivMonQ::deserialize_from_bytes(&bytes).unwrap();
+        let mut resumed = UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&bytes).unwrap();
         for value in &values[1_337..] {
             uninterrupted.update(value);
             resumed.update(value);
@@ -2464,21 +2248,6 @@ mod tests {
             chi_squared < 400.0,
             "position-inclusion chi-squared={chi_squared}"
         );
-    }
-
-    #[test]
-    fn legacy_distinct_ordered_sample_is_rejected() {
-        let legacy = LegacyUnivMonQWire {
-            version: 1,
-            config: tiny_config(),
-            levels: Vec::new(),
-            count: 1,
-            min: Some(float_to_ordered(1.0)),
-            max: Some(float_to_ordered(1.0)),
-            ordered_frequencies: vec![(float_to_ordered(1.0), 1)],
-        };
-        let bytes = rmp_serde::to_vec_named(&legacy).unwrap();
-        assert!(UnivMonQ::deserialize_from_bytes(&bytes).is_err());
     }
 
     #[test]

--- a/src/sketch_framework/univmon_q/wire.rs
+++ b/src/sketch_framework/univmon_q/wire.rs
@@ -1,0 +1,1007 @@
+//! ASAPv1 wire serialization for [`UnivMonQ`].
+//!
+//! Child submodule of [`crate::sketch_framework::univmon_q`]: it holds the
+//! metadata/payload DTOs, the kind_id constant and the `serialize_to_bytes` /
+//! `deserialize_from_bytes` impls, while the algorithm lives in the parent
+//! module file. Being a descendant module, it reads the private `levels`,
+//! `count`, `min`, `max`, `source_id`, `next_sequence` and `ordered_heap`
+//! fields directly without widening any field visibility. See
+//! `docs/asapv1_wire_format.md`.
+//!
+//! UnivMon-Q is one algorithm — a single kind_id `0x1a 0x00`. The whole
+//! [`UnivMonQConfig`](super::UnivMonQConfig) is construction config and lives
+//! in the metadata, so every per-level width, the hash layout and each level's
+//! candidate capacity are derived and none is stored.
+//!
+//! ## Rebuilt, not carried
+//!
+//! A level's candidate min-heap and the ordered sample's `BinaryHeap` are
+//! array orders that do not survive a rebuild, so the payload is
+//! **order-defined** — candidates ascending by key, occurrences ascending by
+//! `(priority_high, priority_low, key)` — and both heaps are rebuilt on
+//! decode. No heap index reaches the wire.
+//!
+//! ## Sequence state
+//!
+//! `source_id` and `next_sequence` are the identity the coordinated bottom-k
+//! sample draws its priorities from, so a decoded sketch continues the same
+//! draw sequence instead of re-drawing identities it already used.
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::marker::PhantomData;
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+use crate::{HashProfile, SketchHasher};
+
+use super::{
+    Counters, HashLayout, Level, OrderedOccurrence, PackedCountSketch, UnivMonQ, UnivMonQConfig,
+    decode_error, level_width, validate_config,
+};
+
+/// UnivMon-Q kind_id: family `0x1a`, single algorithm variant `0x00`.
+const UNIVMON_Q_KIND: &[u8] = &[0x1a, 0x00];
+
+/// UnivMon-Q descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`) with keys in this declaration order — the canonical order
+/// the wire spec fixes (Go must mirror it). Hash-spec fields first, then the
+/// configuration that shapes the payload.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct UnivMonQMetadata {
+    pub(crate) metadata_version: u8,
+    pub(crate) hash_profile_id: String,
+    pub(crate) hash_algorithm: String,
+    pub(crate) seed_derivation: String,
+    pub(crate) input_encoding: String,
+    pub(crate) seed_list: Vec<u64>,
+    pub(crate) seed_index: u32,
+    pub(crate) levels: u32,
+    pub(crate) width: u32,
+    pub(crate) width_halving_period: u8,
+    pub(crate) depth: u32,
+    pub(crate) counter_type: String,
+    pub(crate) candidates: u32,
+    pub(crate) ordered_samples: u32,
+}
+
+/// Builds the UnivMon-Q descriptor metadata from the hasher's [`HashProfile`],
+/// so the wire bytes truthfully describe how the sketch was hashed.
+/// `seed_index` is the config's own `hash_seed`, a construction parameter
+/// rather than a profile constant, so it is carried as a structural param.
+pub(crate) fn univmon_q_metadata<H: HashProfile>(
+    config: UnivMonQConfig,
+    counter_type: &str,
+) -> Result<UnivMonQMetadata, String> {
+    let field = |name: &str, value: usize| {
+        u32::try_from(value)
+            .map_err(|_| format!("UnivMon-Q {name} {value} exceeds the u32 metadata field"))
+    };
+    Ok(UnivMonQMetadata {
+        metadata_version: 1,
+        hash_profile_id: H::PROFILE_ID.to_string(),
+        hash_algorithm: H::ALGORITHM.to_string(),
+        seed_derivation: H::SEED_DERIVATION.to_string(),
+        input_encoding: H::INPUT_ENCODING.to_string(),
+        seed_list: H::seed_list(),
+        seed_index: field("hash_seed", config.hash_seed)?,
+        levels: field("levels", config.levels)?,
+        width: field("width", config.width)?,
+        width_halving_period: config.width_halving_period,
+        depth: field("depth", config.depth)?,
+        counter_type: counter_type.to_string(),
+        candidates: field("candidates", config.candidates)?,
+        ordered_samples: field("ordered_samples", config.ordered_samples)?,
+    })
+}
+
+/// The config a validated metadata block describes.
+fn config_of(meta: &UnivMonQMetadata) -> Result<UnivMonQConfig, RmpDecodeError> {
+    Ok(UnivMonQConfig {
+        levels: meta.levels as usize,
+        width: meta.width as usize,
+        width_halving_period: meta.width_halving_period,
+        depth: meta.depth as usize,
+        counter_bits: counter_bits_of(&meta.counter_type)?,
+        candidates: meta.candidates as usize,
+        ordered_samples: meta.ordered_samples as usize,
+        hash_seed: meta.seed_index as usize,
+    })
+}
+
+/// Metadata `counter_type` of a counter width: 32-bit counters are `"i32"`,
+/// 64-bit are `"i64"`. Counters are signed, so Count-Min's `"f64"` has no
+/// counterpart.
+fn counter_type_of(counter_bits: u8) -> Result<&'static str, String> {
+    match counter_bits {
+        32 => Ok("i32"),
+        64 => Ok("i64"),
+        other => Err(format!(
+            "UnivMon-Q counter_bits {other} is not a wire counter width"
+        )),
+    }
+}
+
+/// Reads the metadata `counter_type` back into a counter width.
+fn counter_bits_of(counter_type: &str) -> Result<u8, RmpDecodeError> {
+    match counter_type {
+        "i32" => Ok(32),
+        "i64" => Ok(64),
+        other => Err(decode_error(format!(
+            "UnivMon-Q counter_type {other:?} is not a wire counter type"
+        ))),
+    }
+}
+
+/// UnivMon-Q payload (ASAPv1 §3.x), a msgpack **array** (`to_vec`,
+/// positional). `counters` concatenates the levels' CountSketch rows; the
+/// candidate and occurrence arrays are parallel runs cut by `candidate_lens`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct UnivMonQPayload<C> {
+    pub(crate) counters: Vec<C>,
+    pub(crate) candidate_lens: Vec<u32>,
+    pub(crate) candidate_keys: Vec<u64>,
+    pub(crate) candidate_scores: Vec<u64>,
+    pub(crate) ever_evicted: Vec<bool>,
+    pub(crate) count: u64,
+    pub(crate) min: Option<u64>,
+    pub(crate) max: Option<u64>,
+    pub(crate) source_id: u64,
+    pub(crate) next_sequence: u64,
+    pub(crate) occurrence_priority_high: Vec<u64>,
+    pub(crate) occurrence_priority_low: Vec<u64>,
+    pub(crate) occurrence_keys: Vec<u64>,
+}
+
+/// Everything the payload carries besides the counters, which are read at the
+/// width `counter_type` names.
+struct SharedPayload {
+    candidate_lens: Vec<u32>,
+    candidate_keys: Vec<u64>,
+    candidate_scores: Vec<u64>,
+    ever_evicted: Vec<bool>,
+    count: u64,
+    min: Option<u64>,
+    max: Option<u64>,
+    source_id: u64,
+    next_sequence: u64,
+    occurrences: Vec<OrderedOccurrence>,
+}
+
+/// The occurrences in emitted order: ascending
+/// `(priority_high, priority_low, key)`.
+fn emitted_occurrences(heap: &BinaryHeap<OrderedOccurrence>) -> Vec<OrderedOccurrence> {
+    let mut occurrences = heap.clone().into_vec();
+    occurrences.sort_unstable();
+    occurrences
+}
+
+/// The per-level CountSketch widths the config implies.
+fn level_widths(config: UnivMonQConfig) -> Vec<usize> {
+    (0..config.levels)
+        .map(|level| level_width(config, level))
+        .collect()
+}
+
+/// Counters a flat block holds.
+fn counters_len(counters: &Counters) -> usize {
+    match counters {
+        Counters::I32(values) => values.len(),
+        Counters::I64(values) => values.len(),
+    }
+}
+
+/// One level's run of the flat counter block, at the block's own width.
+fn counters_slice(counters: &Counters, start: usize, len: usize) -> Counters {
+    match counters {
+        Counters::I32(values) => Counters::I32(values[start..start + len].to_vec()),
+        Counters::I64(values) => Counters::I64(values[start..start + len].to_vec()),
+    }
+}
+
+/// Reads the payload with `counters` at the width `counter_type` names, and
+/// zips the three occurrence arrays back into records.
+fn read_payload(
+    counter_type: &str,
+    payload: &[u8],
+) -> Result<(Counters, SharedPayload), RmpDecodeError> {
+    macro_rules! unpack {
+        ($variant:ident, $ty:ty) => {{
+            let decoded: UnivMonQPayload<$ty> = from_slice(payload)?;
+            (Counters::$variant(decoded.counters), {
+                if decoded.occurrence_priority_high.len() != decoded.occurrence_priority_low.len()
+                    || decoded.occurrence_priority_high.len() != decoded.occurrence_keys.len()
+                {
+                    return Err(decode_error(
+                        "UnivMon-Q ordered occurrence arrays are not parallel".to_string(),
+                    ));
+                }
+                let occurrences = decoded
+                    .occurrence_priority_high
+                    .into_iter()
+                    .zip(decoded.occurrence_priority_low)
+                    .zip(decoded.occurrence_keys)
+                    .map(|((priority_high, priority_low), key)| OrderedOccurrence {
+                        priority_high,
+                        priority_low,
+                        key,
+                    })
+                    .collect();
+                SharedPayload {
+                    candidate_lens: decoded.candidate_lens,
+                    candidate_keys: decoded.candidate_keys,
+                    candidate_scores: decoded.candidate_scores,
+                    ever_evicted: decoded.ever_evicted,
+                    count: decoded.count,
+                    min: decoded.min,
+                    max: decoded.max,
+                    source_id: decoded.source_id,
+                    next_sequence: decoded.next_sequence,
+                    occurrences,
+                }
+            })
+        }};
+    }
+
+    Ok(match counter_type {
+        "i32" => unpack!(I32, i32),
+        "i64" => unpack!(I64, i64),
+        other => {
+            return Err(decode_error(format!(
+                "UnivMon-Q counter_type {other:?} is not a wire counter type"
+            )));
+        }
+    })
+}
+
+/// Checks everything the counters do not cover: the per-level runs, the
+/// capacities, the extrema and the ordered sample.
+fn validate_shared(config: UnivMonQConfig, shared: &SharedPayload) -> Result<(), RmpDecodeError> {
+    if shared.candidate_lens.len() != config.levels || shared.ever_evicted.len() != config.levels {
+        return Err(decode_error(format!(
+            "UnivMon-Q carries {} candidate runs and {} eviction flags over {} levels",
+            shared.candidate_lens.len(),
+            shared.ever_evicted.len(),
+            config.levels
+        )));
+    }
+    let mut seated = 0usize;
+    for (index, &len) in shared.candidate_lens.iter().enumerate() {
+        if len as usize > config.candidates {
+            return Err(decode_error(format!(
+                "UnivMon-Q candidate capacity exceeded at level {index}"
+            )));
+        }
+        seated = seated
+            .checked_add(len as usize)
+            .ok_or_else(|| decode_error("UnivMon-Q candidate count overflows".to_string()))?;
+    }
+    if shared.candidate_keys.len() != seated || shared.candidate_scores.len() != seated {
+        return Err(decode_error(format!(
+            "UnivMon-Q carries {} candidate keys and {} scores against the declared {seated}",
+            shared.candidate_keys.len(),
+            shared.candidate_scores.len()
+        )));
+    }
+    if shared.occurrences.len() > config.ordered_samples {
+        return Err(decode_error(
+            "UnivMon-Q ordered sample capacity exceeded".to_string(),
+        ));
+    }
+    if config.ordered_samples == 0 && !shared.occurrences.is_empty() {
+        return Err(decode_error(
+            "UnivMon-Q has ordered state while ordered sampling is disabled".to_string(),
+        ));
+    }
+    let unique: HashSet<&OrderedOccurrence> = shared.occurrences.iter().collect();
+    if unique.len() != shared.occurrences.len() {
+        return Err(decode_error(
+            "duplicate UnivMon-Q ordered occurrences".to_string(),
+        ));
+    }
+    let valid_extrema = if shared.count == 0 {
+        shared.min.is_none() && shared.max.is_none()
+    } else {
+        shared.min.is_some() && shared.max.is_some()
+    };
+    if !valid_extrema {
+        return Err(decode_error(
+            "UnivMon-Q count/min/max state is inconsistent".to_string(),
+        ));
+    }
+    if shared
+        .min
+        .zip(shared.max)
+        .is_some_and(|(min, max)| min > max)
+    {
+        return Err(decode_error(
+            "UnivMon-Q minimum exceeds maximum".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+// Wire serialization for UnivMon-Q. `wire` is a descendant of the sketch
+// module, so this impl reads the private fields directly.
+impl<H: SketchHasher + HashProfile> UnivMonQ<H> {
+    /// Serializes the sketch into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x1a 0x00`). The metadata is derived from the hasher's
+    /// [`HashProfile`], so it truthfully describes how the sketch was hashed.
+    ///
+    /// Fails on any state the decoder would refuse: a level whose CountSketch
+    /// does not match the config's layout, a candidate table over capacity, an
+    /// ordered sample over capacity, or a `count`/`min`/`max` triple that
+    /// cannot have arisen.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let syntax = |problem: String| RmpEncodeError::Syntax(problem);
+        let counter_type = counter_type_of(self.config.counter_bits).map_err(syntax)?;
+        let metadata = rmp_serde::to_vec_named(
+            &univmon_q_metadata::<H>(self.config, counter_type).map_err(syntax)?,
+        )?;
+        if self.levels.len() != self.config.levels {
+            return Err(syntax(format!(
+                "ASAPv1 UnivMon-Q envelope: {} levels against a config of {}",
+                self.levels.len(),
+                self.config.levels
+            )));
+        }
+        let valid_extrema = if self.count == 0 {
+            self.min.is_none() && self.max.is_none()
+        } else {
+            self.min.is_some() && self.max.is_some()
+        };
+        if !valid_extrema || self.min.zip(self.max).is_some_and(|(min, max)| min > max) {
+            return Err(syntax(
+                "ASAPv1 UnivMon-Q envelope: count/min/max state is inconsistent".to_string(),
+            ));
+        }
+        let occurrences = emitted_occurrences(&self.ordered_heap);
+        if occurrences.len() > self.config.ordered_samples {
+            return Err(syntax(format!(
+                "ASAPv1 UnivMon-Q envelope: {} ordered samples over a capacity of {}",
+                occurrences.len(),
+                self.config.ordered_samples
+            )));
+        }
+        if occurrences.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(syntax(
+                "ASAPv1 UnivMon-Q envelope: the same ordered occurrence appears twice".to_string(),
+            ));
+        }
+        let mut candidate_lens = Vec::with_capacity(self.levels.len());
+        let mut candidate_keys = Vec::new();
+        let mut candidate_scores = Vec::new();
+        let mut ever_evicted = Vec::with_capacity(self.levels.len());
+        for (index, level) in self.levels.iter().enumerate() {
+            if !level.sketch.matches(
+                level_width(self.config, index),
+                self.config.depth,
+                self.config.counter_bits,
+            ) {
+                return Err(syntax(format!(
+                    "ASAPv1 UnivMon-Q envelope: CountSketch layout mismatch at level {index}"
+                )));
+            }
+            if level.candidate_scores.len() > self.config.candidates {
+                return Err(syntax(format!(
+                    "ASAPv1 UnivMon-Q envelope: candidate capacity exceeded at level {index}"
+                )));
+            }
+            if level
+                .candidate_scores
+                .keys()
+                .any(|key| self.sample_level(*key) != index)
+            {
+                return Err(syntax(format!(
+                    "ASAPv1 UnivMon-Q envelope: a candidate sits in the wrong terminal level {index}"
+                )));
+            }
+            let mut candidates: Vec<(u64, u64)> = level
+                .candidate_scores
+                .iter()
+                .map(|(&key, &score)| (key, score))
+                .collect();
+            candidates.sort_unstable();
+            candidate_lens.push(u32::try_from(candidates.len()).map_err(|_| {
+                syntax(format!(
+                    "ASAPv1 UnivMon-Q envelope: level {index} holds more candidates than u32 can name"
+                ))
+            })?);
+            candidate_keys.extend(candidates.iter().map(|entry| entry.0));
+            candidate_scores.extend(candidates.iter().map(|entry| entry.1));
+            ever_evicted.push(level.ever_evicted);
+        }
+
+        macro_rules! pack {
+            ($variant:ident) => {{
+                let mut counters = Vec::new();
+                for level in &self.levels {
+                    match &level.sketch.counters {
+                        Counters::$variant(values) => counters.extend_from_slice(values),
+                        _ => {
+                            return Err(syntax(
+                                "ASAPv1 UnivMon-Q envelope: levels mix counter widths".to_string(),
+                            ));
+                        }
+                    }
+                }
+                rmp_serde::to_vec(&UnivMonQPayload {
+                    counters,
+                    candidate_lens,
+                    candidate_keys,
+                    candidate_scores,
+                    ever_evicted,
+                    count: self.count,
+                    min: self.min,
+                    max: self.max,
+                    source_id: self.source_id,
+                    next_sequence: self.next_sequence,
+                    occurrence_priority_high: occurrences
+                        .iter()
+                        .map(|entry| entry.priority_high)
+                        .collect(),
+                    occurrence_priority_low: occurrences
+                        .iter()
+                        .map(|entry| entry.priority_low)
+                        .collect(),
+                    occurrence_keys: occurrences.iter().map(|entry| entry.key).collect(),
+                })?
+            }};
+        }
+
+        let payload = match counter_type {
+            "i32" => pack!(I32),
+            _ => pack!(I64),
+        };
+        Ok(envelope::encode(UNIVMON_Q_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The whole
+    /// config is structural (it is a property of the stored sketch), so it is
+    /// echoed back into the expected metadata; the hash spec is pinned against
+    /// this target.
+    ///
+    /// Every state the algorithm could not have produced is rejected with an
+    /// error rather than a panic, and no declared capacity — `candidates`,
+    /// `ordered_samples` or a level width — sizes an allocation before the
+    /// payload is measured against it.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != UNIVMON_Q_KIND {
+            return Err(decode_error(format!(
+                "UnivMon-Q kind_id mismatch: stored {kind_id:?}, expected {UNIVMON_Q_KIND:?}"
+            )));
+        }
+        let meta: UnivMonQMetadata = from_slice(metadata)?;
+        let config = config_of(&meta)?;
+        let expected = univmon_q_metadata::<H>(config, &meta.counter_type).map_err(decode_error)?;
+        if meta != expected {
+            return Err(decode_error(
+                "ASAPv1 UnivMon-Q envelope: metadata mismatch".to_string(),
+            ));
+        }
+        validate_config(config).map_err(|error| decode_error(error.to_string()))?;
+        let hash_layout = HashLayout::new(config).map_err(|e| decode_error(e.to_string()))?;
+
+        let (counters, shared) = read_payload(&meta.counter_type, payload)?;
+        let widths = level_widths(config);
+        let cells = widths
+            .iter()
+            .try_fold(0usize, |total, width| {
+                width
+                    .checked_mul(config.depth)
+                    .and_then(|cells| total.checked_add(cells))
+            })
+            .ok_or_else(|| decode_error("UnivMon-Q level layout overflows".to_string()))?;
+        if counters_len(&counters) != cells {
+            return Err(decode_error(format!(
+                "UnivMon-Q carries {} counters against the config's {cells}",
+                counters_len(&counters)
+            )));
+        }
+        validate_shared(config, &shared)?;
+
+        let mut levels = Vec::with_capacity(widths.len());
+        let mut cell = 0usize;
+        let mut candidate = 0usize;
+        for (index, &width) in widths.iter().enumerate() {
+            let run = shared.candidate_lens[index] as usize;
+            let mut candidate_scores = HashMap::with_capacity(run);
+            let mut candidate_heap = BinaryHeap::with_capacity(run);
+            for offset in candidate..candidate + run {
+                let key = shared.candidate_keys[offset];
+                let score = shared.candidate_scores[offset];
+                if candidate_scores.insert(key, score).is_some() {
+                    return Err(decode_error(
+                        "duplicate UnivMon-Q candidate keys".to_string(),
+                    ));
+                }
+                candidate_heap.push(Reverse((score, key)));
+            }
+            candidate += run;
+            let span = width * config.depth;
+            levels.push(Level {
+                sketch: PackedCountSketch {
+                    width,
+                    depth: config.depth,
+                    counters: counters_slice(&counters, cell, span),
+                },
+                candidate_scores,
+                candidate_heap,
+                candidate_capacity: config.candidates,
+                ever_evicted: shared.ever_evicted[index],
+            });
+            cell += span;
+        }
+
+        let sketch = UnivMonQ {
+            config,
+            hash_layout,
+            levels,
+            count: shared.count,
+            min: shared.min,
+            max: shared.max,
+            source_id: shared.source_id,
+            next_sequence: shared.next_sequence,
+            ordered_heap: BinaryHeap::from(shared.occurrences),
+            hasher: PhantomData,
+        };
+        // A candidate only reaches a level its own key hashes into.
+        for (index, level) in sketch.levels.iter().enumerate() {
+            if level
+                .candidate_scores
+                .keys()
+                .any(|key| sketch.sample_level(*key) != index)
+            {
+                return Err(decode_error(format!(
+                    "UnivMon-Q candidate stored in the wrong terminal level {index}"
+                )));
+            }
+        }
+        Ok(sketch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CANONICAL_HASH_SEED, DataInput, DefaultXxHasher, HeapItem, RegularPath, Vector2D};
+
+    fn tiny_config() -> UnivMonQConfig {
+        UnivMonQConfig {
+            levels: 4,
+            width: 64,
+            width_halving_period: 0,
+            depth: 3,
+            counter_bits: 64,
+            candidates: 16,
+            ordered_samples: 16,
+            hash_seed: 5,
+        }
+    }
+
+    fn populated() -> UnivMonQ<DefaultXxHasher> {
+        let mut sketch = UnivMonQ::new_with_source_id(tiny_config(), 7).expect("config");
+        for value in (0..200).map(|value| (value % 23) as f64) {
+            sketch.update(&value);
+        }
+        sketch
+    }
+
+    fn metadata_of(bytes: &[u8]) -> UnivMonQMetadata {
+        let (_, metadata, _) = envelope::split(bytes).expect("split");
+        from_slice(metadata).expect("metadata")
+    }
+
+    fn payload_of(bytes: &[u8]) -> UnivMonQPayload<i64> {
+        let (_, _, payload) = envelope::split(bytes).expect("split");
+        from_slice(payload).expect("payload")
+    }
+
+    fn crafted(meta: &UnivMonQMetadata, payload: &UnivMonQPayload<i64>) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(meta).expect("metadata");
+        let payload = rmp_serde::to_vec(payload).expect("payload");
+        envelope::encode(UNIVMON_Q_KIND, &metadata, &payload)
+    }
+
+    /// A config that differs from [`tiny_config`] in the named fields.
+    fn config_with(mutate: impl FnOnce(&mut UnivMonQConfig)) -> UnivMonQConfig {
+        let mut config = tiny_config();
+        mutate(&mut config);
+        config
+    }
+
+    #[test]
+    fn univmon_q_round_trip_serialization() {
+        let sketch = populated();
+        let encoded = sketch.serialize_to_bytes().expect("serialize UnivMon-Q");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x1a, 0x00]); // kind_id_len=2, kind_id=[0x1a,0x00]
+
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.metadata_version, 1);
+        assert_eq!((meta.levels, meta.width, meta.depth), (4, 64, 3));
+        assert_eq!(meta.counter_type, "i64");
+        assert_eq!(meta.seed_index, 5);
+
+        let decoded = UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&encoded)
+            .expect("deserialize UnivMon-Q");
+        assert_eq!(decoded.config(), sketch.config());
+        assert_eq!(decoded.source_id(), sketch.source_id());
+        assert_eq!(decoded.count(), sketch.count());
+        assert_eq!(decoded.min(), sketch.min());
+        assert_eq!(decoded.max(), sketch.max());
+        assert_eq!(decoded.cdf(), sketch.cdf());
+        assert_eq!(decoded.estimate_f2(), sketch.estimate_f2());
+        assert_eq!(
+            decoded.serialize_to_bytes().expect("re-serialize"),
+            encoded,
+            "a decoded sketch re-serialized to different bytes"
+        );
+    }
+
+    /// The ordering state survives: a decoded sketch fed the same subsequent
+    /// updates agrees with the original fed those updates.
+    #[test]
+    fn univmon_q_ordering_state_continues_after_a_round_trip() {
+        let mut original = UnivMonQ::new_with_source_id(tiny_config(), 991).expect("config");
+        for value in (0..300).map(|value| (value % 37) as f64) {
+            original.update(&value);
+        }
+        let encoded = original.serialize_to_bytes().expect("serialize");
+        let mut resumed =
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&encoded).expect("decode");
+
+        for value in (300..700).map(|value| (value % 53) as f64) {
+            original.update(&value);
+            resumed.update(&value);
+        }
+        assert_eq!(resumed.next_sequence, original.next_sequence);
+        assert_eq!(
+            resumed.ordered_heap.clone().into_sorted_vec(),
+            original.ordered_heap.clone().into_sorted_vec(),
+            "the resumed sketch drew different occurrence priorities"
+        );
+        assert_eq!(resumed.cdf(), original.cdf());
+        assert_eq!(
+            resumed.serialize_to_bytes().expect("serialize"),
+            original.serialize_to_bytes().expect("serialize")
+        );
+    }
+
+    /// An empty sketch has exactly one encoding, and `min` / `max` travel as
+    /// msgpack nil. A cleared sketch keeps its occurrence sequence, so it is
+    /// deliberately not the same bytes as a fresh one.
+    #[test]
+    fn univmon_q_empty_has_one_encoding() {
+        let left = UnivMonQ::<DefaultXxHasher>::new_with_source_id(tiny_config(), 3).expect("left");
+        let right =
+            UnivMonQ::<DefaultXxHasher>::new_with_source_id(tiny_config(), 3).expect("right");
+        let mut cleared =
+            UnivMonQ::<DefaultXxHasher>::new_with_source_id(tiny_config(), 3).expect("cleared");
+        cleared.update(&5.0);
+        cleared.clear();
+
+        let encoded = left.serialize_to_bytes().expect("serialize");
+        assert_eq!(right.serialize_to_bytes().expect("serialize"), encoded);
+        assert_ne!(cleared.serialize_to_bytes().expect("serialize"), encoded);
+        let payload = payload_of(&encoded);
+        assert_eq!(payload.count, 0);
+        assert!(payload.min.is_none() && payload.max.is_none());
+
+        let decoded =
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&encoded).expect("decode");
+        assert!(decoded.is_empty());
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// The counter width is pinned by `counter_type`: an i32 sketch and an i64
+    /// one holding the same counters do not share bytes.
+    #[test]
+    fn univmon_q_counter_type_is_pinned() {
+        let narrow_config = config_with(|config| config.counter_bits = 32);
+        let mut narrow = UnivMonQ::<DefaultXxHasher>::new_with_source_id(narrow_config, 7)
+            .expect("narrow config");
+        let mut wide =
+            UnivMonQ::<DefaultXxHasher>::new_with_source_id(tiny_config(), 7).expect("wide config");
+        for value in (0..50).map(|value| value as f64) {
+            narrow.update(&value);
+            wide.update(&value);
+        }
+
+        let narrow_bytes = narrow.serialize_to_bytes().expect("serialize i32");
+        assert_eq!(metadata_of(&narrow_bytes).counter_type, "i32");
+        let decoded =
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&narrow_bytes).expect("decode i32");
+        assert_eq!(decoded.estimate_f2(), narrow.estimate_f2());
+        assert_ne!(narrow_bytes, wide.serialize_to_bytes().expect("serialize"));
+
+        let mut relabelled = metadata_of(&narrow_bytes);
+        relabelled.counter_type = "f64".to_string();
+        let (_, _, payload) = envelope::split(&narrow_bytes).expect("split");
+        let forged = envelope::encode(
+            UNIVMON_Q_KIND,
+            &rmp_serde::to_vec_named(&relabelled).expect("metadata"),
+            payload,
+        );
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&forged).is_err(),
+            "f64 is not a UnivMon-Q wire counter type"
+        );
+    }
+
+    // A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    // declares a DIFFERENT `HashProfile`.
+    #[derive(Clone, Debug)]
+    struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    #[test]
+    fn univmon_q_custom_hasher_profile_round_trips_and_is_self_describing() {
+        // (a) A sketch built with a custom-profile hasher round-trips.
+        let mut alt =
+            UnivMonQ::<AltHasher>::with_hasher_and_source_id(tiny_config(), 7).expect("alt config");
+        let mut std =
+            UnivMonQ::<DefaultXxHasher>::new_with_source_id(tiny_config(), 7).expect("std config");
+        for value in (0..100).map(|value| (value % 13) as f64) {
+            alt.update(&value);
+            std.update(&value);
+        }
+
+        let alt_bytes = alt.serialize_to_bytes().expect("alt serialize");
+        let decoded =
+            UnivMonQ::<AltHasher>::deserialize_from_bytes(&alt_bytes).expect("alt decode");
+        assert_eq!(decoded.estimate_f2(), alt.estimate_f2());
+
+        // (b) Bytes differ from the standard-profile sketch.
+        let std_bytes = std.serialize_to_bytes().expect("std serialize");
+        assert_ne!(alt_bytes, std_bytes);
+
+        // (c) Standard-profile decode fails closed on custom-profile bytes.
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&alt_bytes).is_err(),
+            "standard-profile decode must reject custom-profile bytes"
+        );
+    }
+
+    /// Each family's envelope is rejected by the other three, and by a plain
+    /// Count Sketch envelope.
+    #[test]
+    fn univmon_q_rejects_foreign_kind_ids() {
+        let count_sketch = crate::Count::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8)
+            .serialize_to_bytes()
+            .expect("serialize Count Sketch");
+        let count_l2hh =
+            crate::sketches::countsketch_topk::CountL2HH::<DefaultXxHasher>::with_dimensions(2, 8)
+                .serialize_to_bytes()
+                .expect("serialize CountL2HH");
+        let univmon = crate::UnivMon::init_univmon(4, 2, 8, 2)
+            .serialize_to_bytes()
+            .expect("serialize UnivMon");
+        let pyramid = crate::UnivMonPyramid::new(4, 1, 2, 8, 2, 4, 2)
+            .serialize_to_bytes()
+            .expect("serialize UnivMonPyramid");
+
+        for foreign in [count_sketch, count_l2hh, univmon, pyramid] {
+            assert!(
+                UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&foreign).is_err(),
+                "a foreign envelope must not decode as a UnivMon-Q"
+            );
+        }
+    }
+
+    /// Fail closed (not panic) on crafted level counts, widths and capacities,
+    /// including a level layout far larger than the payload carries. Every
+    /// check precedes an allocation.
+    #[test]
+    fn univmon_q_rejects_crafted_shapes() {
+        let encoded = populated().serialize_to_bytes().expect("serialize");
+        let base = metadata_of(&encoded);
+        let payload = payload_of(&encoded);
+
+        let shaped = |config: UnivMonQConfig| {
+            univmon_q_metadata::<DefaultXxHasher>(config, "i64").expect("metadata")
+        };
+        let cases = [
+            shaped(config_with(|config| config.levels = 63)),
+            shaped(config_with(|config| config.width = u32::MAX as usize)),
+            shaped(config_with(|config| config.levels = 1)),
+            shaped(config_with(|config| config.depth = 4)),
+            shaped(config_with(|config| config.candidates = 0)),
+            shaped(config_with(|config| config.ordered_samples = 0)),
+            shaped(config_with(|config| config.hash_seed = 6)),
+        ];
+        for meta in cases {
+            assert!(
+                UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&crafted(&meta, &payload))
+                    .is_err(),
+                "a crafted shape must be rejected, not decoded"
+            );
+        }
+
+        let mut short = payload_of(&encoded);
+        short.candidate_scores.pop();
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&crafted(&base, &short)).is_err()
+        );
+
+        let mut flags = payload_of(&encoded);
+        flags.ever_evicted.pop();
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&crafted(&base, &flags)).is_err()
+        );
+
+        let mut extrema = payload_of(&encoded);
+        extrema.min = None;
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&crafted(&base, &extrema)).is_err()
+        );
+
+        let mut swapped = payload_of(&encoded);
+        std::mem::swap(&mut swapped.min, &mut swapped.max);
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&crafted(&base, &swapped)).is_err()
+        );
+
+        let mut truncated = payload_of(&encoded);
+        truncated.occurrence_keys.pop();
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&crafted(&base, &truncated))
+                .is_err()
+        );
+
+        let mut misplaced = payload_of(&encoded);
+        misplaced.candidate_keys.reverse();
+        assert!(
+            UnivMonQ::<DefaultXxHasher>::deserialize_from_bytes(&crafted(&base, &misplaced))
+                .is_err(),
+            "a candidate must live in the level its own key hashes into"
+        );
+    }
+
+    /// A sketch whose levels disagree with its own config must not serialize.
+    #[test]
+    fn univmon_q_rejects_serializing_an_inconsistent_state() {
+        let mut wrong_layout = populated();
+        wrong_layout.levels[1].sketch = PackedCountSketch::new(8, 3, 64);
+        assert!(
+            wrong_layout.serialize_to_bytes().is_err(),
+            "a level whose CountSketch is not the config's size must not serialize"
+        );
+
+        let mut wrong_extrema = populated();
+        wrong_extrema.min = None;
+        assert!(
+            wrong_extrema.serialize_to_bytes().is_err(),
+            "a count/min/max triple the algorithm cannot reach must not serialize"
+        );
+
+        let mut over_capacity = populated();
+        over_capacity.config.candidates = 1;
+        assert!(
+            over_capacity.serialize_to_bytes().is_err(),
+            "a candidate table over its capacity must not serialize"
+        );
+    }
+
+    /// Fail closed on an unexpected metadata key, and on a missing required
+    /// one.
+    #[test]
+    fn univmon_q_metadata_rejects_unknown_and_missing_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            seed_index: u32,
+            levels: u32,
+            width: u32,
+            width_halving_period: u8,
+            depth: u32,
+            counter_type: String,
+            candidates: u32,
+            ordered_samples: u32,
+            bogus_field: u8, // key not in UnivMonQMetadata
+        }
+        #[derive(Serialize)]
+        struct WithoutCounterType {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            seed_index: u32,
+            levels: u32,
+            width: u32,
+            width_halving_period: u8,
+            depth: u32,
+            candidates: u32,
+            ordered_samples: u32,
+        }
+        let m = univmon_q_metadata::<DefaultXxHasher>(tiny_config(), "i64").expect("metadata");
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            seed_index: m.seed_index,
+            levels: m.levels,
+            width: m.width,
+            width_halving_period: m.width_halving_period,
+            depth: m.depth,
+            counter_type: m.counter_type.clone(),
+            candidates: m.candidates,
+            ordered_samples: m.ordered_samples,
+            bogus_field: 7,
+        };
+        let without = WithoutCounterType {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            seed_index: m.seed_index,
+            levels: m.levels,
+            width: m.width,
+            width_halving_period: m.width_halving_period,
+            depth: m.depth,
+            candidates: m.candidates,
+            ordered_samples: m.ordered_samples,
+        };
+        assert!(
+            from_slice::<UnivMonQMetadata>(&rmp_serde::to_vec_named(&extra).unwrap()).is_err(),
+            "an unknown metadata key must be rejected"
+        );
+        assert!(
+            from_slice::<UnivMonQMetadata>(&rmp_serde::to_vec_named(&without).unwrap()).is_err(),
+            "a missing required key must be rejected"
+        );
+    }
+}

--- a/src/sketches/countsketch_topk.rs
+++ b/src/sketches/countsketch_topk.rs
@@ -6,9 +6,6 @@
 //! - [`CountL2HH`]: Count Sketch augmented with per-row L2 norm tracking for
 //!   heavy-hitter detection.
 
-use rmp_serde::{
-    decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice, to_vec_named,
-};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
@@ -20,6 +17,7 @@ use crate::{
     SketchHasher, Vector1D, Vector2D, compute_median_inline_f64, heap_item_to_sketch_input,
 };
 
+pub(crate) mod l2hh_wire;
 mod wire;
 
 const DEFAULT_TOP_K: usize = 32;
@@ -1153,16 +1151,6 @@ impl<H: SketchHasher> CountL2HH<H> {
             sign_bit_pos -= 1;
         }
         compute_median_inline_f64(&mut lst[..])
-    }
-
-    /// Serializes the CountL2HH sketch into MessagePack bytes.
-    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
-        to_vec_named(self)
-    }
-
-    /// Deserializes a CountL2HH sketch from MessagePack bytes.
-    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
-        from_slice(bytes)
     }
 }
 

--- a/src/sketches/countsketch_topk/l2hh_wire.rs
+++ b/src/sketches/countsketch_topk/l2hh_wire.rs
@@ -1,0 +1,537 @@
+//! ASAPv1 wire serialization for [`CountL2HH`], plus the sub-payload the
+//! UnivMon family reuses.
+//!
+//! Child submodule of [`crate::sketches::countsketch_topk`]: it holds the
+//! metadata/payload DTOs, the kind_id constant and the `serialize_to_bytes` /
+//! `deserialize_from_bytes` impls, while the algorithm lives in the parent
+//! module file. Being a descendant module, it reads the private `counts`,
+//! `l2`, `row`, `col` and `seed_idx` fields directly without widening any
+//! field visibility. See `docs/asapv1_wire_format.md`.
+//!
+//! CountL2HH is one algorithm — a single kind_id `0x19 0x00`. The dimensions
+//! (`rows` / `cols`) and the seed-list index the sketch hashes with
+//! (`seed_index`) are construction config and live in the metadata, so the
+//! payload is `[counts, l2]`.
+//!
+//! ## The shared sub-payload
+//!
+//! [`CountL2HH`] is also the per-layer counter of `UnivMon`, `UnivMonPyramid`
+//! and every other `L2HH::COUNT`. Those sketches inline the same
+//! `(counts, l2)` state into their own positional arrays instead of nesting an
+//! envelope per layer, so [`layer_state`] and [`rebuild_layer`] are the one
+//! place that state is read and rebuilt.
+//!
+//! ## `l2` is carried, not recomputed
+//!
+//! A row's `l2` is its running sum of squares, clamped to `[0, i64::MAX]`. It
+//! is not `sum(counts[row]^2)`: `fast_insert_with_count_without_l2_and_hash`
+//! moves counters without it and saturation is one-way, so it is state.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+use crate::message_pack_format::envelope;
+use crate::{HashProfile, SketchHasher, Vector1D, Vector2D};
+
+use super::CountL2HH;
+
+/// CountL2HH kind_id: family `0x19`, single algorithm variant `0x00`.
+const L2HH_KIND: &[u8] = &[0x19, 0x00];
+
+/// CountL2HH descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`) with keys in this declaration order — the canonical order
+/// the wire spec fixes (Go must mirror it). Hash-spec fields first, then the
+/// structural params `seed_index` / `rows` / `cols`.
+///
+/// There is no `counter_type` and no `mode`: the counters are `i64` and the
+/// column derivation is fixed by the algorithm, so `kind_id` already
+/// determines both.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct L2hhMetadata {
+    pub(crate) metadata_version: u8,
+    pub(crate) hash_profile_id: String,
+    pub(crate) hash_algorithm: String,
+    pub(crate) seed_derivation: String,
+    pub(crate) input_encoding: String,
+    pub(crate) seed_list: Vec<u64>,
+    pub(crate) seed_index: u32,
+    pub(crate) rows: u32,
+    pub(crate) cols: u32,
+}
+
+/// Builds the CountL2HH descriptor metadata from the hasher's [`HashProfile`],
+/// so the wire bytes truthfully describe how the sketch was hashed.
+/// `seed_index` is the sketch's own seed offset, a construction parameter
+/// rather than a profile constant, so it is carried as a structural param.
+pub(crate) fn l2hh_metadata<H: HashProfile>(seed_index: u32, rows: u32, cols: u32) -> L2hhMetadata {
+    L2hhMetadata {
+        metadata_version: 1,
+        hash_profile_id: H::PROFILE_ID.to_string(),
+        hash_algorithm: H::ALGORITHM.to_string(),
+        seed_derivation: H::SEED_DERIVATION.to_string(),
+        input_encoding: H::INPUT_ENCODING.to_string(),
+        seed_list: H::seed_list(),
+        seed_index,
+        rows,
+        cols,
+    }
+}
+
+/// CountL2HH payload (ASAPv1 §3.x), a msgpack **array** (`to_vec`,
+/// positional): `[counts, l2]`. `counts` is packed row-major over `rows*cols`
+/// signed cells; `l2` is one accumulator per row.
+#[derive(Debug, Serialize, Deserialize)]
+struct L2hhPayload {
+    counts: Vec<i64>,
+    l2: Vec<i64>,
+}
+
+/// Rejects a zero dimension. `Vector2D` derives its column mask via
+/// `cols.ilog2()`, which panics on `cols == 0`.
+pub(crate) fn check_dimensions(rows: usize, cols: usize) -> Result<(), String> {
+    if rows == 0 || cols == 0 {
+        return Err(format!(
+            "CountL2HH dimensions must be non-zero: rows={rows}, cols={cols}"
+        ));
+    }
+    Ok(())
+}
+
+/// The `(counts, l2)` sub-payload one CountL2HH contributes, in the order the
+/// wire emits it. Rejects a matrix whose cell count disagrees with its own
+/// dimensions, a mis-sized `l2`, and a negative accumulator — states the
+/// decoder refuses.
+pub(crate) fn layer_state<H: SketchHasher>(
+    sketch: &CountL2HH<H>,
+) -> Result<(&[i64], &[i64]), RmpEncodeError> {
+    let cells = sketch.row.saturating_mul(sketch.col);
+    let counts = sketch.counts.as_slice();
+    let l2 = sketch.l2.as_slice();
+    if counts.len() != cells {
+        return Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 CountL2HH state: counts length {} != rows*cols {cells}",
+            counts.len()
+        )));
+    }
+    if l2.len() != sketch.row {
+        return Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 CountL2HH state: l2 length {} != rows {}",
+            l2.len(),
+            sketch.row
+        )));
+    }
+    if let Some(negative) = l2.iter().find(|&&value| value < 0) {
+        return Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 CountL2HH state: l2 accumulator {negative} is negative"
+        )));
+    }
+    Ok((counts, l2))
+}
+
+/// Rebuilds one CountL2HH from a validated sub-payload. The lengths are
+/// checked against the declared geometry before the matrix is built, so a
+/// crafted `rows`/`cols` never drives an allocation.
+pub(crate) fn rebuild_layer<H: SketchHasher>(
+    rows: usize,
+    cols: usize,
+    seed_idx: usize,
+    counts: &[i64],
+    l2: &[i64],
+) -> Result<CountL2HH<H>, RmpDecodeError> {
+    check_dimensions(rows, cols).map_err(RmpDecodeError::Uncategorized)?;
+    let cells = rows.saturating_mul(cols);
+    if counts.len() != cells {
+        return Err(RmpDecodeError::Uncategorized(format!(
+            "CountL2HH counts length {} != rows*cols {cells}",
+            counts.len()
+        )));
+    }
+    if l2.len() != rows {
+        return Err(RmpDecodeError::Uncategorized(format!(
+            "CountL2HH l2 length {} != rows {rows}",
+            l2.len()
+        )));
+    }
+    if let Some(negative) = l2.iter().find(|&&value| value < 0) {
+        return Err(RmpDecodeError::Uncategorized(format!(
+            "CountL2HH l2 accumulator {negative} is negative"
+        )));
+    }
+    Ok(CountL2HH {
+        counts: Vector2D::from_fn(rows, cols, |r, c| counts[r * cols + c]),
+        l2: Vector1D::from_vec(l2.to_vec()),
+        row: rows,
+        col: cols,
+        seed_idx,
+        _hasher: PhantomData,
+    })
+}
+
+// Wire serialization for CountL2HH. `l2hh_wire` is a descendant of the sketch
+// module, so this impl reads the private fields directly.
+impl<H: SketchHasher + HashProfile> CountL2HH<H> {
+    /// Serializes the sketch into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x19 0x00`). The metadata is derived from the hasher's
+    /// [`HashProfile`], so it truthfully describes how the sketch was hashed.
+    ///
+    /// Fails when the state disagrees with its own dimensions, when an `l2`
+    /// accumulator is negative, or when a dimension or the seed index
+    /// overflows its `u32` metadata field.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        check_dimensions(self.row, self.col).map_err(RmpEncodeError::Syntax)?;
+        let (counts, l2) = layer_state(self)?;
+        let field = |name: &str, value: usize| {
+            u32::try_from(value).map_err(|_| {
+                RmpEncodeError::Syntax(format!(
+                    "ASAPv1 CountL2HH envelope: {name} {value} exceeds the u32 metadata field"
+                ))
+            })
+        };
+        let metadata = rmp_serde::to_vec_named(&l2hh_metadata::<H>(
+            field("seed_index", self.seed_idx)?,
+            field("rows", self.row)?,
+            field("cols", self.col)?,
+        ))?;
+        let payload = rmp_serde::to_vec(&L2hhPayload {
+            counts: counts.to_vec(),
+            l2: l2.to_vec(),
+        })?;
+        Ok(envelope::encode(L2HH_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The
+    /// dimensions and the seed index are structural (they are properties of
+    /// the stored sketch, not of the target), so they are echoed back into the
+    /// expected metadata; the hash spec is pinned against this target.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != L2HH_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "CountL2HH kind_id mismatch: stored {kind_id:?}, expected {L2HH_KIND:?}"
+            )));
+        }
+        let meta: L2hhMetadata = from_slice(metadata)?;
+        if meta != l2hh_metadata::<H>(meta.seed_index, meta.rows, meta.cols) {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 CountL2HH envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let p: L2hhPayload = from_slice(payload)?;
+        rebuild_layer::<H>(
+            meta.rows as usize,
+            meta.cols as usize,
+            meta.seed_index as usize,
+            &p.counts,
+            &p.l2,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CANONICAL_HASH_SEED, DataInput, DefaultXxHasher, HeapItem, RegularPath};
+
+    /// The standard-profile sketch, named so decode calls can pick a hasher.
+    type Std = CountL2HH<DefaultXxHasher>;
+
+    fn populated() -> CountL2HH {
+        let mut sketch = CountL2HH::with_dimensions_and_seed(3, 32, 7);
+        for (key, weight) in [("alpha", 9i64), ("beta", 5), ("gamma", -4)] {
+            sketch.fast_insert_with_count(&DataInput::Str(key), weight);
+        }
+        sketch
+    }
+
+    fn metadata_of(bytes: &[u8]) -> L2hhMetadata {
+        let (_, metadata, _) = envelope::split(bytes).expect("split");
+        from_slice(metadata).expect("metadata")
+    }
+
+    fn crafted(meta: &L2hhMetadata, counts: Vec<i64>, l2: Vec<i64>) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(meta).expect("metadata");
+        let payload = rmp_serde::to_vec(&L2hhPayload { counts, l2 }).expect("payload");
+        envelope::encode(L2HH_KIND, &metadata, &payload)
+    }
+
+    #[test]
+    fn count_l2hh_round_trip_serialization() {
+        let sketch = populated();
+        let encoded = sketch.serialize_to_bytes().expect("serialize CountL2HH");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x19, 0x00]); // kind_id_len=2, kind_id=[0x19,0x00]
+
+        let meta = metadata_of(&encoded);
+        assert_eq!(meta.metadata_version, 1);
+        assert_eq!((meta.seed_index, meta.rows, meta.cols), (7, 3, 32));
+
+        let decoded = Std::deserialize_from_bytes(&encoded).expect("deserialize CountL2HH");
+        assert_eq!(decoded.rows(), 3);
+        assert_eq!(decoded.cols(), 32);
+        assert_eq!(decoded.seed_idx(), 7);
+        assert_eq!(
+            sketch.as_storage().as_slice(),
+            decoded.as_storage().as_slice()
+        );
+        assert_eq!(sketch.l2.as_slice(), decoded.l2.as_slice());
+        assert_eq!(sketch.get_l2(), decoded.get_l2());
+    }
+
+    /// A decoded sketch re-serializes byte-identically.
+    #[test]
+    fn count_l2hh_decoded_re_serializes_identically() {
+        let sketch = populated();
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        let decoded = Std::deserialize_from_bytes(&encoded).expect("decode");
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// Count Sketch cells are signed, so a CountL2HH carries negatives through
+    /// unchanged.
+    #[test]
+    fn count_l2hh_negative_counters_round_trip() {
+        let mut sketch: CountL2HH = CountL2HH::with_dimensions(2, 8);
+        sketch.fast_insert_with_count(&DataInput::U64(11), -25);
+        sketch.fast_insert_with_count(&DataInput::U64(12), -7);
+        assert!(sketch.as_storage().as_slice().iter().any(|&v| v < 0));
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize");
+        let decoded = Std::deserialize_from_bytes(&encoded).expect("decode");
+        assert_eq!(
+            sketch.as_storage().as_slice(),
+            decoded.as_storage().as_slice()
+        );
+        assert!(decoded.as_storage().as_slice().iter().any(|&v| v < 0));
+        assert_eq!(decoded.serialize_to_bytes().expect("re-serialize"), encoded);
+    }
+
+    /// The seed index is state, not a profile constant: two sketches that
+    /// differ only in it do not share bytes and do not decode into each other.
+    #[test]
+    fn count_l2hh_seed_index_travels_with_the_sketch() {
+        let zero: CountL2HH = CountL2HH::with_dimensions_and_seed(2, 8, 0);
+        let nine: CountL2HH = CountL2HH::with_dimensions_and_seed(2, 8, 9);
+        let zero_bytes = zero.serialize_to_bytes().expect("serialize");
+        let nine_bytes = nine.serialize_to_bytes().expect("serialize");
+        assert_ne!(zero_bytes, nine_bytes);
+        assert_eq!(
+            Std::deserialize_from_bytes(&nine_bytes)
+                .expect("decode")
+                .seed_idx(),
+            9
+        );
+    }
+
+    // A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    // declares a DIFFERENT `HashProfile`.
+    #[derive(Clone, Debug)]
+    struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    #[test]
+    fn count_l2hh_custom_hasher_profile_round_trips_and_is_self_describing() {
+        // (a) A CountL2HH built with a custom-profile hasher round-trips.
+        let mut alt = CountL2HH::<AltHasher>::with_dimensions(3, 32);
+        let mut std: CountL2HH = CountL2HH::with_dimensions(3, 32);
+        alt.fast_insert_with_count(&DataInput::U64(42), 5);
+        std.fast_insert_with_count(&DataInput::U64(42), 5);
+
+        let alt_bytes = alt.serialize_to_bytes().expect("alt serialize");
+        let decoded =
+            CountL2HH::<AltHasher>::deserialize_from_bytes(&alt_bytes).expect("alt decode");
+        assert_eq!(alt.as_storage().as_slice(), decoded.as_storage().as_slice());
+
+        // (b) Bytes differ from the standard-profile sketch.
+        let std_bytes = std.serialize_to_bytes().expect("std serialize");
+        assert_ne!(alt_bytes, std_bytes);
+
+        // (c) Standard-profile decode fails closed on custom-profile bytes.
+        assert!(
+            Std::deserialize_from_bytes(&alt_bytes).is_err(),
+            "standard-profile decode must reject custom-profile bytes"
+        );
+    }
+
+    /// Each family's envelope is rejected by the other three, and by a plain
+    /// Count Sketch envelope.
+    #[test]
+    fn count_l2hh_rejects_foreign_kind_ids() {
+        let count_sketch = crate::Count::<Vector2D<i64>, RegularPath>::with_dimensions(3, 8)
+            .serialize_to_bytes()
+            .expect("serialize Count Sketch");
+        let univmon = crate::UnivMon::init_univmon(4, 2, 8, 2)
+            .serialize_to_bytes()
+            .expect("serialize UnivMon");
+        let pyramid = crate::UnivMonPyramid::new(4, 1, 2, 8, 2, 4, 2)
+            .serialize_to_bytes()
+            .expect("serialize UnivMonPyramid");
+        let univmon_q = crate::UnivMonQ::new(crate::UnivMonQConfig {
+            levels: 2,
+            width: 8,
+            depth: 3,
+            candidates: 4,
+            ordered_samples: 4,
+            ..Default::default()
+        })
+        .expect("config")
+        .serialize_to_bytes()
+        .expect("serialize UnivMonQ");
+
+        for foreign in [count_sketch, univmon, pyramid, univmon_q] {
+            assert!(
+                Std::deserialize_from_bytes(&foreign).is_err(),
+                "a foreign envelope must not decode as a CountL2HH"
+            );
+        }
+    }
+
+    /// Fail closed (not panic) on a crafted envelope carrying a zero
+    /// dimension, and on one whose declared geometry the payload does not
+    /// carry. Both checks precede any allocation.
+    #[test]
+    fn count_l2hh_rejects_crafted_geometry() {
+        let meta = l2hh_metadata::<DefaultXxHasher>(0, 4, 0);
+        assert!(Std::deserialize_from_bytes(&crafted(&meta, Vec::new(), vec![0; 4])).is_err());
+
+        let huge = l2hh_metadata::<DefaultXxHasher>(0, 4096, 4096);
+        assert!(
+            Std::deserialize_from_bytes(&crafted(&huge, vec![1, 2, 3], vec![0; 4096])).is_err(),
+            "counts length must match rows*cols"
+        );
+
+        let meta = l2hh_metadata::<DefaultXxHasher>(0, 2, 4);
+        assert!(
+            Std::deserialize_from_bytes(&crafted(&meta, vec![0; 8], vec![0; 5])).is_err(),
+            "l2 length must match rows"
+        );
+        assert!(
+            Std::deserialize_from_bytes(&crafted(&meta, vec![0; 8], vec![-1, 0])).is_err(),
+            "a negative l2 accumulator is not a state the algorithm reaches"
+        );
+    }
+
+    /// An unpopulated matrix carries dimensions its cells do not match.
+    /// Serializing it must fail rather than emit bytes the decoder refuses.
+    #[test]
+    fn count_l2hh_rejects_serializing_an_unfilled_matrix() {
+        let mut sketch: CountL2HH = CountL2HH::with_dimensions(2, 4);
+        sketch.counts = Vector2D::init(2, 4);
+        assert!(
+            sketch.serialize_to_bytes().is_err(),
+            "a matrix whose cell count disagrees with its dimensions must not serialize"
+        );
+    }
+
+    /// Fail closed on an unexpected metadata key, and on a missing required
+    /// one.
+    #[test]
+    fn l2hh_metadata_rejects_unknown_and_missing_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            seed_index: u32,
+            rows: u32,
+            cols: u32,
+            bogus_field: u8, // key not in L2hhMetadata
+        }
+        #[derive(Serialize)]
+        struct WithoutCols {
+            metadata_version: u8,
+            hash_profile_id: String,
+            hash_algorithm: String,
+            seed_derivation: String,
+            input_encoding: String,
+            seed_list: Vec<u64>,
+            seed_index: u32,
+            rows: u32,
+        }
+        let m = l2hh_metadata::<DefaultXxHasher>(0, 2, 4);
+        let extra = WithExtra {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            seed_index: m.seed_index,
+            rows: m.rows,
+            cols: m.cols,
+            bogus_field: 7,
+        };
+        let without = WithoutCols {
+            metadata_version: m.metadata_version,
+            hash_profile_id: m.hash_profile_id.clone(),
+            hash_algorithm: m.hash_algorithm.clone(),
+            seed_derivation: m.seed_derivation.clone(),
+            input_encoding: m.input_encoding.clone(),
+            seed_list: m.seed_list.clone(),
+            seed_index: m.seed_index,
+            rows: m.rows,
+        };
+        assert!(
+            from_slice::<L2hhMetadata>(&rmp_serde::to_vec_named(&extra).unwrap()).is_err(),
+            "an unknown metadata key must be rejected"
+        );
+        assert!(
+            from_slice::<L2hhMetadata>(&rmp_serde::to_vec_named(&without).unwrap()).is_err(),
+            "a missing required key must be rejected"
+        );
+    }
+
+    /// An empty sketch has exactly one encoding.
+    #[test]
+    fn count_l2hh_empty_has_one_encoding() {
+        let left: CountL2HH = CountL2HH::with_dimensions(3, 32);
+        let mut right: CountL2HH = CountL2HH::with_dimensions(3, 32);
+        right.fast_insert_with_count(&DataInput::U64(5), 4);
+        right.clear();
+        assert_eq!(
+            left.serialize_to_bytes().expect("serialize"),
+            right.serialize_to_bytes().expect("serialize")
+        );
+    }
+}


### PR DESCRIPTION
ASAPv1 wire payloads for the four kinds that form one dependency cluster:
**CountL2HH** `0x19 0x00`, **UnivMon** `0x10 0x00`, **UnivMon Optimized**
`0x11 0x00` and **UnivMon-Q** `0x1a 0x00`.

`UnivMon` and `UnivMonPyramid` both hold `Vector1D<L2HH>`, and `L2HH` is
`COUNT(CountL2HH)`, so UnivMon's payload literally contains CountL2HH's state.
The CountL2HH sub-payload is designed once and reused everywhere.

No golden fixtures in this round, and `docs/asapv1_wire_format.md` is untouched
— the four §3.x drafts below are written for the harvester to number and paste.

---

## §3.x: CountL2HH payload (`0x19 0x00`)

`CountL2HH` is a Count Sketch whose rows also carry a running L2 accumulator.
Its counters are always `i64` and its column derivation is fixed by the
algorithm, so — unlike Count-Min (§3.2) and Count Sketch (§3.6) — its metadata
carries neither a `counter_type` nor a `mode`: `kind_id` already determines
both. What is left is the geometry and the seed-list index it hashes with:

| Pos | Field | Type | Notes |
| ----- | ------- | ------ | ------- |
| 0 | `counts` | array | packed **row-major**, `rows*cols` cells; `i64`, **signed** |
| 1 | `l2` | array | one `i64` accumulator per row, length `rows`; every entry `>= 0` |

**Metadata vs payload.** `rows`, `cols` and `seed_index` are chosen at
construction (`CountL2HH::with_dimensions_and_seed`), so per the
config-to-metadata rule they live in the descriptor and the payload omits them.
Structural-param order is `seed_index, rows, cols`, mirroring Count-Min's
`matrix_seed_index, rows, cols, ...`.

`seed_index` is **not** a profile constant. Count-Min's `matrix_seed_index` is
`H::MATRIX_SEED_INDEX`, read off the hasher; a CountL2HH's seed offset is
per-instance state a caller chose, and UnivMon gives layer `i` the value `i`. So
it is a **structural param echoed back on decode**, not a hash-spec field pinned
against the target — the same treatment `rows`/`cols` get.

`l2` is carried rather than recomputed. It is *not* `sum(counts[row]^2)`:
`fast_insert_with_count_without_l2_and_hash` moves counters without touching it,
and the accumulator clamps to `[0, i64::MAX]` one way, so a decoder that
recomputed it would report a different `get_l2` than the sketch it read.

**Emitted order (cross-language contract).** `counts` is row-major, row 0 first;
`l2` is in row order. There is one encoding per state, so a decoded sketch
re-serializes byte-identically.

**Decode rules.** Fail **closed** on each, with an error and never a panic:

1. `kind_id` is `0x19 0x00`; any other id is rejected.
2. The hash-spec group matches the **target hasher's** `HashProfile`.
   `seed_index`, `rows` and `cols` are properties of the *stored* sketch, so
   they are echoed back into the expected metadata rather than pinned.
3. `rows` and `cols` are both non-zero. Checked before the matrix is built:
   the column mask is derived from `cols.ilog2()`, which panics on `cols == 0`.
4. `len(counts) == rows * cols` exactly, checked **before** the allocation, so
   crafted dimensions cannot drive a huge reserve.
5. `len(l2) == rows`.
6. Every `l2[i] >= 0` — a negative accumulator is not a state a sum of squares
   reaches.

Rules 3-6 are enforced on the **encode** side too (a matrix whose cell count
disagrees with its own dimensions fails to serialize, as Count Sketch's does),
so the format never emits bytes it would refuse to read back.

### The shared sub-payload

Positions 0 and 1 above are the **CountL2HH sub-payload**. When a CountL2HH is
a UnivMon layer it is **inlined**, not wrapped: the layer's `counts` and `l2`
are appended to the outer sketch's own positional arrays, and its `rows` /
`cols` / `seed_index` are derived from the outer metadata plus the layer's
position. No nested `ASAPv1` envelope, magic, version or metadata map is
emitted per layer.

---

## §3.x: UnivMon payload (`0x10 0x00`)

UnivMon is a pyramid of `layer_size` layers, each a `CountL2HH` of
`sketch_row x sketch_col` plus an `HHHeap` of capacity `heap_size`. Every layer
has the same dimensions and the same heap capacity, and layer `i` hashes at seed
index `i`, so all of that is metadata or derived and the payload is the layers'
raw state:

| Pos | Field | Type | Notes |
| ----- | ------- | ------ | ------- |
| 0 | `counts` | array | the layers' `CountL2HH` counters concatenated in layer order, each layer row-major; length `layer_size * sketch_row * sketch_col` |
| 1 | `l2` | array | the layers' L2 accumulators concatenated in layer order; length `layer_size * sketch_row` |
| 2 | `heap_lens` | array | u32 entries held by each layer's heap, one per layer |
| 3 | `keys` | array | every layer's heap keys concatenated, cut by `heap_lens`; element type = `key_type`; homogeneous |
| 4 | `heap_counts` | array | i64 heap count, parallel to `keys` |
| 5 | `candidate_complete` | array | one bool per layer |
| 6 | `bucket_size` | u64 | total weight recorded |
| 7 | `update_mode` | u8 | `0` unset, `1` standard, `2` terminal-only |

**Metadata vs payload.** `layer_size`, `sketch_row`, `sketch_col` and
`heap_size` are `init_univmon`'s four arguments — configuration that shapes the
payload, so the descriptor carries them and every derived length is checked
rather than re-stored. `key_type` is a structural param in the §3.5 sense: it
fixes the element type of `keys`, and the payload cannot be read without it. One
`key_type` covers every layer; a pyramid whose layers mix `HeapItem` variants
has no single one and fails to serialize, as a Space-Saving summary does.
Structural-param order is `layer_size, sketch_row, sketch_col, heap_size,
key_type`.

UnivMon carries the hash-spec group — it hashes, and a consumer must reproduce
that hash to query a key — but carries **no seed-index key**. It hashes the
bottom-layer finder at `BOTTOM_LAYER_FINDER` unconditionally: a fixed part of
the algorithm, not a profile choice, exactly as Space-Saving's index 0 is
(§3.5). The per-layer counter seed index *is* a real value, but it equals the
layer's position, so it is derived and not stored — and the encoder rejects a
layer whose seed index is not its position rather than emitting a lie.

`update_mode` and `candidate_complete` are both **carried**:

- `update_mode` is acquired from the first update, not configured, and it
  selects the query recurrence (`calc_terminal_g_sum` versus the standard
  layer recurrence). A decoder that guessed it would answer entropy and
  cardinality from the wrong reconstruction.
- `candidate_complete` is not derivable. `len < heap_size` implies complete,
  but a full heap is ambiguous — exactly-filled-never-evicted and
  evicted-since look identical — and `mark_candidates_incomplete` (the
  OctoSketch delta path) lowers the flag with no observable trace at all. A
  decoder that ignored it and re-derived from heap fullness would call an
  evicted-from layer complete, which sends `heavy_threshold` down the
  permissive branch (threshold `0` instead of `l2 / sqrt(heap_size)`) and
  counts every candidate including noise: overstated `calc_card` and
  `calc_entropy`, with nothing anywhere to indicate a problem.

`bucket_size` is the exact L1 and is not recoverable from the counters, so it
is carried. Everything else UnivMon reports — `calc_l2`, `calc_entropy`,
`calc_card` — is recomputed from the layers and appears nowhere.

**`L2HH` carries no variant tag.** `L2HH` is a single-variant enum
(`COUNT(CountL2HH)`) today, and `kind_id` fixes the payload's structure, so the
wire spells out the CountL2HH state directly with no tag — the same rule that
keeps a variant tag out of every other payload. Consequence: adding a second
`L2HH` variant later does **not** silently change these bytes. It needs either
a new metadata structural param naming the per-layer counter kind (as Count-Min
does with `counter_type`) or a new `kind_id`; `0x10 0x00` and `0x11 0x00` are
defined as all-`COUNT` and stay readable either way.

**Emitted order (cross-language contract).** Layers ascend, `0 .. layer_size`,
in every array. Within a layer the heap's entries are written in **descending
`count`**, ties broken by a **total order over the key** (variant tag first,
then the value) — the same order `heap_wire` pins for CMSHeap and CSHeap
(§3.5). This is required, not cosmetic: `HHHeap`'s array order follows the sift
path and does not survive a rebuild, so an unordered payload would re-serialize
to different bytes than it decoded from. The heap's digest index (`slots`,
`positions`) is rebuilt from the entries, so no index reaches the wire and no
crafted payload can point one out of bounds or into a cycle.

**Decode rules.** Fail **closed** on each, with an error and never a panic:

1. `kind_id` is `0x10 0x00`; any other id is rejected.
2. The hash-spec group matches the target's `HashProfile`. `layer_size`,
   `sketch_row`, `sketch_col`, `heap_size` and `key_type` are properties of the
   stored sketch, so they are echoed back rather than pinned.
3. `layer_size >= 1` and `heap_size >= 1`.
4. `sketch_row * layer_size == len(l2)` exactly, checked **before** the layer
   geometry is built, so a declared `layer_size` far larger than the payload
   carries never reserves anything.
5. Every layer's `rows` and `cols` are non-zero (`cols.ilog2()` panics on zero),
   and `len(counts)` equals the layers' total cell count, computed with checked
   arithmetic.
6. `len(heap_lens) == len(candidate_complete) == layer_size`, and
   `len(keys) == len(heap_counts) == sum(heap_lens)`.
7. `key_type` is one of the thirteen names in §3.5; the `keys` array is read
   **as** that type, so a payload whose keys are not of the declared type is
   rejected by the msgpack decode itself.
8. Each layer's entry count is `<= heap_size`, and no key appears twice within
   a layer. `heap_size` **never sizes an allocation**: each heap is seated from
   the entries the payload actually carries.
9. `update_mode` is `0`, `1` or `2`; any other value is rejected.
10. `bucket_size` fits this target's `usize`.

The encode side enforces 3-9's shape rules as well (a layer that is not the
declared size, a layer hashing at another layer's seed index, mixed or 128-bit
keys), so the format never emits bytes it would refuse to read back.

---

## §3.x: UnivMon Optimized payload (`0x11 0x00`)

`UnivMonPyramid` is UnivMon with two tiers: layers `0 .. elephant_layers` use
`elephant_row x elephant_col` counters and the rest use `mouse_row x mouse_col`.
Nothing else about it differs, so it **shares UnivMon's payload byte for byte**
and differs only in its metadata — the way HLL Classic and Ertl-MLE share one
payload and differ only by `kind_id`:

| Pos | Field | Type | Notes |
| ----- | ------- | ------ | ------- |
| 0 | `counts` | array | the layers' `CountL2HH` counters concatenated in layer order, each layer row-major; length is the layers' total cell count under the two-tier layout |
| 1 | `l2` | array | the layers' L2 accumulators concatenated in layer order; length `min(elephant_layers, layer_size) * elephant_row + max(0, layer_size - elephant_layers) * mouse_row` |
| 2 | `heap_lens` | array | u32 entries held by each layer's heap, one per layer |
| 3 | `keys` | array | every layer's heap keys concatenated, cut by `heap_lens`; element type = `key_type`; homogeneous |
| 4 | `heap_counts` | array | i64 heap count, parallel to `keys` |
| 5 | `candidate_complete` | array | one bool per layer |
| 6 | `bucket_size` | u64 | total weight recorded |
| 7 | `update_mode` | u8 | `0` unset, `1` standard, `2` terminal-only |

**Metadata vs payload.** `UnivMonPyramid::new`'s seven arguments are the
configuration, so the descriptor carries `layer_size`, `elephant_layers`,
`elephant_row`, `elephant_col`, `mouse_row`, `mouse_col` and `heap_size`, plus
the heaps' `key_type`. Layer `i`'s dimensions are `i < elephant_layers ?
elephant : mouse` — **derived**, so no per-layer geometry is stored, and a
pyramid built with `total_layers <= elephant_layers` (every layer an elephant)
falls out of the same rule with no special case. The hash-spec discussion,
the absent seed-index key, the `L2HH` no-variant-tag rule and the treatment of
`update_mode` / `candidate_complete` / `bucket_size` are all exactly UnivMon's.

**`UnivSketchPool` is not a wire kind.** It is a free-list of pre-allocated
scratch `UnivMon`s with a `total_allocated` counter — an allocator, not a
sketch, with nothing an observer could query. `0x11 0x00` is UnivMonPyramid's
alone and no id is invented for the pool.

**Emitted order (cross-language contract).** Identical to UnivMon's: layers
ascend in every array, and within a layer heap entries are descending `count`
with ties broken by the total order over the key. A decoded pyramid
re-serializes byte-identically.

**Decode rules.** Fail **closed** on each, with an error and never a panic:

1. `kind_id` is `0x11 0x00`; any other id is rejected.
2. The hash-spec group matches the target's `HashProfile`; the seven layout
   fields and `key_type` are echoed back rather than pinned.
3. `layer_size >= 1` and `heap_size >= 1`.
4. The declared layout's accumulator count equals `len(l2)` exactly, computed
   with checked arithmetic and checked **before** the geometry is built, so a
   crafted `layer_size` or tier width never reserves anything.
5. Every layer's `rows` and `cols` are non-zero, and `len(counts)` equals the
   layers' total cell count.
6. `len(heap_lens) == len(candidate_complete) == layer_size`, and
   `len(keys) == len(heap_counts) == sum(heap_lens)`.
7. `key_type` is one of the thirteen names in §3.5, and `keys` is read as it.
8. Each layer's entry count is `<= heap_size`, no key repeats within a layer,
   and `heap_size` never sizes an allocation.
9. `update_mode` is `0`, `1` or `2`.
10. `bucket_size` fits this target's `usize`.

---

## §3.x: UnivMon-Q payload (`0x1a 0x00`)

`UnivMonQ` encodes each numeric value into an order-preserving `u64` key, keeps
one `PackedCountSketch` and one bounded candidate table per level, and keeps a
coordinated bottom-k sample of stream *occurrences* keyed by
`(source_id, local_sequence)`. The whole `UnivMonQConfig` is construction
config, so the per-level widths, the hash layout and each level's candidate
capacity are all derived and the payload is raw state only:

| Pos | Field | Type | Notes |
| ----- | ------- | ------ | ------- |
| 0 | `counters` | array | the levels' CountSketch rows concatenated in level order, each level row-major over `level_width(i) * depth`; element type = `counter_type` |
| 1 | `candidate_lens` | array | u32 candidates held at each level, one per level |
| 2 | `candidate_keys` | array | u64 candidate keys concatenated, cut by `candidate_lens` |
| 3 | `candidate_scores` | array | u64 recorded score, parallel to `candidate_keys` |
| 4 | `ever_evicted` | array | one bool per level |
| 5 | `count` | u64 | observations recorded, duplicates included |
| 6 | `min` | u64 or nil | order-preserving encoding of the exact minimum; nil when empty |
| 7 | `max` | u64 or nil | order-preserving encoding of the exact maximum; nil when empty |
| 8 | `source_id` | u64 | identity the occurrence priorities are drawn from |
| 9 | `next_sequence` | u64 | next local sequence number |
| 10 | `occurrence_priority_high` | array | u64 high word of each retained occurrence's 128-bit priority |
| 11 | `occurrence_priority_low` | array | u64 low word, parallel |
| 12 | `occurrence_keys` | array | u64 key, parallel |

**Metadata vs payload.** Everything in `UnivMonQConfig` shapes the payload and
is chosen at construction, so it all lives in the descriptor: `seed_index`
(the config's `hash_seed`), `levels`, `width`, `width_halving_period`, `depth`,
`counter_type`, `candidates`, `ordered_samples`. `level_width(config, i)` and
the `HashLayout` follow from those, so no per-level width and no bucket-bit
count is stored. `candidate_capacity` is `candidates` on every level, so it is
not stored either.

`counter_type` is `"i32"` or `"i64"` and names the element type of `counters`,
exactly as Count Sketch's does (§3.6): the counters are signed, so Count-Min's
`"f64"` has no counterpart, and `i128` has no msgpack integer form. It replaces
the in-memory `counter_bits` (32/64) rather than joining it — carrying both
would be one field derivable from the other. Like `seed_index` for CountL2HH,
the hash seed here is a config value rather than a profile constant, so it is a
structural param echoed back on decode.

`min` and `max` are exact stream extrema and are **not** derivable from the
sketch, so they are carried; `None` is msgpack **nil** (the encoding Coco
already uses for a free bucket). They are nil exactly when `count == 0`, and
that biconditional is checked on both sides.

`source_id` and `next_sequence` are genuinely-carried sequence state. An
occurrence's priority is `hash128(hash_seed ^ domain, (source_id << 64) |
sequence)`, so a decoded sketch that restarted its sequence would re-draw
identities it had already used and corrupt the coordinated sample the moment it
was merged. `ever_evicted` is carried for the same reason
`candidate_complete` is on UnivMon: a full candidate table does not say whether
it ever displaced anything, and guessing "full means evicted" would widen the
recovery threshold on a level that never lost a key.

**Emitted order (cross-language contract).** Levels ascend, `0 .. levels`, in
every array. Within a level, candidates are written **ascending by key**.
Occurrences are written **ascending by `(priority_high, priority_low, key)`**,
the record's own total order. Both are required, not cosmetic: the candidate
min-heap (`BinaryHeap<Reverse<(score, key)>>`) and the ordered sample
(`BinaryHeap<OrderedOccurrence>`) are array orders that do not survive a
rebuild — the same argument §3.5 makes for Space-Saving's arenas and
`heap_wire` makes for `HHHeap`. Both heaps are rebuilt from the ordered arrays
on decode, so no heap index reaches the wire and a decoded sketch re-serializes
byte-identically.

**Decode rules.** Fail **closed** on each, with an error and never a panic:

1. `kind_id` is `0x1a 0x00`; any other id is rejected.
2. The hash-spec group matches the target's `HashProfile`; the config is
   echoed back rather than pinned.
3. `counter_type` is `"i32"` or `"i64"`; anything else is rejected, and
   `counters` is read **as** that type, so a relabelled payload does not decode.
4. The config is valid on its own terms before anything is sized from it:
   `2 <= levels <= 63`, `width >= 1`, `depth` odd and non-zero,
   `candidates >= 1`, and the hash layout fits in 128 bits. Checked **before**
   `HashLayout::new`, whose `width - 1` underflows on `width == 0`.
5. `len(counters)` equals `sum over levels of level_width(i) * depth`, computed
   with checked arithmetic, **before** any level is built.
6. `len(candidate_lens) == len(ever_evicted) == levels`, every
   `candidate_lens[i] <= candidates`, and
   `len(candidate_keys) == len(candidate_scores) == sum(candidate_lens)`.
7. No candidate key repeats within a level, and each candidate's key hashes
   into the level it is stored at.
8. The three occurrence arrays are parallel and equal-length,
   `len <= ordered_samples`, no occurrence repeats, and an
   `ordered_samples == 0` config carries none.
9. `count == 0` if and only if `min` and `max` are both nil, and
   `min <= max` when both are present.
10. `candidates` and `ordered_samples` **never size an allocation.** Each
    level's candidate map and heap are sized from the run the payload carries,
    and the ordered heap is built from the occurrences it carries, so a payload
    declaring `candidates = 2^32 - 1` with two candidates costs two candidates.
    The sketch is built field by field rather than through
    `with_hasher_and_source_id`, which reserves from the declared capacities.

Rules 4-9 are enforced on the **encode** side too, so the format never emits
bytes it would refuse to read back.

---

## Decisions recorded

- **The CountL2HH sub-payload is `[counts, l2]`, defined once** in
  `src/sketches/countsketch_topk/l2hh_wire.rs`. `counts` is row-major
  `rows*cols`; `l2` is `rows` long and is state, not a recomputable derivative.
  `rows` / `cols` / `seed_index` are construction config and go into the
  standalone `0x19 0x00` metadata. As a UnivMon layer the same two arrays are
  **inlined** into the outer positional array and the three parameters come
  from the outer metadata plus the layer's position.
- **Where the shared helpers live.** A new `pub(crate) mod l2hh_wire` beside
  CSHeap's `wire.rs` under `src/sketches/countsketch_topk/`, imported by path —
  the `heap_wire.rs` precedent. It is a *sibling* of `wire.rs` rather than part
  of it because `wire.rs` stays private while `l2hh_wire` must be reachable
  from `sketch_framework`; keeping them separate widens nothing else. The
  pyramid payload shared by `0x10 0x00` and `0x11 0x00` lives the same way, in
  `pub(crate) mod wire` under `src/sketch_framework/univmon/`, and
  `univmon_optimized/wire.rs` imports it by path.
- **`L2HH` carries no variant tag** (see the UnivMon draft above for the
  consequence of adding a second variant).
- **`update_mode` is carried; `candidate_complete` is carried.** Neither is
  reconstructible; the UnivMon draft says what a decoder that ignored
  `candidate_complete` would get wrong.
- **UnivMon-Q's ordering state** is carried with a pinned emitted order and
  both heaps rebuilt on decode (see the UnivMon-Q draft).
- **`min` / `max` are msgpack nil when absent**, and are not derivable.
- **Emitted order is pinned for every array in all four payloads**, so a
  decoded sketch re-serializes byte-identically. There are tests for each.
- **`UnivMonPyramid` and `UnivSketchPool` are one kind_id, not two.**
  `0x11 0x00` is the pyramid's. `UnivSketchPool` is a free-list of scratch
  `UnivMon`s — an allocator with no queryable state — so it gets no id, and
  none is invented for it here.
- **UnivMon and UnivMonPyramid are profile-pinned to `DefaultXxHasher`.** They
  hash through the free `hash64_seeded` / `hash_item64_seeded` helpers and hold
  `CountL2HH<DefaultXxHasher>` layers, so there is no hasher type parameter to
  derive from and no truthful way to emit another profile. Their metadata is
  still *derived live* from `DefaultXxHasher`'s `HashProfile` (never
  hardcoded), and the `AltHasher` test for them is the fail-closed half: a
  custom-profile envelope is different bytes and is rejected on decode.
  CountL2HH and UnivMon-Q are generic over `H` and get the full three-part
  test.
- **A new wire module adds no `native/<x>.rs` shim.** None added.

## Files outside the four wire modules

Three edits were unavoidable and are called out here:

- `src/message_pack_format/native/countsketch_topk.rs` — the existing
  `MessagePackCodec` shim for `CountL2HH<H>` was bounded on `H: SketchHasher`
  alone and cannot call a method that needs `H: HashProfile`. One bound
  widened to `H: SketchHasher + HashProfile`; nothing else changed.
- `examples/evaluate_univmon_q_skew.rs` — `UnivMonQ::serialize_to_bytes` /
  `deserialize_from_bytes` moved from `impl UnivMonQ<DefaultXxHasher>` to the
  generic impl, so one unconstrained `UnivMonQ::deserialize_from_bytes(..)`
  call needed its hasher spelled out.
- `docs/api/api_cs_heap.md` — two lines that said CountL2HH has no ASAPv1
  payload are now false.

`src/common/input.rs` was read but not changed: `L2HH` needed nothing.
`docs/asapv1_wire_format.md`, `docs/tests.md`, `asapv1_golden/`,
`tests/asapv1_golden.rs`, `src/message_pack_format/envelope.rs` and every other
sketch's `wire.rs` (including `heap_wire.rs`, reused read-only) are untouched.

## Tests

`src/sketches/countsketch_topk/l2hh_wire.rs` (10): round trip asserting
`b"ASAPv1"` and `[0x19,0x00]`; decoded value re-serializes byte-identically;
negative counters round-trip unchanged; the seed index travels with the sketch
and separates two otherwise-identical sketches; the `AltHasher` three-part
custom-profile test; cross-rejection of UnivMon, UnivMonPyramid, UnivMon-Q and
a plain Count Sketch envelope; crafted geometry (zero dimension, a
`4096x4096` claim over a three-cell payload, a mis-sized `l2`, a negative
accumulator) rejected before any allocation and without a panic; encode-side
rejection of an unfilled matrix; unknown and missing metadata keys rejected;
an empty sketch has exactly one encoding.

`src/sketch_framework/univmon/wire.rs` (9): round trip asserting `b"ASAPv1"`
and `[0x10,0x00]`, with the decoded pyramid re-serializing byte-identically and
agreeing on L1/L2/entropy/cardinality; layers holding different-sized heaps
round-trip with each layer's entries and order intact; `update_mode` and
`candidate_complete` are carried, and flipping the flags changes what a query
reports; an empty pyramid has exactly one encoding and decodes to empty heaps;
the profile is pinned (`AltHasher` bytes differ and are rejected);
cross-rejection of CountL2HH, UnivMonPyramid, UnivMon-Q and a Count Sketch
envelope; crafted shapes rejected without a panic, including
`layer_size = u32::MAX`, a zero `sketch_col`, a zero `layer_size`, a zero
`heap_size`, a `4096x4096` geometry, a `heap_size` under the payload's own
entry count, short parallel arrays and an out-of-range `update_mode`;
encode-side rejection of a mis-sized layer, a layer at the wrong seed index,
mixed key variants and a 128-bit key; unknown and missing metadata keys
rejected.

`src/sketch_framework/univmon_optimized/wire.rs` (11): the same set for
`[0x11,0x00]`, plus the two-tier geometry surviving a round trip (elephant
layers keep their dimensions, mouse layers keep theirs, every layer keeps its
seed index) and a pyramid with no mouse layers round-tripping.

`src/sketch_framework/univmon_q/wire.rs` (9): round trip asserting `b"ASAPv1"`
and `[0x1a,0x00]` with a byte-identical re-serialization; the ordering-state
test — a decoded sketch fed the same subsequent updates agrees with the
original fed those updates, on `next_sequence`, on the retained occurrence
sample and on the CDF; an empty sketch has exactly one encoding with nil
extrema, and a cleared sketch is deliberately *not* the same bytes because it
keeps its sequence; `counter_type` pinned (i32 and i64 bytes differ, an
`"f64"` label is rejected); the `AltHasher` three-part test; cross-rejection of
the other three; crafted shapes rejected without a panic, including a
`levels = 63` claim over a four-level payload, `width = u32::MAX`, an invalid
`levels`/`depth`/`candidates`, a disabled `ordered_samples` with samples
present, a foreign seed index, short parallel arrays, inconsistent extrema and
a candidate moved to the wrong terminal level; encode-side rejection of a
mis-sized level, an impossible `count`/`min`/`max` triple and an over-capacity
candidate table; unknown and missing metadata keys rejected.

Existing tests kept and now exercising the new path: `countl2hh_round_trip_serialization`,
`univmon_round_trip_serialization`, and UnivMon-Q's eviction-history,
query-preservation and checkpoint-resume tests (the last three renamed from
`native_messagepack_*` / `messagepack_*` to `asapv1_*`). UnivMon-Q's two
version-1 legacy-DTO tests are removed with the DTO they exercised — under
Q-VER a new encoding gets a new `kind_id`, so `0x1a 0x00` has no payload
version field and no legacy-upgrade path.

## CI

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean.
- `cargo test --all-features --locked --verbose` — all green.

The known pre-existing `cargo clippy --workspace --all-targets --locked`
(default features) failure in `tests/e2e_octo.rs` is untouched and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
