### PR TITLE
feat(eh): ASAPv1 wire payloads for ExponentialHistogram (0x13 0x00) and EHSketchList (0x14 0x00)

### DIFF
--- a/docs/api/api_ehsketchlist.md
+++ b/docs/api/api_ehsketchlist.md
@@ -49,7 +49,37 @@ fn merge(&mut self, other: &EHSketchList) -> Result<(), &'static str>
 
 ## Serialization
 
-Serialized through serde as part of parent structures.
+```rust
+fn serialize_to_bytes(&self) -> Result<Vec<u8>, rmp_serde::encode::Error>
+fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, rmp_serde::decode::Error>
+```
+
+ASAPv1 MessagePack, kind_id `0x14 0x00`. The metadata carries only
+`metadata_version`; the payload is the triple `[variant, descriptor, state]`,
+where `variant` is the wire name of the enum arm and `descriptor` / `state` are
+that sketch's own ASAPv1 metadata and payload blocks carried verbatim as
+msgpack `bin`. An `ExponentialHistogram` bucket inlines the same triple, so
+there is one EHSketchList encoding.
+
+The ten wire names and the kind_id whose blocks they carry:
+
+| Variant | Wire name | Blocks belong to | Feature |
+| ------- | --------- | ---------------- | ------- |
+| `CM` | `"CountMin"` | `0x02 0x00` | default |
+| `COCO` | `"Coco"` | `0x0c 0x00` | `experimental` |
+| `COUNTL2HH` | `"CountL2HH"` | `0x19 0x00` | default |
+| `CS` | `"CountSketch"` | `0x04 0x00` | default |
+| `DDS` | `"DDSketch"` | `0x05 0x00` | default |
+| `ELASTIC` | `"Elastic"` | `0x0b 0x00` | `experimental` |
+| `HLL` | `"HLL"` | `0x01 0x02` | default |
+| `KLL` | `"KLL"` | `0x06 0x00` | default |
+| `UNIFORM` | `"UniformSampling"` | `0x0d 0x00` | `experimental` |
+| `UNIVMON` | `"UnivMon"` | `0x10 0x00` | default |
+
+The name table is the same in every build. A decoder built without
+`experimental` rejects `"Coco"`, `"Elastic"` and `"UniformSampling"` with an
+error naming the variant, and its encoder can never emit them. An unrecognized
+name is rejected. `EHSketchList` also derives serde.
 
 ## Examples
 

--- a/docs/api/api_exponential_histogram.md
+++ b/docs/api/api_exponential_histogram.md
@@ -42,7 +42,25 @@ Managed internally during bucket compaction.
 
 ## Serialization
 
-No dedicated serialization API.
+```rust
+fn serialize_to_bytes(&self) -> Result<Vec<u8>, rmp_serde::encode::Error>
+fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, rmp_serde::decode::Error>
+```
+
+ASAPv1 MessagePack, kind_id `0x13 0x00`. The metadata carries `window` and `k`;
+the payload is `[buckets, sizes, min_times, max_times, prototype]`. `buckets`
+holds one inlined `EHSketchList` triple per bucket, oldest to newest, and the
+next three arrays are parallel to it; `prototype` is the `type_to_clone` triple.
+The bucket count is `len(buckets)`.
+
+There is no hash-spec group: the histogram never hashes, and each bucket's own
+`descriptor` carries whatever hash spec its sketch has. `l2_mass` and
+`merge_norm` are recomputed on decode rather than carried, so a state whose
+cached values disagree with the sketches they derive from does not serialize.
+
+A `k` of zero, a bucket of size zero, an inverted bucket time range, parallel
+arrays of unequal length, an unknown or feature-gated variant name, and a
+bucket whose descriptor names a different hash profile are all rejected.
 
 ## Examples
 
@@ -58,6 +76,8 @@ let _ = eh.query_interval_merge(0, 120);
 ## Caveats
 
 - Payload behavior depends on selected `EHSketchList` variant.
+- `payload`, `l2_mass` and `merge_norm` are public fields; a histogram edited
+  into a state `update_with` cannot reach does not serialize.
 
 ## Status
 

--- a/src/sketch_framework/eh.rs
+++ b/src/sketch_framework/eh.rs
@@ -8,6 +8,8 @@ use super::EHSketchList;
 use super::eh_sketch_list::SketchNorm;
 use crate::DataInput;
 
+mod wire;
+
 const MASS_EPSILON: f64 = 1e-9;
 
 #[derive(Clone, Debug)]

--- a/src/sketch_framework/eh/wire.rs
+++ b/src/sketch_framework/eh/wire.rs
@@ -1,0 +1,520 @@
+//! ASAPv1 wire serialization for [`ExponentialHistogram`].
+//!
+//! Child submodule of [`crate::sketch_framework::eh`]: it holds the
+//! metadata/payload DTOs, the kind_id constant and the `serialize_to_bytes` /
+//! `deserialize_from_bytes` impls. Being a descendant module, it reads the
+//! private `infer_merge_norm` / `compute_l2_mass` rules directly.
+//!
+//! ExponentialHistogram is one kind_id, `0x13 0x00`. `window` and `k` are
+//! construction config and live in the metadata, so the payload is the buckets,
+//! their time ranges and sizes, and the prototype.
+//!
+//! ## Buckets are inlined
+//!
+//! Each bucket holds one [`EHSketchList`], written into this payload as the
+//! `[variant, descriptor, state]` triple
+//! [`crate::sketch_framework::eh_sketch_list::wire`] defines. No bucket carries
+//! an envelope, a magic or a kind_id of its own.
+//!
+//! ## No hash-spec group
+//!
+//! The histogram never hashes: its buckets' sketches do, each in its own way,
+//! and three of the ten do not hash at all. Every hash spec on the wire is the
+//! one inside a bucket's own `descriptor`.
+//!
+//! ## Emitted order (byte-stable round trips)
+//!
+//! Buckets are emitted oldest to newest and the parallel arrays follow that
+//! order, so a decoded histogram re-serializes byte-identically.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+use crate::sketch_framework::eh_sketch_list::wire::{SketchState, rebuild_sketch, sketch_state};
+
+use super::{EHBucket, ExponentialHistogram, compute_l2_mass, infer_merge_norm};
+
+/// ExponentialHistogram kind_id: family `0x13`, single algorithm variant `0x00`.
+const EH_KIND: &[u8] = &[0x13, 0x00];
+
+/// ExponentialHistogram descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`) with keys in this declaration order — the canonical order
+/// the wire spec fixes (Go must mirror it).
+///
+/// Structural params only. The histogram does not hash, so there is no
+/// hash-spec group; each bucket's `descriptor` carries its sketch's own.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct EhMetadata {
+    pub(crate) metadata_version: u8,
+    pub(crate) window: u64,
+    pub(crate) k: u32,
+}
+
+/// Builds the ExponentialHistogram descriptor metadata.
+pub(crate) fn eh_metadata(window: u64, k: u32) -> EhMetadata {
+    EhMetadata {
+        metadata_version: 1,
+        window,
+        k,
+    }
+}
+
+/// ExponentialHistogram payload (ASAPv1, kind_id `0x13 0x00`), a msgpack
+/// **array** (`to_vec`, positional):
+/// `[buckets, sizes, min_times, max_times, prototype]`.
+///
+/// The first four are parallel and dense, oldest bucket first; the bucket count
+/// is `len(buckets)`. `prototype` is the sketch every new bucket is cloned from.
+#[derive(Debug, Serialize, Deserialize)]
+struct EhPayload {
+    buckets: Vec<SketchState>,
+    sizes: Vec<u64>,
+    min_times: Vec<u64>,
+    max_times: Vec<u64>,
+    prototype: SketchState,
+}
+
+/// Rejects a bucket state the algorithm never reaches: an empty bucket, an
+/// inverted time range, or a cached mass that disagrees with its sketch.
+fn check_bucket(index: usize, bucket: &EHBucket) -> Result<(), String> {
+    if bucket.size == 0 {
+        return Err(format!("bucket {index} has size 0"));
+    }
+    if bucket.min_time > bucket.max_time {
+        return Err(format!(
+            "bucket {index} spans [{}, {}]",
+            bucket.min_time, bucket.max_time
+        ));
+    }
+    let mass = compute_l2_mass(&bucket.bucket);
+    if bucket.l2_mass != mass {
+        return Err(format!(
+            "bucket {index} caches l2_mass {} against its sketch's {mass}",
+            bucket.l2_mass
+        ));
+    }
+    Ok(())
+}
+
+// Wire serialization for ExponentialHistogram. `wire` is a descendant of the
+// framework module, so this impl reads the parent's derivation rules directly.
+impl ExponentialHistogram {
+    /// Serializes the histogram into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x13 0x00`). `window` and `k` land in the metadata; the
+    /// payload is the buckets, their sizes and time ranges, and the prototype.
+    ///
+    /// A `k` of zero, a bucket the algorithm never reaches, and a `merge_norm`
+    /// that disagrees with the prototype are errors rather than bytes that
+    /// would be refused on decode.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let fail = |problem: String| {
+            RmpEncodeError::Syntax(format!("ASAPv1 ExponentialHistogram envelope: {problem}"))
+        };
+        if self.k == 0 {
+            return Err(fail("k must be at least 1".to_string()));
+        }
+        let k = u32::try_from(self.k)
+            .map_err(|_| fail(format!("k {} exceeds the u32 metadata field", self.k)))?;
+        if self.merge_norm != infer_merge_norm(&self.type_to_clone) {
+            return Err(fail(format!(
+                "merge_norm {:?} disagrees with the prototype's",
+                self.merge_norm
+            )));
+        }
+        let mut buckets = Vec::with_capacity(self.payload.len());
+        let mut sizes = Vec::with_capacity(self.payload.len());
+        for (index, bucket) in self.payload.iter().enumerate() {
+            check_bucket(index, bucket).map_err(fail)?;
+            sizes.push(u64::try_from(bucket.size).map_err(|_| {
+                fail(format!(
+                    "bucket {index} size {} exceeds the u64 payload field",
+                    bucket.size
+                ))
+            })?);
+            buckets.push(sketch_state(&bucket.bucket)?);
+        }
+        let metadata = rmp_serde::to_vec_named(&eh_metadata(self.window, k))?;
+        let payload = rmp_serde::to_vec(&EhPayload {
+            buckets,
+            sizes,
+            min_times: self.payload.iter().map(|b| b.min_time).collect(),
+            max_times: self.payload.iter().map(|b| b.max_time).collect(),
+            prototype: sketch_state(&self.type_to_clone)?,
+        })?;
+        Ok(envelope::encode(EH_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a histogram from an ASAPv1 MessagePack envelope. The bucket
+    /// count is the payload's own array length, `l2_mass` is recomputed from
+    /// each decoded sketch and `merge_norm` from the decoded prototype.
+    ///
+    /// Every state the algorithm could not have produced is rejected with an
+    /// error rather than a panic, and no declared count sizes an allocation
+    /// before the payload is measured against it.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != EH_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "ExponentialHistogram kind_id mismatch: stored {kind_id:?}, expected {EH_KIND:?}"
+            )));
+        }
+        let meta: EhMetadata = from_slice(metadata)?;
+        // `window` and `k` are properties of the stored histogram rather than
+        // of the target, so they are echoed back into the expected block and
+        // bounded by range instead of being pinned.
+        if meta != eh_metadata(meta.window, meta.k) {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 ExponentialHistogram envelope: metadata mismatch".to_string(),
+            ));
+        }
+        if meta.k == 0 {
+            return Err(RmpDecodeError::Uncategorized(
+                "ExponentialHistogram k must be at least 1".to_string(),
+            ));
+        }
+        let p: EhPayload = from_slice(payload)?;
+        let count = p.buckets.len();
+        if p.sizes.len() != count || p.min_times.len() != count || p.max_times.len() != count {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "ExponentialHistogram parallel lengths (buckets {count}, sizes {}, min_times {}, max_times {}) disagree",
+                p.sizes.len(),
+                p.min_times.len(),
+                p.max_times.len()
+            )));
+        }
+        let mut decoded = Vec::with_capacity(count);
+        for (index, triple) in p.buckets.iter().enumerate() {
+            let sketch = rebuild_sketch(triple)?;
+            let bucket = EHBucket {
+                l2_mass: compute_l2_mass(&sketch),
+                bucket: sketch,
+                size: usize::try_from(p.sizes[index]).map_err(|_| {
+                    RmpDecodeError::Uncategorized(format!(
+                        "ExponentialHistogram bucket {index} size {} exceeds this target's usize",
+                        p.sizes[index]
+                    ))
+                })?,
+                min_time: p.min_times[index],
+                max_time: p.max_times[index],
+            };
+            check_bucket(index, &bucket).map_err(RmpDecodeError::Uncategorized)?;
+            decoded.push(bucket);
+        }
+        let type_to_clone = rebuild_sketch(&p.prototype)?;
+        Ok(ExponentialHistogram {
+            payload: decoded,
+            window: meta.window,
+            k: meta.k as usize,
+            merge_norm: infer_merge_norm(&type_to_clone),
+            type_to_clone,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sketch_framework::eh_sketch_list::wire::tests::{
+        alt_profile_triple, populated_variants, relabelled, sample_input,
+    };
+    use crate::sketch_framework::eh_sketch_list::wire::{
+        CM_VARIANT, COCO_VARIANT, ELASTIC_VARIANT, UNIFORM_VARIANT,
+    };
+    use crate::sketch_framework::eh_sketch_list::{EHSketchList, SketchNorm};
+    use crate::{CountMin, DataInput, FastPath, Vector2D};
+
+    /// A histogram over Count-Min buckets with a few timestamped updates.
+    fn populated_eh() -> ExponentialHistogram {
+        let mut eh = ExponentialHistogram::new(
+            2,
+            1000,
+            EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8)),
+        );
+        for i in 0..6u64 {
+            eh.update(i * 10, &DataInput::U64(i % 3));
+        }
+        eh
+    }
+
+    /// The `(size, min_time, max_time, l2_mass)` of every bucket, oldest first.
+    /// The mass is compared bit-exactly: it is recomputed on decode, not read.
+    fn ranges(eh: &ExponentialHistogram) -> Vec<(usize, u64, u64, u64)> {
+        eh.payload
+            .iter()
+            .map(|b| (b.size, b.min_time, b.max_time, b.l2_mass.to_bits()))
+            .collect()
+    }
+
+    /// Wraps a crafted payload in a `0x13 0x00` envelope with valid metadata.
+    fn envelope_for(payload: &EhPayload) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(&eh_metadata(1000, 2)).unwrap();
+        envelope::encode(EH_KIND, &metadata, &rmp_serde::to_vec(payload).unwrap())
+    }
+
+    #[test]
+    fn eh_round_trip_serialization() {
+        let eh = populated_eh();
+        let encoded = eh.serialize_to_bytes().expect("serialize EH");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x13, 0x00]); // kind_id_len=2, kind_id=[0x13,0x00]
+
+        let decoded = ExponentialHistogram::deserialize_from_bytes(&encoded).expect("deserialize");
+        assert_eq!(decoded.window, eh.window);
+        assert_eq!(decoded.k, eh.k);
+        assert_eq!(decoded.merge_norm, eh.merge_norm);
+        assert_eq!(ranges(&decoded), ranges(&eh));
+        assert_eq!(decoded.bucket_count(), eh.bucket_count());
+    }
+
+    /// Every variant this build carries round-trips as an EH bucket and as the
+    /// prototype.
+    #[test]
+    fn eh_every_variant_round_trips_as_a_bucket() {
+        for prototype in populated_variants() {
+            let name = prototype.sketch_type();
+            let key = sample_input(name);
+            let mut eh = ExponentialHistogram::new(3, 1000, prototype);
+            for i in 0..4u64 {
+                eh.update(i * 5, &key);
+            }
+            let encoded = eh
+                .serialize_to_bytes()
+                .unwrap_or_else(|e| panic!("serialize EH<{name}>: {e}"));
+            let decoded = ExponentialHistogram::deserialize_from_bytes(&encoded)
+                .unwrap_or_else(|e| panic!("deserialize EH<{name}>: {e}"));
+            assert_eq!(decoded.type_to_clone.sketch_type(), name);
+            assert_eq!(ranges(&decoded), ranges(&eh));
+            let again = decoded.serialize_to_bytes().expect("re-serialize");
+            assert_eq!(encoded, again, "EH<{name}> is not byte-stable");
+        }
+    }
+
+    /// An empty histogram has exactly one encoding and round-trips.
+    #[test]
+    fn eh_empty_has_one_encoding_and_round_trips() {
+        let prototype =
+            EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let a = ExponentialHistogram::new(2, 1000, prototype.clone());
+        let b = ExponentialHistogram::new(2, 1000, prototype);
+        let bytes = a.serialize_to_bytes().expect("serialize");
+        assert_eq!(bytes, b.serialize_to_bytes().expect("serialize"));
+
+        let decoded = ExponentialHistogram::deserialize_from_bytes(&bytes).expect("deserialize");
+        assert_eq!(decoded.bucket_count(), 0);
+        assert_eq!(bytes, decoded.serialize_to_bytes().expect("re-serialize"));
+    }
+
+    /// A prototype carrying state keeps it, so later buckets start from it.
+    #[test]
+    fn eh_carries_a_non_empty_prototype() {
+        let mut prototype =
+            EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        for _ in 0..7 {
+            prototype.insert(&DataInput::U64(9));
+        }
+        let eh = ExponentialHistogram::new(2, 1000, prototype);
+        let bytes = eh.serialize_to_bytes().expect("serialize");
+        let decoded = ExponentialHistogram::deserialize_from_bytes(&bytes).expect("deserialize");
+        assert_eq!(
+            decoded.type_to_clone.query(&DataInput::U64(9)),
+            eh.type_to_clone.query(&DataInput::U64(9))
+        );
+        assert!(decoded.type_to_clone.query(&DataInput::U64(9)).unwrap() >= 7.0);
+    }
+
+    /// A decoded histogram re-serializes byte-identically and answers an
+    /// interval query the way the original did.
+    #[test]
+    fn eh_decoded_re_serializes_byte_identically_and_queries_agree() {
+        let eh = populated_eh();
+        let bytes = eh.serialize_to_bytes().expect("serialize");
+        let decoded = ExponentialHistogram::deserialize_from_bytes(&bytes).expect("deserialize");
+        assert_eq!(bytes, decoded.serialize_to_bytes().expect("re-serialize"));
+
+        let key = DataInput::U64(1);
+        let original = eh.query_interval_merge(0, 50).expect("query");
+        let round_tripped = decoded.query_interval_merge(0, 50).expect("query");
+        assert_eq!(original.query(&key).ok(), round_tripped.query(&key).ok());
+    }
+
+    /// An EHSketchList envelope and a Count-Min envelope are not
+    /// ExponentialHistogram envelopes.
+    #[test]
+    fn eh_rejects_foreign_kind_ids() {
+        let list = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let list_bytes = list.serialize_to_bytes().expect("serialize EHSketchList");
+        assert!(ExponentialHistogram::deserialize_from_bytes(&list_bytes).is_err());
+
+        let cms = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8);
+        let cms_bytes = cms.serialize_to_bytes().expect("serialize CMS");
+        assert!(ExponentialHistogram::deserialize_from_bytes(&cms_bytes).is_err());
+    }
+
+    /// Fail closed on an unexpected metadata key.
+    #[test]
+    fn eh_metadata_rejects_unknown_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            window: u64,
+            k: u32,
+            bogus_field: u8,
+        }
+        let bytes = rmp_serde::to_vec_named(&WithExtra {
+            metadata_version: 1,
+            window: 1000,
+            k: 2,
+            bogus_field: 7,
+        })
+        .unwrap();
+        assert!(rmp_serde::from_slice::<EhMetadata>(&bytes).is_err());
+    }
+
+    /// `k` is required: a metadata map missing it does not decode, so it can
+    /// never be silently defaulted.
+    #[test]
+    fn eh_metadata_rejects_a_missing_key() {
+        #[derive(Serialize)]
+        struct WithoutK {
+            metadata_version: u8,
+            window: u64,
+        }
+        let bytes = rmp_serde::to_vec_named(&WithoutK {
+            metadata_version: 1,
+            window: 1000,
+        })
+        .unwrap();
+        assert!(rmp_serde::from_slice::<EhMetadata>(&bytes).is_err());
+    }
+
+    /// `k` is at least 1 on both sides.
+    #[test]
+    fn eh_rejects_a_zero_k() {
+        let mut eh = populated_eh();
+        eh.k = 0;
+        assert!(eh.serialize_to_bytes().is_err());
+
+        let good = populated_eh().serialize_to_bytes().expect("serialize");
+        let (_, _, payload) = envelope::split(&good).expect("split");
+        let metadata = rmp_serde::to_vec_named(&eh_metadata(1000, 0)).unwrap();
+        let bytes = envelope::encode(EH_KIND, &metadata, payload);
+        assert!(ExponentialHistogram::deserialize_from_bytes(&bytes).is_err());
+    }
+
+    /// A declared array far longer than the buckets the payload carries is
+    /// rejected before anything is sized from it.
+    #[test]
+    fn eh_rejects_parallel_arrays_of_unequal_length() {
+        let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let triple = sketch_state(&sketch).expect("state");
+        let payload = EhPayload {
+            buckets: vec![sketch_state(&sketch).expect("state")],
+            sizes: vec![1; 1_000_000],
+            min_times: vec![0],
+            max_times: vec![0],
+            prototype: triple,
+        };
+        assert!(ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload)).is_err());
+    }
+
+    /// A zero size and an inverted time range are states the algorithm never
+    /// reaches, rejected on both sides.
+    #[test]
+    fn eh_rejects_impossible_bucket_state() {
+        let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let payload = EhPayload {
+            buckets: vec![sketch_state(&sketch).expect("state")],
+            sizes: vec![0],
+            min_times: vec![0],
+            max_times: vec![0],
+            prototype: sketch_state(&sketch).expect("state"),
+        };
+        assert!(ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload)).is_err());
+
+        let payload = EhPayload {
+            buckets: vec![sketch_state(&sketch).expect("state")],
+            sizes: vec![1],
+            min_times: vec![9],
+            max_times: vec![4],
+            prototype: sketch_state(&sketch).expect("state"),
+        };
+        assert!(ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload)).is_err());
+
+        let mut eh = populated_eh();
+        eh.payload[0].size = 0;
+        assert!(eh.serialize_to_bytes().is_err());
+    }
+
+    /// A cached `l2_mass` or `merge_norm` that disagrees with the state it is
+    /// derived from has no encoding.
+    #[test]
+    fn eh_rejects_derived_fields_that_disagree() {
+        let mut eh = populated_eh();
+        eh.payload[0].l2_mass = 42.0;
+        assert!(eh.serialize_to_bytes().is_err());
+
+        let mut eh = populated_eh();
+        eh.merge_norm = SketchNorm::L2;
+        assert!(eh.serialize_to_bytes().is_err());
+    }
+
+    /// An experimental variant tag in a bucket is rejected without the feature.
+    /// Crafted bytes, so the test runs in both builds.
+    #[test]
+    fn eh_rejects_an_experimental_variant_tag_in_a_bucket() {
+        let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        for variant in [COCO_VARIANT, ELASTIC_VARIANT, UNIFORM_VARIANT] {
+            let payload = EhPayload {
+                buckets: vec![relabelled(&sketch, variant)],
+                sizes: vec![1],
+                min_times: vec![0],
+                max_times: vec![0],
+                prototype: relabelled(&sketch, CM_VARIANT),
+            };
+            let message = ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload))
+                .expect_err("a relabelled bucket must not decode")
+                .to_string();
+            assert!(!message.is_empty());
+            #[cfg(not(feature = "experimental"))]
+            {
+                assert!(message.contains(variant), "{message}");
+                assert!(message.contains("experimental"), "{message}");
+            }
+        }
+    }
+
+    /// A bucket whose descriptor names a custom hash profile is rejected: the
+    /// variant's decoder pins the profile of the type it rebuilds.
+    #[test]
+    fn eh_rejects_a_custom_hash_profile_bucket() {
+        let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let payload = EhPayload {
+            buckets: vec![alt_profile_triple()],
+            sizes: vec![1],
+            min_times: vec![0],
+            max_times: vec![0],
+            prototype: sketch_state(&sketch).expect("state"),
+        };
+        assert!(ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload)).is_err());
+    }
+
+    /// An unknown variant tag in a bucket is rejected by name.
+    #[test]
+    fn eh_rejects_an_unknown_variant_tag_in_a_bucket() {
+        let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let payload = EhPayload {
+            buckets: vec![relabelled(&sketch, "Bogus")],
+            sizes: vec![1],
+            min_times: vec![0],
+            max_times: vec![0],
+            prototype: sketch_state(&sketch).expect("state"),
+        };
+        let message = ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload))
+            .expect_err("an unknown variant must not decode")
+            .to_string();
+        assert!(message.contains("Bogus"), "{message}");
+    }
+}

--- a/src/sketch_framework/eh_sketch_list.rs
+++ b/src/sketch_framework/eh_sketch_list.rs
@@ -7,6 +7,8 @@ use super::super::sketches::*;
 use super::UnivMon;
 use crate::sketches::countsketch_topk::CountL2HH;
 
+pub(crate) mod wire;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 /// Norm choices used by EH merge policies.
 pub enum SketchNorm {

--- a/src/sketch_framework/eh_sketch_list/wire.rs
+++ b/src/sketch_framework/eh_sketch_list/wire.rs
@@ -1,0 +1,556 @@
+//! ASAPv1 wire serialization for [`EHSketchList`], plus the sub-payload
+//! [`ExponentialHistogram`] reuses.
+//!
+//! Child submodule of [`crate::sketch_framework::eh_sketch_list`]: it holds the
+//! metadata/payload DTOs, the kind_id constant, the variant-tag table and the
+//! `serialize_to_bytes` / `deserialize_from_bytes` impls.
+//!
+//! EHSketchList is one kind_id, `0x14 0x00`. It is a tagged union over ten
+//! sketch algorithms, so the encoding is the triple
+//! `[variant, descriptor, state]`.
+//!
+//! ## One encoding, used in both places
+//!
+//! [`sketch_state`] and [`rebuild_sketch`] are the only place an EHSketchList is
+//! read or rebuilt. The standalone `0x14 0x00` payload is one triple; an
+//! [`ExponentialHistogram`] bucket inlines the same triple.
+//!
+//! ## `descriptor` and `state` are the variant's own blocks
+//!
+//! `descriptor` is the variant's ASAPv1 metadata block and `state` its ASAPv1
+//! payload block, both verbatim. The variant tag stands in for the kind_id, so
+//! no magic, version or kind_id byte appears inside the triple.
+//!
+//! ## The tag namespace is fixed in every build
+//!
+//! All ten names and their kind_ids exist whatever features are on. A decoder
+//! built without `experimental` rejects `Coco`, `Elastic` and `UniformSampling`
+//! with an error naming the variant, and its encoder can never emit them.
+
+use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
+use serde::{Deserialize, Serialize};
+
+use crate::message_pack_format::envelope;
+
+use super::EHSketchList;
+
+/// EHSketchList kind_id: family `0x14`, single algorithm variant `0x00`.
+pub(crate) const EH_SKETCH_LIST_KIND: &[u8] = &[0x14, 0x00];
+
+/// Wire name of [`EHSketchList::CM`].
+pub(crate) const CM_VARIANT: &str = "CountMin";
+/// Wire name of `EHSketchList::COCO`.
+pub(crate) const COCO_VARIANT: &str = "Coco";
+/// Wire name of [`EHSketchList::COUNTL2HH`].
+pub(crate) const COUNTL2HH_VARIANT: &str = "CountL2HH";
+/// Wire name of [`EHSketchList::CS`].
+pub(crate) const CS_VARIANT: &str = "CountSketch";
+/// Wire name of [`EHSketchList::DDS`].
+pub(crate) const DDS_VARIANT: &str = "DDSketch";
+/// Wire name of `EHSketchList::ELASTIC`.
+pub(crate) const ELASTIC_VARIANT: &str = "Elastic";
+/// Wire name of [`EHSketchList::HLL`].
+pub(crate) const HLL_VARIANT: &str = "HLL";
+/// Wire name of [`EHSketchList::KLL`].
+pub(crate) const KLL_VARIANT: &str = "KLL";
+/// Wire name of `EHSketchList::UNIFORM`.
+pub(crate) const UNIFORM_VARIANT: &str = "UniformSampling";
+/// Wire name of [`EHSketchList::UNIVMON`].
+pub(crate) const UNIVMON_VARIANT: &str = "UnivMon";
+
+/// The kind_id each variant's `descriptor` / `state` blocks belong to.
+/// Present for all ten names in every build.
+pub(crate) fn variant_kind_id(variant: &str) -> Option<&'static [u8]> {
+    match variant {
+        CM_VARIANT => Some(&[0x02, 0x00]),
+        COCO_VARIANT => Some(&[0x0c, 0x00]),
+        COUNTL2HH_VARIANT => Some(&[0x19, 0x00]),
+        CS_VARIANT => Some(&[0x04, 0x00]),
+        DDS_VARIANT => Some(&[0x05, 0x00]),
+        ELASTIC_VARIANT => Some(&[0x0b, 0x00]),
+        HLL_VARIANT => Some(&[0x01, 0x02]),
+        KLL_VARIANT => Some(&[0x06, 0x00]),
+        UNIFORM_VARIANT => Some(&[0x0d, 0x00]),
+        UNIVMON_VARIANT => Some(&[0x10, 0x00]),
+        _ => None,
+    }
+}
+
+/// EHSketchList descriptor metadata (ASAPv1 §2), a msgpack **map**
+/// (`to_vec_named`). The union has no construction config of its own: the
+/// variant belongs to the triple, which travels whole.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct EhSketchListMetadata {
+    pub(crate) metadata_version: u8,
+}
+
+/// Builds the EHSketchList descriptor metadata.
+pub(crate) fn eh_sketch_list_metadata() -> EhSketchListMetadata {
+    EhSketchListMetadata {
+        metadata_version: 1,
+    }
+}
+
+/// One EHSketchList as a msgpack **array** (`to_vec`, positional):
+/// `[variant, descriptor, state]`. `descriptor` and `state` are the variant's
+/// own ASAPv1 metadata and payload blocks, carried as msgpack `bin`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SketchState {
+    pub(crate) variant: String,
+    #[serde(with = "serde_bytes")]
+    pub(crate) descriptor: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub(crate) state: Vec<u8>,
+}
+
+/// Rejects a variant name outside the ten.
+pub(crate) fn unknown_variant(variant: &str) -> RmpDecodeError {
+    RmpDecodeError::Uncategorized(format!(
+        "ASAPv1 EHSketchList: variant {variant:?} is not a wire variant"
+    ))
+}
+
+/// Rejects the three variants a build without `experimental` does not carry.
+#[cfg(not(feature = "experimental"))]
+fn check_variant_available(variant: &str) -> Result<(), RmpDecodeError> {
+    match variant {
+        COCO_VARIANT | ELASTIC_VARIANT | UNIFORM_VARIANT => Err(RmpDecodeError::Uncategorized(
+            format!("ASAPv1 EHSketchList: variant {variant:?} requires the experimental feature"),
+        )),
+        _ => Ok(()),
+    }
+}
+
+/// Every variant is carried in an `experimental` build.
+#[cfg(feature = "experimental")]
+fn check_variant_available(_variant: &str) -> Result<(), RmpDecodeError> {
+    Ok(())
+}
+
+/// Splits one variant's own envelope into the triple, pinning its kind_id.
+fn triple(variant: &'static str, bytes: &[u8]) -> Result<SketchState, RmpEncodeError> {
+    let (kind_id, descriptor, state) = envelope::split(bytes).map_err(RmpEncodeError::Syntax)?;
+    let expected = variant_kind_id(variant).ok_or_else(|| {
+        RmpEncodeError::Syntax(format!(
+            "ASAPv1 EHSketchList: variant {variant:?} is not a wire variant"
+        ))
+    })?;
+    if kind_id != expected {
+        return Err(RmpEncodeError::Syntax(format!(
+            "ASAPv1 EHSketchList: variant {variant:?} produced kind_id {kind_id:?}, expected {expected:?}"
+        )));
+    }
+    Ok(SketchState {
+        variant: variant.to_string(),
+        descriptor: descriptor.to_vec(),
+        state: state.to_vec(),
+    })
+}
+
+/// The triple one EHSketchList contributes, in the order the wire emits it.
+/// Every state the variant's own encoder refuses is refused here too.
+pub(crate) fn sketch_state(sketch: &EHSketchList) -> Result<SketchState, RmpEncodeError> {
+    match sketch {
+        EHSketchList::CM(s) => triple(CM_VARIANT, &s.serialize_to_bytes()?),
+        #[cfg(feature = "experimental")]
+        EHSketchList::COCO(s) => triple(COCO_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::COUNTL2HH(s) => triple(COUNTL2HH_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::CS(s) => triple(CS_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::DDS(s) => triple(DDS_VARIANT, &s.serialize_to_bytes()?),
+        #[cfg(feature = "experimental")]
+        EHSketchList::ELASTIC(s) => triple(ELASTIC_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::HLL(s) => triple(HLL_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::KLL(s) => triple(KLL_VARIANT, &s.serialize_to_bytes()?),
+        #[cfg(feature = "experimental")]
+        EHSketchList::UNIFORM(s) => triple(UNIFORM_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::UNIVMON(s) => triple(UNIVMON_VARIANT, &s.serialize_to_bytes()?),
+    }
+}
+
+/// Rebuilds one EHSketchList from a triple, through the variant's own decoder.
+/// An unknown name, and an experimental name in a build without the feature,
+/// are rejected before any state is read.
+pub(crate) fn rebuild_sketch(triple: &SketchState) -> Result<EHSketchList, RmpDecodeError> {
+    let variant = triple.variant.as_str();
+    let kind_id = variant_kind_id(variant).ok_or_else(|| unknown_variant(variant))?;
+    check_variant_available(variant)?;
+    let bytes = envelope::encode(kind_id, &triple.descriptor, &triple.state);
+    match variant {
+        CM_VARIANT => Ok(EHSketchList::CM(crate::CountMin::deserialize_from_bytes(
+            &bytes,
+        )?)),
+        #[cfg(feature = "experimental")]
+        COCO_VARIANT => Ok(EHSketchList::COCO(crate::Coco::deserialize_from_bytes(
+            &bytes,
+        )?)),
+        COUNTL2HH_VARIANT => Ok(EHSketchList::COUNTL2HH(
+            crate::CountL2HH::deserialize_from_bytes(&bytes)?,
+        )),
+        CS_VARIANT => Ok(EHSketchList::CS(crate::Count::deserialize_from_bytes(
+            &bytes,
+        )?)),
+        DDS_VARIANT => Ok(EHSketchList::DDS(crate::DDSketch::deserialize_from_bytes(
+            &bytes,
+        )?)),
+        #[cfg(feature = "experimental")]
+        ELASTIC_VARIANT => Ok(EHSketchList::ELASTIC(
+            crate::Elastic::deserialize_from_bytes(&bytes)?,
+        )),
+        HLL_VARIANT => Ok(EHSketchList::HLL(
+            crate::HyperLogLog::<crate::ErtlMLE>::deserialize_from_bytes(&bytes)?,
+        )),
+        KLL_VARIANT => Ok(EHSketchList::KLL(crate::KLL::deserialize_from_bytes(
+            &bytes,
+        )?)),
+        #[cfg(feature = "experimental")]
+        UNIFORM_VARIANT => Ok(EHSketchList::UNIFORM(
+            crate::UniformSampling::deserialize_from_bytes(&bytes)?,
+        )),
+        UNIVMON_VARIANT => Ok(EHSketchList::UNIVMON(
+            crate::UnivMon::deserialize_from_bytes(&bytes)?,
+        )),
+        other => Err(unknown_variant(other)),
+    }
+}
+
+// Wire serialization for EHSketchList. `wire` is a descendant of the union's
+// module, so this impl matches its variants directly.
+impl EHSketchList {
+    /// Serializes the sketch into an ASAPv1 MessagePack envelope
+    /// (kind_id `0x14 0x00`). The payload is the triple
+    /// `[variant, descriptor, state]`.
+    ///
+    /// A state the variant's own encoder refuses is an error rather than bytes
+    /// that would be refused on decode.
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, RmpEncodeError> {
+        let metadata = rmp_serde::to_vec_named(&eh_sketch_list_metadata())?;
+        let payload = rmp_serde::to_vec(&sketch_state(self)?)?;
+        Ok(envelope::encode(EH_SKETCH_LIST_KIND, &metadata, &payload))
+    }
+
+    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The variant
+    /// tag selects the decoder, which validates its own descriptor and state.
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
+        let (kind_id, metadata, payload) =
+            envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
+        if kind_id != EH_SKETCH_LIST_KIND {
+            return Err(RmpDecodeError::Uncategorized(format!(
+                "EHSketchList kind_id mismatch: stored {kind_id:?}, expected {EH_SKETCH_LIST_KIND:?}"
+            )));
+        }
+        let meta: EhSketchListMetadata = from_slice(metadata)?;
+        if meta != eh_sketch_list_metadata() {
+            return Err(RmpDecodeError::Uncategorized(
+                "ASAPv1 EHSketchList envelope: metadata mismatch".to_string(),
+            ));
+        }
+        let triple: SketchState = from_slice(payload)?;
+        rebuild_sketch(&triple)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::sketch_framework::univmon::UnivMon;
+    use crate::{
+        CANONICAL_HASH_SEED, Count, CountL2HH, CountMin, DDSketch, DataInput, DefaultXxHasher,
+        ErtlMLE, FastPath, HashProfile, HyperLogLog, KLL, SketchHasher, Vector2D,
+    };
+
+    /// An input the named variant accepts. UnivMon's heaps hold one `HeapItem`
+    /// variant at a time, so its keys stay strings.
+    pub(crate) fn sample_input(sketch_type: &str) -> DataInput<'static> {
+        match sketch_type {
+            "Coco" | "Elastic" | "UnivMon" => DataInput::Str("flow::a"),
+            _ => DataInput::F64(7.5),
+        }
+    }
+
+    /// One populated sketch per variant this build carries, in wire-name order.
+    pub(crate) fn populated_variants() -> Vec<EHSketchList> {
+        let mut out = vec![EHSketchList::CM(
+            CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8),
+        )];
+        #[cfg(feature = "experimental")]
+        out.push(EHSketchList::COCO(crate::Coco::init_with_size(16, 2)));
+        out.push(EHSketchList::COUNTL2HH(CountL2HH::with_dimensions(3, 256)));
+        out.push(EHSketchList::CS(
+            Count::<Vector2D<i32>, FastPath>::with_dimensions(3, 8),
+        ));
+        out.push(EHSketchList::DDS(DDSketch::new(0.01)));
+        #[cfg(feature = "experimental")]
+        out.push(EHSketchList::ELASTIC(crate::Elastic::init_with_dimensions(
+            8, 2, 256,
+        )));
+        out.push(EHSketchList::HLL(HyperLogLog::<ErtlMLE>::default()));
+        out.push(EHSketchList::KLL(KLL::init_kll(200)));
+        #[cfg(feature = "experimental")]
+        out.push(EHSketchList::UNIFORM(crate::UniformSampling::new(0.5)));
+        out.push(EHSketchList::UNIVMON(UnivMon::default()));
+        for sketch in &mut out {
+            let key = sample_input(sketch.sketch_type());
+            for _ in 0..5 {
+                sketch.insert(&key);
+            }
+        }
+        out
+    }
+
+    /// A test-only custom hasher: hashes exactly like `DefaultXxHasher` but
+    /// declares a DIFFERENT `HashProfile`.
+    #[derive(Clone, Debug)]
+    pub(crate) struct AltHasher;
+
+    impl SketchHasher for AltHasher {
+        type HashType = <DefaultXxHasher as SketchHasher>::HashType;
+
+        fn hash64_seeded(d: usize, key: &DataInput) -> u64 {
+            DefaultXxHasher::hash64_seeded(d, key)
+        }
+        fn hash128_seeded(d: usize, key: &DataInput) -> u128 {
+            DefaultXxHasher::hash128_seeded(d, key)
+        }
+        fn hash_item64_seeded(d: usize, key: &crate::HeapItem) -> u64 {
+            DefaultXxHasher::hash_item64_seeded(d, key)
+        }
+        fn hash_item128_seeded(d: usize, key: &crate::HeapItem) -> u128 {
+            DefaultXxHasher::hash_item128_seeded(d, key)
+        }
+        fn hash_for_matrix_seeded(
+            seed_idx: usize,
+            rows: usize,
+            cols: usize,
+            key: &DataInput,
+        ) -> Self::HashType {
+            DefaultXxHasher::hash_for_matrix_seeded(seed_idx, rows, cols, key)
+        }
+    }
+
+    impl HashProfile for AltHasher {
+        const PROFILE_ID: &'static str = "test.alt.profile.v1";
+        const ALGORITHM: &'static str = "xxh3_64_128";
+        const SEED_DERIVATION: &'static str = "seed_list_index_wrap";
+        const INPUT_ENCODING: &'static str = "projectasap.input.v1";
+        fn seed_list() -> Vec<u64> {
+            vec![1, 2, 3, 4, 5]
+        }
+        const CANONICAL_SEED_INDEX: u32 = CANONICAL_HASH_SEED as u32;
+        const MATRIX_SEED_INDEX: u32 = 0;
+    }
+
+    /// A Count-Min triple whose descriptor names a custom hash profile.
+    pub(crate) fn alt_profile_triple() -> SketchState {
+        let sketch = CountMin::<Vector2D<i32>, FastPath, AltHasher>::with_dimensions(3, 8);
+        let bytes = sketch.serialize_to_bytes().expect("serialize alt CM");
+        let (_, descriptor, state) = envelope::split(&bytes).expect("split alt CM");
+        SketchState {
+            variant: CM_VARIANT.to_string(),
+            descriptor: descriptor.to_vec(),
+            state: state.to_vec(),
+        }
+    }
+
+    /// The triple a variant contributes, with the tag replaced.
+    pub(crate) fn relabelled(sketch: &EHSketchList, variant: &str) -> SketchState {
+        let mut triple = sketch_state(sketch).expect("state");
+        triple.variant = variant.to_string();
+        triple
+    }
+
+    /// Wraps a triple in a `0x14 0x00` envelope.
+    pub(crate) fn envelope_for(triple: &SketchState) -> Vec<u8> {
+        let metadata = rmp_serde::to_vec_named(&eh_sketch_list_metadata()).unwrap();
+        let payload = rmp_serde::to_vec(triple).unwrap();
+        envelope::encode(EH_SKETCH_LIST_KIND, &metadata, &payload)
+    }
+
+    #[test]
+    fn eh_sketch_list_round_trip_serialization() {
+        let mut sketch =
+            EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        sketch.insert(&DataInput::U64(42));
+
+        let encoded = sketch.serialize_to_bytes().expect("serialize EHSketchList");
+        assert!(encoded.starts_with(b"ASAPv1"));
+        assert_eq!(&encoded[7..10], &[2u8, 0x14, 0x00]); // kind_id_len=2, kind_id=[0x14,0x00]
+
+        let decoded = EHSketchList::deserialize_from_bytes(&encoded).expect("deserialize");
+        assert_eq!(decoded.sketch_type(), "CountMin");
+        assert_eq!(
+            decoded.query(&DataInput::U64(42)),
+            sketch.query(&DataInput::U64(42))
+        );
+    }
+
+    /// Every variant this build carries round-trips, keeps its type, and
+    /// re-serializes byte-identically.
+    #[test]
+    fn eh_sketch_list_every_variant_round_trips() {
+        for sketch in populated_variants() {
+            let encoded = sketch
+                .serialize_to_bytes()
+                .unwrap_or_else(|e| panic!("serialize {}: {e}", sketch.sketch_type()));
+            let decoded = EHSketchList::deserialize_from_bytes(&encoded)
+                .unwrap_or_else(|e| panic!("deserialize {}: {e}", sketch.sketch_type()));
+            assert_eq!(decoded.sketch_type(), sketch.sketch_type());
+            let again = decoded.serialize_to_bytes().expect("re-serialize");
+            assert_eq!(
+                encoded,
+                again,
+                "{} is not byte-stable",
+                sketch.sketch_type()
+            );
+        }
+    }
+
+    /// The ten tags and their kind_ids are the same in every build.
+    #[test]
+    fn eh_sketch_list_variant_tags_are_build_independent() {
+        let table: [(&str, &[u8]); 10] = [
+            (CM_VARIANT, &[0x02, 0x00]),
+            (COCO_VARIANT, &[0x0c, 0x00]),
+            (COUNTL2HH_VARIANT, &[0x19, 0x00]),
+            (CS_VARIANT, &[0x04, 0x00]),
+            (DDS_VARIANT, &[0x05, 0x00]),
+            (ELASTIC_VARIANT, &[0x0b, 0x00]),
+            (HLL_VARIANT, &[0x01, 0x02]),
+            (KLL_VARIANT, &[0x06, 0x00]),
+            (UNIFORM_VARIANT, &[0x0d, 0x00]),
+            (UNIVMON_VARIANT, &[0x10, 0x00]),
+        ];
+        for (variant, kind_id) in table {
+            assert_eq!(variant_kind_id(variant), Some(kind_id), "{variant}");
+        }
+        assert_eq!(variant_kind_id("CountMinSketch"), None);
+    }
+
+    /// An experimental tag is rejected without the feature, with an error
+    /// naming the variant. Crafted bytes, so the test runs in both builds.
+    #[test]
+    fn eh_sketch_list_rejects_an_experimental_variant_tag() {
+        for variant in [COCO_VARIANT, ELASTIC_VARIANT, UNIFORM_VARIANT] {
+            let triple = SketchState {
+                variant: variant.to_string(),
+                descriptor: Vec::new(),
+                state: Vec::new(),
+            };
+            let message = EHSketchList::deserialize_from_bytes(&envelope_for(&triple))
+                .expect_err("an empty variant state must not decode")
+                .to_string();
+            assert!(!message.is_empty());
+            #[cfg(not(feature = "experimental"))]
+            {
+                assert!(message.contains(variant), "{message}");
+                assert!(message.contains("experimental"), "{message}");
+            }
+        }
+    }
+
+    #[test]
+    fn eh_sketch_list_rejects_an_unknown_variant_tag() {
+        let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let triple = relabelled(&sketch, "Bogus");
+        let message = EHSketchList::deserialize_from_bytes(&envelope_for(&triple))
+            .expect_err("an unknown variant must not decode")
+            .to_string();
+        assert!(message.contains("Bogus"), "{message}");
+    }
+
+    /// A tag that does not match the block it carries is rejected by the
+    /// variant's own decoder.
+    #[test]
+    fn eh_sketch_list_rejects_a_mismatched_variant_and_descriptor() {
+        let sketch = EHSketchList::HLL(HyperLogLog::<ErtlMLE>::default());
+        let triple = relabelled(&sketch, CM_VARIANT);
+        assert!(EHSketchList::deserialize_from_bytes(&envelope_for(&triple)).is_err());
+    }
+
+    /// A Count-Min envelope and an ExponentialHistogram envelope are not
+    /// EHSketchList envelopes.
+    #[test]
+    fn eh_sketch_list_rejects_foreign_kind_ids() {
+        let cms = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8);
+        let cms_bytes = cms.serialize_to_bytes().expect("serialize CMS");
+        assert!(EHSketchList::deserialize_from_bytes(&cms_bytes).is_err());
+
+        let eh = crate::ExponentialHistogram::new(
+            2,
+            100,
+            EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8)),
+        );
+        let eh_bytes = eh.serialize_to_bytes().expect("serialize EH");
+        assert!(EHSketchList::deserialize_from_bytes(&eh_bytes).is_err());
+    }
+
+    /// Fail closed on an unexpected metadata key.
+    #[test]
+    fn eh_sketch_list_metadata_rejects_unknown_keys() {
+        #[derive(Serialize)]
+        struct WithExtra {
+            metadata_version: u8,
+            bogus_field: u8,
+        }
+        let bytes = rmp_serde::to_vec_named(&WithExtra {
+            metadata_version: 1,
+            bogus_field: 7,
+        })
+        .unwrap();
+        assert!(rmp_serde::from_slice::<EhSketchListMetadata>(&bytes).is_err());
+    }
+
+    /// `metadata_version` is required: a map missing it does not decode.
+    #[test]
+    fn eh_sketch_list_metadata_rejects_a_missing_key() {
+        #[derive(Serialize)]
+        struct Empty {}
+        let bytes = rmp_serde::to_vec_named(&Empty {}).unwrap();
+        assert!(rmp_serde::from_slice::<EhSketchListMetadata>(&bytes).is_err());
+    }
+
+    /// Crafted blocks fail closed with an error, never a panic.
+    #[test]
+    fn eh_sketch_list_rejects_crafted_blocks() {
+        let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
+        let good = sketch_state(&sketch).expect("state");
+
+        let truncated = SketchState {
+            variant: CM_VARIANT.to_string(),
+            descriptor: good.descriptor[..good.descriptor.len() / 2].to_vec(),
+            state: good.state.clone(),
+        };
+        assert!(EHSketchList::deserialize_from_bytes(&envelope_for(&truncated)).is_err());
+
+        let garbage = SketchState {
+            variant: CM_VARIANT.to_string(),
+            descriptor: good.descriptor.clone(),
+            state: vec![0xc1, 0xc1, 0xc1],
+        };
+        assert!(EHSketchList::deserialize_from_bytes(&envelope_for(&garbage)).is_err());
+    }
+
+    /// A descriptor naming a custom hash profile is rejected: the variant's
+    /// decoder pins the profile of the type it rebuilds.
+    #[test]
+    fn eh_sketch_list_rejects_a_custom_hash_profile_descriptor() {
+        let triple = alt_profile_triple();
+        assert!(EHSketchList::deserialize_from_bytes(&envelope_for(&triple)).is_err());
+    }
+
+    /// A decoded union answers a query the way the original did.
+    #[test]
+    fn eh_sketch_list_query_agrees_after_decode() {
+        for sketch in populated_variants() {
+            let key = sample_input(sketch.sketch_type());
+            let encoded = sketch.serialize_to_bytes().expect("serialize");
+            let decoded = EHSketchList::deserialize_from_bytes(&encoded).expect("deserialize");
+            assert_eq!(
+                sketch.query(&key).ok(),
+                decoded.query(&key).ok(),
+                "{} disagrees after decode",
+                sketch.sketch_type()
+            );
+        }
+    }
+}


### PR DESCRIPTION
ASAPv1 wire payloads for `ExponentialHistogram` (`0x13 0x00`) and `EHSketchList`
(`0x14 0x00`). Both kind_ids were already allocated in the Section 1 registry.

`ExponentialHistogram` literally contains `EHSketchList` — every `EHBucket`
holds one — so there is exactly **one** EHSketchList encoding, designed once and
used in both places: as the standalone `0x14 0x00` payload and as the inlined
sub-payload of every EH bucket.

---

## Read this first: how a nested sketch's state is carried

The settled convention is *inline the nested sketch's raw state, never nest an
envelope*. Ten different algorithms can sit in an `EHSketchList`, and eight of
them cannot be rebuilt from raw arrays outside their own module: their fields
are private and their `wire` submodule is the only descendant that can
reconstruct them. `HyperLogLogImpl`, `DDSketch`, `KLL`, `Coco`, `Elastic` and
`UniformSampling` have no public constructor from state at all. Writing the raw
arrays out here would have needed either a `pub(crate)` rebuild helper added to
each of the eight `src/sketches/*/wire.rs` files (the `l2hh_wire` precedent), or
widened field visibility. The task forbids both, so this PR takes the third
option:

**A nested `EHSketchList` carries the variant's own ASAPv1 *metadata block* and
*payload block*, verbatim, with no envelope.** No magic, no version byte and no
`kind_id` appears anywhere inside an EH payload — a stable variant *name* stands
in for the `kind_id`, and the two blocks are carried as msgpack `bin`.

Consequences, stated plainly:

- The encoding of each variant is, byte for byte, the §3.x encoding that variant
  already has. There is nothing new to specify per variant and nothing to drift.
- Encode calls the variant's public `serialize_to_bytes` and splits the envelope
  off with the shared `message_pack_format::envelope`; decode reassembles the
  envelope from the variant name's `kind_id` and calls the variant's public
  `deserialize_from_bytes`. No sketch's `wire.rs` is imported and no field
  visibility is widened. Every geometry check, allocation guard and hash-profile
  pin each variant already enforces applies unchanged inside an EH.
- The cost is that a bucket's `descriptor` repeats that sketch's metadata map
  (~140 bytes for a hashing variant). This is not pure redundancy: a bucket's
  descriptor genuinely varies per bucket — `UnivMon`'s `key_type` is derived
  from the keys its heaps hold, so two buckets of the same EH can legitimately
  carry different descriptors. Hoisting one shared descriptor into the EH
  metadata would reject legitimate histograms.

**This is the one point in the PR that needs a decision I was not authorised to
make.** If the preferred answer is instead to add a `pub(crate)` `state` /
`rebuild` pair to each of the eight sketch `wire.rs` modules (mirroring
`l2hh_wire::layer_state` / `rebuild_layer`), say so and the payload shapes below
stay identical — only `descriptor` and `state` collapse into per-variant raw
arrays.

---

## §3.x: EHSketchList payload (`0x14 0x00`)

`EHSketchList` is a tagged union over ten sketch algorithms. Its encoding is one
positional triple, and that triple is the unit that travels wherever an
`EHSketchList` appears:

| Pos | Field | Type | Notes |
| --- | ----- | ---- | ----- |
| 0 | `variant` | str | one of the ten wire names below; exact, never widened |
| 1 | `descriptor` | bin | that variant's own ASAPv1 metadata block, verbatim |
| 2 | `state` | bin | that variant's own ASAPv1 payload block, verbatim |

The standalone `0x14 0x00` payload **is** this triple. An `ExponentialHistogram`
bucket inlines the same triple as a nested 3-element array. One encoding, two
places.

**Metadata vs payload.** The union has no construction configuration of its own:
which algorithm it holds, and that algorithm's configuration, both belong to the
value being carried rather than to the wrapper. So `0x14 0x00`'s metadata is
`metadata_version` alone, and `variant` sits at position 0 of the payload — read
before `descriptor` and `state`, which is all a positional decoder needs. This
is what keeps the encoding identical in both places: an EH bucket has no
metadata map of its own to put a variant name in.

**No hash-spec group.** `EHSketchList` does not hash; the sketch inside it does,
each in its own way, and three of the ten (`KLL`, `DDSketch`,
`UniformSampling`) do not hash at all. A hash-spec group on the wrapper would
have no truthful value, so per Q-KLL it does not exist. Every hash spec on the
wire is the one inside a `descriptor`, written by the variant that owns it.

### Variant tags

| `variant` | Rust arm | Blocks belong to kind_id | Build |
| --------- | -------- | ------------------------ | ----- |
| `"CountMin"` | `CM(CountMin<Vector2D<i32>, FastPath>)` | `0x02 0x00` | always |
| `"Coco"` | `COCO(Coco)` | `0x0c 0x00` | `experimental` |
| `"CountL2HH"` | `COUNTL2HH(CountL2HH)` | `0x19 0x00` | always |
| `"CountSketch"` | `CS(Count<Vector2D<i32>, FastPath>)` | `0x04 0x00` | always |
| `"DDSketch"` | `DDS(DDSketch)` | `0x05 0x00` | always |
| `"Elastic"` | `ELASTIC(Elastic)` | `0x0b 0x00` | `experimental` |
| `"HLL"` | `HLL(HyperLogLog<ErtlMLE>)` | `0x01 0x02` | always |
| `"KLL"` | `KLL(KLL)` | `0x06 0x00` | always |
| `"UniformSampling"` | `UNIFORM(UniformSampling)` | `0x0d 0x00` | `experimental` |
| `"UnivMon"` | `UNIVMON(UnivMon)` | `0x10 0x00` | always |

**Feature-gating contract (cross-language; Go must honour it).**

1. The tag namespace is **fixed and identical in every build**. All ten names
   and all ten kind_id mappings exist whether or not the `experimental` feature
   is on. A tag is a name, never an enum ordinal and never a discriminant, so no
   tag's meaning can shift because a variant is compiled out.
2. A decoder built **without** `experimental` that meets `"Coco"`, `"Elastic"`
   or `"UniformSampling"` **fails closed**, before any block is assembled, with
   an error naming the variant and the feature. It never misparses, skips, or
   substitutes another variant.
3. An encoder built **without** `experimental` can never emit those three tags:
   the enum arms do not exist.
4. A name outside the ten is rejected. Names follow the Space-Saving §3.5
   `key_type` precedent: exact, never widened, unknown rejected.

`CM` and `CS` both hold `Vector2D<i32>` on the `FastPath`, so their descriptors
carry `counter_type = "i32"` and `mode = "fast"`. `i32` is never widened — a
nested Count Sketch must decode back into the arm it was stored as, which is the
Q-CS rule the spec already records.

**Decode rules.** Fail closed on each, with an error and never a panic:

1. `kind_id` is `0x14 0x00`; any other id is rejected. The metadata is
   `metadata_version = 1` and nothing else; an unknown key or a missing key is
   rejected (`deny_unknown_fields`).
2. `variant` is one of the ten names; anything else is rejected by name.
3. A variant this build does not carry is rejected **before** `descriptor` and
   `state` are assembled into anything, with an error naming the variant.
4. `descriptor` and `state` are handed to that variant's own decoder, wrapped in
   the variant's own `kind_id`. Every check that decoder makes applies here:
   geometry bounds, length agreement, allocation guards, and the hash-profile
   pin. Bytes hashed under a different profile do not decode into an
   `EHSketchList`, exactly as they do not decode into the bare sketch.
5. A `descriptor` / `state` pair that does not belong to the declared variant
   fails inside that variant's decoder; no partial state is produced.

---

## §3.x: ExponentialHistogram payload (`0x13 0x00`)

`ExponentialHistogram` is a sliding window over sketch-bearing buckets. `window`
and `k` are chosen at construction, so per the config→metadata rule they live in
the metadata (`metadata_version`, `window`, `k`). The payload is the buckets and
what the buckets themselves record:

| Pos | Field | Type | Notes |
| --- | ----- | ---- | ----- |
| 0 | `buckets` | array | one inlined EHSketchList triple per bucket, **oldest to newest** |
| 1 | `sizes` | array | u64 aggregate size, parallel to `buckets`; each `>= 1` |
| 2 | `min_times` | array | u64 earliest timestamp, parallel to `buckets` |
| 3 | `max_times` | array | u64 latest timestamp, parallel to `buckets`; `min_times[i] <= max_times[i]` |
| 4 | `prototype` | array | the EHSketchList triple new buckets are cloned from |

The four bucket arrays are parallel and equal-length. **The bucket count is not
carried**: it is `len(buckets)`, derived, so no declared count exists for a
crafted payload to inflate.

**Metadata vs payload.** `window` and `k` are the histogram's two construction
parameters — they shape the merge policy the same way Count-Min's `rows`/`cols`
shape its matrix — so they are the descriptor. `k >= 1` on both sides
(`ExponentialHistogram::new` clamps with `k.max(1)`, so this never rejects real
bytes).

**No hash-spec group.** The histogram itself never hashes. Its buckets' sketches
do, differently per variant, and three variants do not hash at all — so no
single hash spec on `0x13 0x00` could be truthful, and per Q-KLL a field with no
truthful value must not exist. The hash spec that matters is the one inside each
bucket's own `descriptor`, written by the sketch that owns it and validated by
that sketch's decoder.

**Emitted order (cross-language contract).** Buckets are emitted **oldest to
newest**, the order `ExponentialHistogram::payload` maintains and the order the
merge rules depend on: `merge_volumes_l1` walks the vector backwards comparing
adjacent sizes, and `find_l2_merge_candidate` accumulates the mass of everything
newer. Reversing or reordering would change which buckets merge next. `sizes`,
`min_times` and `max_times` follow the same index order, and each bucket's
triple is emitted at its own index, so a decoded histogram re-serializes
byte-identically.

**Decode rules.** Fail closed on each, with an error and never a panic:

1. `kind_id` is `0x13 0x00`; any other id is rejected.
2. Metadata is exactly `{metadata_version, window, k}`; an unknown key or a
   missing key is rejected. `window` and `k` are properties of the stored
   histogram rather than of the target, so they are echoed back into the
   expected block; `k >= 1` is enforced by range.
3. `len(sizes) == len(min_times) == len(max_times) == len(buckets)`. Checked
   before any bucket is rebuilt.
4. Each `sizes[i] >= 1` — a bucket enters the histogram at size 1 and only grows
   by merging — and `min_times[i] <= max_times[i]`.
5. Each bucket triple and the prototype are decoded by the §3.x EHSketchList
   rules above, so a feature-gated tag, an unknown tag, a crafted geometry or a
   foreign hash profile inside any bucket rejects the whole histogram.
6. Nothing is sized from a declared count. `k` sizes no allocation, and the
   bucket count is the payload's own array length, so a hostile `k` or a
   hostile parallel-array length costs nothing.
7. `l2_mass` and `merge_norm` are **recomputed**, never read (below).

---

## Decisions recorded

**`l2_mass` is derived — dropped.** `compute_l2_mass(s)` is
`s.eh_l2_mass().unwrap_or(0.0)`. `eh_l2_mass` answers `Some` only for
`COUNTL2HH` (`get_l2_sqr()`) and `UNIVMON` (`calc_l2()²`), and `None` — hence
`0.0` — for the other eight, including every variant where the mass is
meaningless. Both `Some` arms are pure functions of the sketch's decoded state,
and both call sites that ever write the field (`update_with` and
`EHBucket::to_merge`) assign exactly `compute_l2_mass(&bucket)`. So the field is
exactly recomputable on decode and, per the derived-field rule that keeps CMS's
`l1`/`l2` off the wire, it is **not carried**. The decoder recomputes it. The
encoder rejects a bucket whose cached `l2_mass` disagrees with its sketch — a
state only a hand-edited `EHBucket` can reach, and one the decoder would not
reproduce.

**`merge_norm` is derived — dropped.** `infer_merge_norm(&type_to_clone)` reads
`supports_norm` and is a pure function of the prototype's *variant*.
`ExponentialHistogram::new` is the only constructor and sets it exactly that
way. Not carried; recomputed from the decoded prototype. The encoder rejects a
histogram whose `merge_norm` disagrees with its prototype.

**`type_to_clone` carries its full state.** Nothing constrains the prototype to
be empty: `new(k, window, eh_type)` takes whatever the caller hands it, and
`update_with` clones it for every new bucket without ever mutating it. A
prototype seeded with data therefore seeds every future bucket, so carrying only
its variant and geometry would silently change the histogram's future behaviour.
It is carried as a full EHSketchList triple, the same shape a bucket uses.

**`size` is genuine state — carried.** It counts the updates folded into a
bucket (1 on creation, summed on merge) and is not recoverable from the sketch:
an HLL bucket that saw the same key five times has `size = 5` and cardinality 1.

**Bucket count is derived — not carried.** It is `len(buckets)`.

**`window` and `k` are construction config — metadata.**

**Emitted order is oldest-to-newest**, pinned as a cross-language contract
above, and a decoded histogram re-serializes byte-identically (tested for every
variant).

**`0x13 0x00` carries no hash-spec group**, resolved by the Q-KLL rule as
described above.

---

## Layout

- `src/sketch_framework/eh_sketch_list.rs` gains `pub(crate) mod wire;`
- `src/sketch_framework/eh_sketch_list/wire.rs` — new. Owns the single
  EHSketchList encoding (`SketchState`, `sketch_state`, `rebuild_sketch`), the
  variant-tag table, and the `0x14 0x00` envelope.
- `src/sketch_framework/eh.rs` gains `mod wire;`
- `src/sketch_framework/eh/wire.rs` — new. Owns the `0x13 0x00` envelope and
  imports the triple by path.
- `docs/api/api_ehsketchlist.md`, `docs/api/api_exponential_histogram.md` —
  serialization sections filled in.

No `native/<x>.rs` shim. No golden fixtures. No other sketch's `wire.rs` is
imported or modified; no field visibility is widened anywhere.

---

## Tests

`0x14 0x00` (`src/sketch_framework/eh_sketch_list/wire.rs`), twelve:

1. `eh_sketch_list_round_trip_serialization` — asserts `b"ASAPv1"` and
   `kind_id_len=2, kind_id=[0x14,0x00]`.
2. `eh_sketch_list_every_variant_round_trips` — every variant this build carries
   round-trips, keeps its `sketch_type()`, and re-serializes byte-identically.
3. `eh_sketch_list_variant_tags_are_build_independent` — the ten names and their
   kind_ids, asserted as a table; compiled and run in both builds.
4. `eh_sketch_list_rejects_an_experimental_variant_tag` — crafted bytes for all
   three experimental tags; compiles and runs in both builds, and in the
   default-feature build asserts the error names the variant and the feature.
5. `eh_sketch_list_rejects_an_unknown_variant_tag`.
6. `eh_sketch_list_rejects_a_mismatched_variant_and_descriptor` — an HLL block
   relabelled `"CountMin"`.
7. `eh_sketch_list_rejects_foreign_kind_ids` — a Count-Min envelope and a
   `0x13 0x00` envelope.
8. `eh_sketch_list_metadata_rejects_unknown_keys`.
9. `eh_sketch_list_metadata_rejects_a_missing_key`.
10. `eh_sketch_list_rejects_crafted_blocks` — a truncated descriptor and a
    garbage state; error, no panic.
11. `eh_sketch_list_rejects_a_custom_hash_profile_descriptor` — a Count-Min
    descriptor built with a test `AltHasher` `HashProfile`.
12. `eh_sketch_list_query_agrees_after_decode` — every variant.

`0x13 0x00` (`src/sketch_framework/eh/wire.rs`), fifteen:

1. `eh_round_trip_serialization` — asserts `b"ASAPv1"` and
   `kind_id_len=2, kind_id=[0x13,0x00]`.
2. `eh_every_variant_round_trips_as_a_bucket` — every variant as prototype and
   as bucket; sizes, ranges and cached masses preserved; byte-identical
   re-serialization.
3. `eh_empty_has_one_encoding_and_round_trips` — two independently built empty
   histograms emit identical bytes.
4. `eh_carries_a_non_empty_prototype`.
5. `eh_decoded_re_serializes_byte_identically_and_queries_agree` — plus an
   interval query on both.
6. `eh_rejects_foreign_kind_ids` — a `0x14 0x00` envelope and a Count-Min one.
7. `eh_metadata_rejects_unknown_keys`.
8. `eh_metadata_rejects_a_missing_key` — `k` omitted.
9. `eh_rejects_a_zero_k` — encode and decode sides.
10. `eh_rejects_parallel_arrays_of_unequal_length` — one bucket against a
    declared million sizes; rejected before anything is sized.
11. `eh_rejects_impossible_bucket_state` — size 0, inverted time range, both
    sides.
12. `eh_rejects_derived_fields_that_disagree` — a stale cached `l2_mass` and a
    `merge_norm` that disagrees with the prototype; encode-side rejection of a
    state the decoder would not reproduce.
13. `eh_rejects_an_experimental_variant_tag_in_a_bucket` — crafted bytes,
    compiles and runs in both builds.
14. `eh_rejects_a_custom_hash_profile_bucket` — `AltHasher`.
15. `eh_rejects_an_unknown_variant_tag_in_a_bucket`.

`UnivMon` has no hasher type parameter, so for that variant only the fail-closed
half of the custom-profile test applies; the `AltHasher` half is exercised
through the `CountMin` arm, which is generic over `H`.

## CI

| Command | Result |
| ------- | ------ |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` | pass |
| `cargo test --all-features --locked` | pass |
| `cargo test --locked` | pass |

`cargo clippy --workspace --all-targets --locked` (default features) still
reports the 4 pre-existing dead-code / unused-import warnings in
`tests/e2e_octo.rs` that are on `main`; nothing was added to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
