### PR TITLE
refactor(eh): carry the nested variant's kind_id on the wire

### DIFF
--- a/docs/api/api_ehsketchlist.md
+++ b/docs/api/api_ehsketchlist.md
@@ -55,31 +55,34 @@ fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, rmp_serde::decode::Error
 ```
 
 ASAPv1 MessagePack, kind_id `0x14 0x00`. The metadata carries only
-`metadata_version`; the payload is the triple `[variant, descriptor, state]`,
-where `variant` is the wire name of the enum arm and `descriptor` / `state` are
-that sketch's own ASAPv1 metadata and payload blocks carried verbatim as
-msgpack `bin`. An `ExponentialHistogram` bucket inlines the same triple, so
-there is one EHSketchList encoding.
+`metadata_version`; the payload is the triple `[kind_id, descriptor, state]`,
+all three msgpack `bin`. A nested variant carries its **own** kind_id, metadata
+block and payload block, with the envelope framing (magic, version, lengths)
+stripped, so each variant's own validation applies unchanged. An
+`ExponentialHistogram` bucket inlines the same triple, so there is one
+EHSketchList encoding.
 
-The ten wire names and the kind_id whose blocks they carry:
+The ten nested kind_ids:
 
-| Variant | Wire name | Blocks belong to | Feature |
-| ------- | --------- | ---------------- | ------- |
-| `CM` | `"CountMin"` | `0x02 0x00` | default |
-| `COCO` | `"Coco"` | `0x0c 0x00` | `experimental` |
-| `COUNTL2HH` | `"CountL2HH"` | `0x19 0x00` | default |
-| `CS` | `"CountSketch"` | `0x04 0x00` | default |
-| `DDS` | `"DDSketch"` | `0x05 0x00` | default |
-| `ELASTIC` | `"Elastic"` | `0x0b 0x00` | `experimental` |
-| `HLL` | `"HLL"` | `0x01 0x02` | default |
-| `KLL` | `"KLL"` | `0x06 0x00` | default |
-| `UNIFORM` | `"UniformSampling"` | `0x0d 0x00` | `experimental` |
-| `UNIVMON` | `"UnivMon"` | `0x10 0x00` | default |
+| Variant | Nested kind_id | Registry name | Feature |
+| ------- | -------------- | ------------- | ------- |
+| `CM` | `0x02 0x00` | Count-Min | default |
+| `COCO` | `0x0c 0x00` | Coco | `experimental` |
+| `COUNTL2HH` | `0x19 0x00` | CountL2HH | default |
+| `CS` | `0x04 0x00` | Count Sketch | default |
+| `DDS` | `0x05 0x00` | DDSketch | default |
+| `ELASTIC` | `0x0b 0x00` | Elastic | `experimental` |
+| `HLL` | `0x01 0x02` | HLL Ertl-MLE | default |
+| `KLL` | `0x06 0x00` | KLL compact | default |
+| `UNIFORM` | `0x0d 0x00` | UniformSampling | `experimental` |
+| `UNIVMON` | `0x10 0x00` | UnivMon | default |
 
-The name table is the same in every build. A decoder built without
-`experimental` rejects `"Coco"`, `"Elastic"` and `"UniformSampling"` with an
-error naming the variant, and its encoder can never emit them. An unrecognized
-name is rejected. `EHSketchList` also derives serde.
+Each id is pinned to one algorithm: `HLL` is Ertl-MLE, so `0x01 0x01` (Classic)
+and `0x01 0x03` (HIP) are rejected, and `KLL` is compact, so `0x06 0x01`
+(dynamic) is rejected. The dispatch is the same in every build: a decoder built
+without `experimental` rejects `0x0c 0x00`, `0x0b 0x00` and `0x0d 0x00` with an
+error naming the variant and the feature, and its encoder can never emit them.
+An unrecognized kind_id is rejected. `EHSketchList` also derives serde.
 
 ## Examples
 

--- a/docs/api/api_exponential_histogram.md
+++ b/docs/api/api_exponential_histogram.md
@@ -49,9 +49,9 @@ fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, rmp_serde::decode::Error
 
 ASAPv1 MessagePack, kind_id `0x13 0x00`. The metadata carries `window` and `k`;
 the payload is `[buckets, sizes, min_times, max_times, prototype]`. `buckets`
-holds one inlined `EHSketchList` triple per bucket, oldest to newest, and the
-next three arrays are parallel to it; `prototype` is the `type_to_clone` triple.
-The bucket count is `len(buckets)`.
+holds one inlined `EHSketchList` triple `[kind_id, descriptor, state]` per
+bucket, oldest to newest, and the next three arrays are parallel to it;
+`prototype` is the `type_to_clone` triple. The bucket count is `len(buckets)`.
 
 There is no hash-spec group: the histogram never hashes, and each bucket's own
 `descriptor` carries whatever hash spec its sketch has. `l2_mass` and
@@ -59,7 +59,7 @@ There is no hash-spec group: the histogram never hashes, and each bucket's own
 cached values disagree with the sketches they derive from does not serialize.
 
 A `k` of zero, a bucket of size zero, an inverted bucket time range, parallel
-arrays of unequal length, an unknown or feature-gated variant name, and a
+arrays of unequal length, an unknown or feature-gated nested kind_id, and a
 bucket whose descriptor names a different hash profile are all rejected.
 
 ## Examples

--- a/src/sketch_framework/eh/wire.rs
+++ b/src/sketch_framework/eh/wire.rs
@@ -12,9 +12,9 @@
 //! ## Buckets are inlined
 //!
 //! Each bucket holds one [`EHSketchList`], written into this payload as the
-//! `[variant, descriptor, state]` triple
-//! [`crate::sketch_framework::eh_sketch_list::wire`] defines. No bucket carries
-//! an envelope, a magic or a kind_id of its own.
+//! `[kind_id, descriptor, state]` triple
+//! [`crate::sketch_framework::eh_sketch_list::wire`] defines: the variant's own
+//! envelope with the magic, version and length fields stripped.
 //!
 //! ## No hash-spec group
 //!
@@ -221,7 +221,7 @@ mod tests {
         alt_profile_triple, populated_variants, relabelled, sample_input,
     };
     use crate::sketch_framework::eh_sketch_list::wire::{
-        CM_VARIANT, COCO_VARIANT, ELASTIC_VARIANT, UNIFORM_VARIANT,
+        CM_KIND, COCO_KIND, ELASTIC_KIND, UNIFORM_KIND,
     };
     use crate::sketch_framework::eh_sketch_list::{EHSketchList, SketchNorm};
     use crate::{CountMin, DataInput, FastPath, Vector2D};
@@ -461,18 +461,22 @@ mod tests {
         assert!(eh.serialize_to_bytes().is_err());
     }
 
-    /// An experimental variant tag in a bucket is rejected without the feature.
+    /// An experimental kind_id in a bucket is rejected without the feature.
     /// Crafted bytes, so the test runs in both builds.
     #[test]
-    fn eh_rejects_an_experimental_variant_tag_in_a_bucket() {
+    fn eh_rejects_an_experimental_kind_id_in_a_bucket() {
         let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
-        for variant in [COCO_VARIANT, ELASTIC_VARIANT, UNIFORM_VARIANT] {
+        for (kind_id, name) in [
+            (COCO_KIND, "Coco"),
+            (ELASTIC_KIND, "Elastic"),
+            (UNIFORM_KIND, "UniformSampling"),
+        ] {
             let payload = EhPayload {
-                buckets: vec![relabelled(&sketch, variant)],
+                buckets: vec![relabelled(&sketch, kind_id)],
                 sizes: vec![1],
                 min_times: vec![0],
                 max_times: vec![0],
-                prototype: relabelled(&sketch, CM_VARIANT),
+                prototype: relabelled(&sketch, CM_KIND),
             };
             let message = ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload))
                 .expect_err("a relabelled bucket must not decode")
@@ -480,9 +484,11 @@ mod tests {
             assert!(!message.is_empty());
             #[cfg(not(feature = "experimental"))]
             {
-                assert!(message.contains(variant), "{message}");
+                assert!(message.contains(name), "{message}");
                 assert!(message.contains("experimental"), "{message}");
             }
+            #[cfg(feature = "experimental")]
+            let _ = name;
         }
     }
 
@@ -501,20 +507,20 @@ mod tests {
         assert!(ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload)).is_err());
     }
 
-    /// An unknown variant tag in a bucket is rejected by name.
+    /// An unknown kind_id in a bucket is rejected.
     #[test]
-    fn eh_rejects_an_unknown_variant_tag_in_a_bucket() {
+    fn eh_rejects_an_unknown_kind_id_in_a_bucket() {
         let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
         let payload = EhPayload {
-            buckets: vec![relabelled(&sketch, "Bogus")],
+            buckets: vec![relabelled(&sketch, &[0xff, 0xff])],
             sizes: vec![1],
             min_times: vec![0],
             max_times: vec![0],
             prototype: sketch_state(&sketch).expect("state"),
         };
         let message = ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload))
-            .expect_err("an unknown variant must not decode")
+            .expect_err("an unknown kind_id must not decode")
             .to_string();
-        assert!(message.contains("Bogus"), "{message}");
+        assert!(message.contains("not a wire variant"), "{message}");
     }
 }

--- a/src/sketch_framework/eh_sketch_list/wire.rs
+++ b/src/sketch_framework/eh_sketch_list/wire.rs
@@ -2,12 +2,12 @@
 //! [`ExponentialHistogram`] reuses.
 //!
 //! Child submodule of [`crate::sketch_framework::eh_sketch_list`]: it holds the
-//! metadata/payload DTOs, the kind_id constant, the variant-tag table and the
-//! `serialize_to_bytes` / `deserialize_from_bytes` impls.
+//! metadata/payload DTOs, the kind_id constants and the `serialize_to_bytes` /
+//! `deserialize_from_bytes` impls.
 //!
 //! EHSketchList is one kind_id, `0x14 0x00`. It is a tagged union over ten
 //! sketch algorithms, so the encoding is the triple
-//! `[variant, descriptor, state]`.
+//! `[kind_id, descriptor, state]`.
 //!
 //! ## One encoding, used in both places
 //!
@@ -15,17 +15,17 @@
 //! read or rebuilt. The standalone `0x14 0x00` payload is one triple; an
 //! [`ExponentialHistogram`] bucket inlines the same triple.
 //!
-//! ## `descriptor` and `state` are the variant's own blocks
+//! ## A nested variant is its own envelope minus the framing
 //!
-//! `descriptor` is the variant's ASAPv1 metadata block and `state` its ASAPv1
-//! payload block, both verbatim. The variant tag stands in for the kind_id, so
-//! no magic, version or kind_id byte appears inside the triple.
+//! The triple carries the variant's own kind_id, metadata block and payload
+//! block. The magic, version and length fields are stripped, so the variant's
+//! own decoder validates the blocks it wrote.
 //!
-//! ## The tag namespace is fixed in every build
+//! ## The kind_id namespace is fixed in every build
 //!
-//! All ten names and their kind_ids exist whatever features are on. A decoder
-//! built without `experimental` rejects `Coco`, `Elastic` and `UniformSampling`
-//! with an error naming the variant, and its encoder can never emit them.
+//! All ten ids dispatch whatever features are on. A decoder built without
+//! `experimental` rejects `0x0c 0x00`, `0x0b 0x00` and `0x0d 0x00` by name with
+//! the feature named, and its encoder can never emit them.
 
 use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
 use serde::{Deserialize, Serialize};
@@ -37,48 +37,50 @@ use super::EHSketchList;
 /// EHSketchList kind_id: family `0x14`, single algorithm variant `0x00`.
 pub(crate) const EH_SKETCH_LIST_KIND: &[u8] = &[0x14, 0x00];
 
-/// Wire name of [`EHSketchList::CM`].
-pub(crate) const CM_VARIANT: &str = "CountMin";
-/// Wire name of `EHSketchList::COCO`.
-pub(crate) const COCO_VARIANT: &str = "Coco";
-/// Wire name of [`EHSketchList::COUNTL2HH`].
-pub(crate) const COUNTL2HH_VARIANT: &str = "CountL2HH";
-/// Wire name of [`EHSketchList::CS`].
-pub(crate) const CS_VARIANT: &str = "CountSketch";
-/// Wire name of [`EHSketchList::DDS`].
-pub(crate) const DDS_VARIANT: &str = "DDSketch";
-/// Wire name of `EHSketchList::ELASTIC`.
-pub(crate) const ELASTIC_VARIANT: &str = "Elastic";
-/// Wire name of [`EHSketchList::HLL`].
-pub(crate) const HLL_VARIANT: &str = "HLL";
-/// Wire name of [`EHSketchList::KLL`].
-pub(crate) const KLL_VARIANT: &str = "KLL";
-/// Wire name of `EHSketchList::UNIFORM`.
-pub(crate) const UNIFORM_VARIANT: &str = "UniformSampling";
-/// Wire name of [`EHSketchList::UNIVMON`].
-pub(crate) const UNIVMON_VARIANT: &str = "UnivMon";
+/// Count-Min, the blocks [`EHSketchList::CM`] carries.
+pub(crate) const CM_KIND: &[u8] = &[0x02, 0x00];
+/// Coco, the blocks `EHSketchList::COCO` carries.
+pub(crate) const COCO_KIND: &[u8] = &[0x0c, 0x00];
+/// CountL2HH, the blocks [`EHSketchList::COUNTL2HH`] carries.
+pub(crate) const COUNTL2HH_KIND: &[u8] = &[0x19, 0x00];
+/// Count Sketch, the blocks [`EHSketchList::CS`] carries.
+pub(crate) const CS_KIND: &[u8] = &[0x04, 0x00];
+/// DDSketch, the blocks [`EHSketchList::DDS`] carries.
+pub(crate) const DDS_KIND: &[u8] = &[0x05, 0x00];
+/// Elastic, the blocks `EHSketchList::ELASTIC` carries.
+pub(crate) const ELASTIC_KIND: &[u8] = &[0x0b, 0x00];
+/// HLL Ertl-MLE, the blocks [`EHSketchList::HLL`] carries. Classic
+/// (`0x01 0x01`) and HIP (`0x01 0x03`) are other algorithms.
+pub(crate) const HLL_KIND: &[u8] = &[0x01, 0x02];
+/// Compact KLL, the blocks [`EHSketchList::KLL`] carries. Dynamic KLL
+/// (`0x06 0x01`) is another algorithm.
+pub(crate) const KLL_KIND: &[u8] = &[0x06, 0x00];
+/// UniformSampling, the blocks `EHSketchList::UNIFORM` carries.
+pub(crate) const UNIFORM_KIND: &[u8] = &[0x0d, 0x00];
+/// UnivMon, the blocks [`EHSketchList::UNIVMON`] carries.
+pub(crate) const UNIVMON_KIND: &[u8] = &[0x10, 0x00];
 
-/// The kind_id each variant's `descriptor` / `state` blocks belong to.
-/// Present for all ten names in every build.
-pub(crate) fn variant_kind_id(variant: &str) -> Option<&'static [u8]> {
-    match variant {
-        CM_VARIANT => Some(&[0x02, 0x00]),
-        COCO_VARIANT => Some(&[0x0c, 0x00]),
-        COUNTL2HH_VARIANT => Some(&[0x19, 0x00]),
-        CS_VARIANT => Some(&[0x04, 0x00]),
-        DDS_VARIANT => Some(&[0x05, 0x00]),
-        ELASTIC_VARIANT => Some(&[0x0b, 0x00]),
-        HLL_VARIANT => Some(&[0x01, 0x02]),
-        KLL_VARIANT => Some(&[0x06, 0x00]),
-        UNIFORM_VARIANT => Some(&[0x0d, 0x00]),
-        UNIVMON_VARIANT => Some(&[0x10, 0x00]),
+/// The registry name of a nested kind_id. Error messages only: encoding and
+/// decoding dispatch on the bytes.
+pub(crate) fn variant_name(kind_id: &[u8]) -> Option<&'static str> {
+    match kind_id {
+        CM_KIND => Some("CountMin"),
+        COCO_KIND => Some("Coco"),
+        COUNTL2HH_KIND => Some("CountL2HH"),
+        CS_KIND => Some("CountSketch"),
+        DDS_KIND => Some("DDSketch"),
+        ELASTIC_KIND => Some("Elastic"),
+        HLL_KIND => Some("HLL"),
+        KLL_KIND => Some("KLL"),
+        UNIFORM_KIND => Some("UniformSampling"),
+        UNIVMON_KIND => Some("UnivMon"),
         _ => None,
     }
 }
 
 /// EHSketchList descriptor metadata (ASAPv1 §2), a msgpack **map**
 /// (`to_vec_named`). The union has no construction config of its own: the
-/// variant belongs to the triple, which travels whole.
+/// kind_id belongs to the triple, which travels whole.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct EhSketchListMetadata {
@@ -93,56 +95,54 @@ pub(crate) fn eh_sketch_list_metadata() -> EhSketchListMetadata {
 }
 
 /// One EHSketchList as a msgpack **array** (`to_vec`, positional):
-/// `[variant, descriptor, state]`. `descriptor` and `state` are the variant's
-/// own ASAPv1 metadata and payload blocks, carried as msgpack `bin`.
+/// `[kind_id, descriptor, state]`. All three are msgpack `bin`: the variant's
+/// own kind_id bytes, its ASAPv1 metadata block and its ASAPv1 payload block.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct SketchState {
-    pub(crate) variant: String,
+    #[serde(with = "serde_bytes")]
+    pub(crate) kind_id: Vec<u8>,
     #[serde(with = "serde_bytes")]
     pub(crate) descriptor: Vec<u8>,
     #[serde(with = "serde_bytes")]
     pub(crate) state: Vec<u8>,
 }
 
-/// Rejects a variant name outside the ten.
-pub(crate) fn unknown_variant(variant: &str) -> RmpDecodeError {
+/// Rejects a kind_id outside the ten.
+pub(crate) fn unknown_variant(kind_id: &[u8]) -> RmpDecodeError {
     RmpDecodeError::Uncategorized(format!(
-        "ASAPv1 EHSketchList: variant {variant:?} is not a wire variant"
+        "ASAPv1 EHSketchList: kind_id {kind_id:02x?} is not a wire variant"
     ))
 }
 
 /// Rejects the three variants a build without `experimental` does not carry.
 #[cfg(not(feature = "experimental"))]
-fn check_variant_available(variant: &str) -> Result<(), RmpDecodeError> {
-    match variant {
-        COCO_VARIANT | ELASTIC_VARIANT | UNIFORM_VARIANT => Err(RmpDecodeError::Uncategorized(
-            format!("ASAPv1 EHSketchList: variant {variant:?} requires the experimental feature"),
-        )),
+fn check_variant_available(kind_id: &[u8]) -> Result<(), RmpDecodeError> {
+    match kind_id {
+        COCO_KIND | ELASTIC_KIND | UNIFORM_KIND => Err(RmpDecodeError::Uncategorized(format!(
+            "ASAPv1 EHSketchList: variant {} (kind_id {kind_id:02x?}) needs the experimental feature",
+            variant_name(kind_id).unwrap_or("unnamed")
+        ))),
         _ => Ok(()),
     }
 }
 
 /// Every variant is carried in an `experimental` build.
 #[cfg(feature = "experimental")]
-fn check_variant_available(_variant: &str) -> Result<(), RmpDecodeError> {
+fn check_variant_available(_kind_id: &[u8]) -> Result<(), RmpDecodeError> {
     Ok(())
 }
 
 /// Splits one variant's own envelope into the triple, pinning its kind_id.
-fn triple(variant: &'static str, bytes: &[u8]) -> Result<SketchState, RmpEncodeError> {
+fn triple(kind: &'static [u8], bytes: &[u8]) -> Result<SketchState, RmpEncodeError> {
     let (kind_id, descriptor, state) = envelope::split(bytes).map_err(RmpEncodeError::Syntax)?;
-    let expected = variant_kind_id(variant).ok_or_else(|| {
-        RmpEncodeError::Syntax(format!(
-            "ASAPv1 EHSketchList: variant {variant:?} is not a wire variant"
-        ))
-    })?;
-    if kind_id != expected {
+    if kind_id != kind {
         return Err(RmpEncodeError::Syntax(format!(
-            "ASAPv1 EHSketchList: variant {variant:?} produced kind_id {kind_id:?}, expected {expected:?}"
+            "ASAPv1 EHSketchList: {} produced kind_id {kind_id:02x?}, expected {kind:02x?}",
+            variant_name(kind).unwrap_or("variant")
         )));
     }
     Ok(SketchState {
-        variant: variant.to_string(),
+        kind_id: kind.to_vec(),
         descriptor: descriptor.to_vec(),
         state: state.to_vec(),
     })
@@ -152,62 +152,61 @@ fn triple(variant: &'static str, bytes: &[u8]) -> Result<SketchState, RmpEncodeE
 /// Every state the variant's own encoder refuses is refused here too.
 pub(crate) fn sketch_state(sketch: &EHSketchList) -> Result<SketchState, RmpEncodeError> {
     match sketch {
-        EHSketchList::CM(s) => triple(CM_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::CM(s) => triple(CM_KIND, &s.serialize_to_bytes()?),
         #[cfg(feature = "experimental")]
-        EHSketchList::COCO(s) => triple(COCO_VARIANT, &s.serialize_to_bytes()?),
-        EHSketchList::COUNTL2HH(s) => triple(COUNTL2HH_VARIANT, &s.serialize_to_bytes()?),
-        EHSketchList::CS(s) => triple(CS_VARIANT, &s.serialize_to_bytes()?),
-        EHSketchList::DDS(s) => triple(DDS_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::COCO(s) => triple(COCO_KIND, &s.serialize_to_bytes()?),
+        EHSketchList::COUNTL2HH(s) => triple(COUNTL2HH_KIND, &s.serialize_to_bytes()?),
+        EHSketchList::CS(s) => triple(CS_KIND, &s.serialize_to_bytes()?),
+        EHSketchList::DDS(s) => triple(DDS_KIND, &s.serialize_to_bytes()?),
         #[cfg(feature = "experimental")]
-        EHSketchList::ELASTIC(s) => triple(ELASTIC_VARIANT, &s.serialize_to_bytes()?),
-        EHSketchList::HLL(s) => triple(HLL_VARIANT, &s.serialize_to_bytes()?),
-        EHSketchList::KLL(s) => triple(KLL_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::ELASTIC(s) => triple(ELASTIC_KIND, &s.serialize_to_bytes()?),
+        EHSketchList::HLL(s) => triple(HLL_KIND, &s.serialize_to_bytes()?),
+        EHSketchList::KLL(s) => triple(KLL_KIND, &s.serialize_to_bytes()?),
         #[cfg(feature = "experimental")]
-        EHSketchList::UNIFORM(s) => triple(UNIFORM_VARIANT, &s.serialize_to_bytes()?),
-        EHSketchList::UNIVMON(s) => triple(UNIVMON_VARIANT, &s.serialize_to_bytes()?),
+        EHSketchList::UNIFORM(s) => triple(UNIFORM_KIND, &s.serialize_to_bytes()?),
+        EHSketchList::UNIVMON(s) => triple(UNIVMON_KIND, &s.serialize_to_bytes()?),
     }
 }
 
 /// Rebuilds one EHSketchList from a triple, through the variant's own decoder.
-/// An unknown name, and an experimental name in a build without the feature,
-/// are rejected before any state is read.
+/// An unknown kind_id, and one this build does not carry, are rejected before
+/// any block is assembled.
 pub(crate) fn rebuild_sketch(triple: &SketchState) -> Result<EHSketchList, RmpDecodeError> {
-    let variant = triple.variant.as_str();
-    let kind_id = variant_kind_id(variant).ok_or_else(|| unknown_variant(variant))?;
-    check_variant_available(variant)?;
+    let kind_id = triple.kind_id.as_slice();
+    check_variant_available(kind_id)?;
     let bytes = envelope::encode(kind_id, &triple.descriptor, &triple.state);
-    match variant {
-        CM_VARIANT => Ok(EHSketchList::CM(crate::CountMin::deserialize_from_bytes(
+    match kind_id {
+        CM_KIND => Ok(EHSketchList::CM(crate::CountMin::deserialize_from_bytes(
             &bytes,
         )?)),
         #[cfg(feature = "experimental")]
-        COCO_VARIANT => Ok(EHSketchList::COCO(crate::Coco::deserialize_from_bytes(
+        COCO_KIND => Ok(EHSketchList::COCO(crate::Coco::deserialize_from_bytes(
             &bytes,
         )?)),
-        COUNTL2HH_VARIANT => Ok(EHSketchList::COUNTL2HH(
+        COUNTL2HH_KIND => Ok(EHSketchList::COUNTL2HH(
             crate::CountL2HH::deserialize_from_bytes(&bytes)?,
         )),
-        CS_VARIANT => Ok(EHSketchList::CS(crate::Count::deserialize_from_bytes(
+        CS_KIND => Ok(EHSketchList::CS(crate::Count::deserialize_from_bytes(
             &bytes,
         )?)),
-        DDS_VARIANT => Ok(EHSketchList::DDS(crate::DDSketch::deserialize_from_bytes(
+        DDS_KIND => Ok(EHSketchList::DDS(crate::DDSketch::deserialize_from_bytes(
             &bytes,
         )?)),
         #[cfg(feature = "experimental")]
-        ELASTIC_VARIANT => Ok(EHSketchList::ELASTIC(
+        ELASTIC_KIND => Ok(EHSketchList::ELASTIC(
             crate::Elastic::deserialize_from_bytes(&bytes)?,
         )),
-        HLL_VARIANT => Ok(EHSketchList::HLL(
+        HLL_KIND => Ok(EHSketchList::HLL(
             crate::HyperLogLog::<crate::ErtlMLE>::deserialize_from_bytes(&bytes)?,
         )),
-        KLL_VARIANT => Ok(EHSketchList::KLL(crate::KLL::deserialize_from_bytes(
+        KLL_KIND => Ok(EHSketchList::KLL(crate::KLL::deserialize_from_bytes(
             &bytes,
         )?)),
         #[cfg(feature = "experimental")]
-        UNIFORM_VARIANT => Ok(EHSketchList::UNIFORM(
+        UNIFORM_KIND => Ok(EHSketchList::UNIFORM(
             crate::UniformSampling::deserialize_from_bytes(&bytes)?,
         )),
-        UNIVMON_VARIANT => Ok(EHSketchList::UNIVMON(
+        UNIVMON_KIND => Ok(EHSketchList::UNIVMON(
             crate::UnivMon::deserialize_from_bytes(&bytes)?,
         )),
         other => Err(unknown_variant(other)),
@@ -219,7 +218,7 @@ pub(crate) fn rebuild_sketch(triple: &SketchState) -> Result<EHSketchList, RmpDe
 impl EHSketchList {
     /// Serializes the sketch into an ASAPv1 MessagePack envelope
     /// (kind_id `0x14 0x00`). The payload is the triple
-    /// `[variant, descriptor, state]`.
+    /// `[kind_id, descriptor, state]`.
     ///
     /// A state the variant's own encoder refuses is an error rather than bytes
     /// that would be refused on decode.
@@ -229,8 +228,8 @@ impl EHSketchList {
         Ok(envelope::encode(EH_SKETCH_LIST_KIND, &metadata, &payload))
     }
 
-    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The variant
-    /// tag selects the decoder, which validates its own descriptor and state.
+    /// Deserializes a sketch from an ASAPv1 MessagePack envelope. The nested
+    /// kind_id selects the decoder, which validates its own blocks.
     pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError> {
         let (kind_id, metadata, payload) =
             envelope::split(bytes).map_err(RmpDecodeError::Uncategorized)?;
@@ -268,7 +267,7 @@ pub(crate) mod tests {
         }
     }
 
-    /// One populated sketch per variant this build carries, in wire-name order.
+    /// One populated sketch per variant this build carries, in kind_id order.
     pub(crate) fn populated_variants() -> Vec<EHSketchList> {
         let mut out = vec![EHSketchList::CM(
             CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8),
@@ -346,16 +345,16 @@ pub(crate) mod tests {
         let bytes = sketch.serialize_to_bytes().expect("serialize alt CM");
         let (_, descriptor, state) = envelope::split(&bytes).expect("split alt CM");
         SketchState {
-            variant: CM_VARIANT.to_string(),
+            kind_id: CM_KIND.to_vec(),
             descriptor: descriptor.to_vec(),
             state: state.to_vec(),
         }
     }
 
-    /// The triple a variant contributes, with the tag replaced.
-    pub(crate) fn relabelled(sketch: &EHSketchList, variant: &str) -> SketchState {
+    /// The triple a variant contributes, with the nested kind_id replaced.
+    pub(crate) fn relabelled(sketch: &EHSketchList, kind_id: &[u8]) -> SketchState {
         let mut triple = sketch_state(sketch).expect("state");
-        triple.variant = variant.to_string();
+        triple.kind_id = kind_id.to_vec();
         triple
     }
 
@@ -405,34 +404,49 @@ pub(crate) mod tests {
         }
     }
 
-    /// The ten tags and their kind_ids are the same in every build.
+    /// The ten nested kind_ids and their registry names are the same in every
+    /// build, and every variant emits the id the table gives it.
     #[test]
-    fn eh_sketch_list_variant_tags_are_build_independent() {
-        let table: [(&str, &[u8]); 10] = [
-            (CM_VARIANT, &[0x02, 0x00]),
-            (COCO_VARIANT, &[0x0c, 0x00]),
-            (COUNTL2HH_VARIANT, &[0x19, 0x00]),
-            (CS_VARIANT, &[0x04, 0x00]),
-            (DDS_VARIANT, &[0x05, 0x00]),
-            (ELASTIC_VARIANT, &[0x0b, 0x00]),
-            (HLL_VARIANT, &[0x01, 0x02]),
-            (KLL_VARIANT, &[0x06, 0x00]),
-            (UNIFORM_VARIANT, &[0x0d, 0x00]),
-            (UNIVMON_VARIANT, &[0x10, 0x00]),
+    fn eh_sketch_list_kind_ids_are_build_independent() {
+        let table: [(&[u8], &str); 10] = [
+            (CM_KIND, "CountMin"),
+            (COCO_KIND, "Coco"),
+            (COUNTL2HH_KIND, "CountL2HH"),
+            (CS_KIND, "CountSketch"),
+            (DDS_KIND, "DDSketch"),
+            (ELASTIC_KIND, "Elastic"),
+            (HLL_KIND, "HLL"),
+            (KLL_KIND, "KLL"),
+            (UNIFORM_KIND, "UniformSampling"),
+            (UNIVMON_KIND, "UnivMon"),
         ];
-        for (variant, kind_id) in table {
-            assert_eq!(variant_kind_id(variant), Some(kind_id), "{variant}");
+        for (kind_id, name) in table {
+            assert_eq!(variant_name(kind_id), Some(name), "{kind_id:02x?}");
         }
-        assert_eq!(variant_kind_id("CountMinSketch"), None);
+        assert_eq!(variant_name(&[0xff, 0xff]), None);
+
+        for sketch in populated_variants() {
+            let emitted = sketch_state(&sketch).expect("state").kind_id;
+            let expected = table
+                .iter()
+                .find(|(_, name)| *name == sketch.sketch_type())
+                .expect("variant in table")
+                .0;
+            assert_eq!(emitted, expected, "{}", sketch.sketch_type());
+        }
     }
 
-    /// An experimental tag is rejected without the feature, with an error
+    /// An experimental kind_id is rejected without the feature, with an error
     /// naming the variant. Crafted bytes, so the test runs in both builds.
     #[test]
-    fn eh_sketch_list_rejects_an_experimental_variant_tag() {
-        for variant in [COCO_VARIANT, ELASTIC_VARIANT, UNIFORM_VARIANT] {
+    fn eh_sketch_list_rejects_an_experimental_kind_id() {
+        for (kind_id, name) in [
+            (COCO_KIND, "Coco"),
+            (ELASTIC_KIND, "Elastic"),
+            (UNIFORM_KIND, "UniformSampling"),
+        ] {
             let triple = SketchState {
-                variant: variant.to_string(),
+                kind_id: kind_id.to_vec(),
                 descriptor: Vec::new(),
                 state: Vec::new(),
             };
@@ -442,28 +456,47 @@ pub(crate) mod tests {
             assert!(!message.is_empty());
             #[cfg(not(feature = "experimental"))]
             {
-                assert!(message.contains(variant), "{message}");
+                assert!(message.contains(name), "{message}");
                 assert!(message.contains("experimental"), "{message}");
             }
+            #[cfg(feature = "experimental")]
+            let _ = name;
         }
     }
 
     #[test]
-    fn eh_sketch_list_rejects_an_unknown_variant_tag() {
+    fn eh_sketch_list_rejects_an_unknown_kind_id() {
         let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
-        let triple = relabelled(&sketch, "Bogus");
+        let triple = relabelled(&sketch, &[0xff, 0xff]);
         let message = EHSketchList::deserialize_from_bytes(&envelope_for(&triple))
-            .expect_err("an unknown variant must not decode")
+            .expect_err("an unknown kind_id must not decode")
             .to_string();
-        assert!(message.contains("Bogus"), "{message}");
+        assert!(message.contains("not a wire variant"), "{message}");
     }
 
-    /// A tag that does not match the block it carries is rejected by the
+    /// The nested ids are pinned to one algorithm each: HLL is Ertl-MLE and KLL
+    /// is compact, so their siblings' ids are unknown here.
+    #[test]
+    fn eh_sketch_list_rejects_sibling_algorithm_kind_ids() {
+        let hll = EHSketchList::HLL(HyperLogLog::<ErtlMLE>::default());
+        for sibling in [[0x01u8, 0x01], [0x01, 0x03]] {
+            let triple = relabelled(&hll, &sibling);
+            assert!(
+                EHSketchList::deserialize_from_bytes(&envelope_for(&triple)).is_err(),
+                "{sibling:02x?} must not decode as the HLL arm"
+            );
+        }
+        let kll = EHSketchList::KLL(KLL::init_kll(200));
+        let triple = relabelled(&kll, &[0x06, 0x01]);
+        assert!(EHSketchList::deserialize_from_bytes(&envelope_for(&triple)).is_err());
+    }
+
+    /// A kind_id that does not match the blocks it carries is rejected by the
     /// variant's own decoder.
     #[test]
-    fn eh_sketch_list_rejects_a_mismatched_variant_and_descriptor() {
+    fn eh_sketch_list_rejects_a_mismatched_kind_id_and_descriptor() {
         let sketch = EHSketchList::HLL(HyperLogLog::<ErtlMLE>::default());
-        let triple = relabelled(&sketch, CM_VARIANT);
+        let triple = relabelled(&sketch, CM_KIND);
         assert!(EHSketchList::deserialize_from_bytes(&envelope_for(&triple)).is_err());
     }
 
@@ -516,14 +549,14 @@ pub(crate) mod tests {
         let good = sketch_state(&sketch).expect("state");
 
         let truncated = SketchState {
-            variant: CM_VARIANT.to_string(),
+            kind_id: CM_KIND.to_vec(),
             descriptor: good.descriptor[..good.descriptor.len() / 2].to_vec(),
             state: good.state.clone(),
         };
         assert!(EHSketchList::deserialize_from_bytes(&envelope_for(&truncated)).is_err());
 
         let garbage = SketchState {
-            variant: CM_VARIANT.to_string(),
+            kind_id: CM_KIND.to_vec(),
             descriptor: good.descriptor.clone(),
             state: vec![0xc1, 0xc1, 0xc1],
         };


### PR DESCRIPTION
Follow-up to #119. The nested variant inside an `EHSketchList` triple is
identified by its registry **`kind_id` bytes** instead of a variant-name string.

## Why

#119 shipped the triple as `[variant, descriptor, state]`, with `variant` a wire
name (`"CountMin"`, `"HLL"`, …) resolved to a kind_id through a
`variant_kind_id(&str)` table. That is a second identity namespace running
parallel to the Section 1 registry, with two places to keep in sync. Section 1
already settled the question for the envelope:

> The wire carries the compact `kind_id` and resolves the algorithm name through
> the registry below; it does not encode a raw string like
> `"HyperLogLog-Classic"`.

Carrying the kind_id removes the parallel namespace and makes a nested block
exactly what it always was in substance: **the variant's own envelope with the
framing stripped**. `magic`, `version`, `kind_id_len`, `metadata_len` and
`payload_len` are dropped (the enclosing msgpack supplies the lengths);
`kind_id`, `metadata` and `payload` survive unchanged. That is what lets each
variant's own decoder — its geometry checks, allocation guards, structural-param
cross-checks and hash-profile pinning — run on a nested block untouched.

It also sharpens two mappings the name table blurred: `"HLL"` is now
`0x01 0x02` specifically (Ertl-MLE, not Classic `0x01 0x01` or HIP
`0x01 0x03`), and `"KLL"` is now `0x06 0x00` (compact, not dynamic
`0x06 0x01`). The decoder pins both exactly and rejects the sibling ids.

## Wire-breaking, no compatibility path

**An `ExponentialHistogram` (`0x13 0x00`) or `EHSketchList` (`0x14 0x00`)
envelope written by `main` today does not decode after this change.** Position 0
of the triple was a msgpack `str` and is now a msgpack `bin` of registry bytes.
Decode is a hard cut with no legacy read path — the project's standing
precedent — and both kinds landed one commit ago with no golden fixtures and no
`sketchlib-go` mirror yet, so nothing downstream reads the old shape.

## The encoding

The triple, unchanged in shape and still the single encoding used both as the
standalone `0x14 0x00` payload and as the inlined sub-payload of every EH
bucket:

| Pos | Field | Type | Notes |
| --- | ----- | ---- | ----- |
| 0 | `kind_id` | bin | the nested variant's own registry `kind_id`, the same bytes the envelope would carry (2 bytes today) |
| 1 | `descriptor` | bin | that variant's own ASAPv1 metadata block, verbatim |
| 2 | `state` | bin | that variant's own ASAPv1 payload block, verbatim |

All three are msgpack `bin` (`0xc4` family) — never `str`, never an array of
integers.

### Nested kind_ids

| Nested `kind_id` | Registry name | Rust arm | Build |
| ---------------- | ------------- | -------- | ----- |
| `0x01 0x02` | HLL Ertl-MLE | `HLL(HyperLogLog<ErtlMLE>)` | always |
| `0x02 0x00` | Count-Min | `CM(CountMin<Vector2D<i32>, FastPath>)` | always |
| `0x04 0x00` | Count Sketch | `CS(Count<Vector2D<i32>, FastPath>)` | always |
| `0x05 0x00` | DDSketch | `DDS(DDSketch)` | always |
| `0x06 0x00` | KLL compact | `KLL(KLL)` | always |
| `0x0b 0x00` | Elastic | `ELASTIC(Elastic)` | `experimental` |
| `0x0c 0x00` | Coco | `COCO(Coco)` | `experimental` |
| `0x0d 0x00` | UniformSampling | `UNIFORM(UniformSampling)` | `experimental` |
| `0x10 0x00` | UnivMon | `UNIVMON(UnivMon)` | always |
| `0x19 0x00` | CountL2HH | `COUNTL2HH(CountL2HH)` | always |

**Each id names one algorithm, and its siblings are not it.** `0x01 0x01`,
`0x01 0x03` and `0x06 0x01` are rejected as unknown here: the arms hold
`HyperLogLog<ErtlMLE>` and the compact `KLL` and nothing else.

### Feature-gating contract (cross-language; Go must honour it)

1. The nested-id namespace is **fixed and identical in every build**. All ten
   ids dispatch whether or not `experimental` is on. An id is registry bytes,
   never an enum ordinal and never a discriminant, so no id's meaning can shift
   because a variant is compiled out.
2. A decoder built **without** `experimental` that meets `0x0b 0x00`,
   `0x0c 0x00` or `0x0d 0x00` **fails closed**, before the blocks are assembled
   into anything, with an error naming the variant (`Elastic`, `Coco`,
   `UniformSampling`) **and the feature**. It never misparses, skips,
   substitutes another variant, or falls through the unknown-id path.
3. An encoder built **without** `experimental` can never emit those three ids:
   the enum arms do not exist.
4. An id outside the ten is rejected as unknown.
5. `variant_name(&[u8]) -> Option<&'static str>` exists for **error messages
   only**. Encoding and decoding both dispatch on the bytes; the name lookup
   influences neither.

### Decode rules that changed

Rules 2 and 3 of the `0x14 0x00` decode list now read:

2. The nested `kind_id` is one of the ten; anything else, **including a sibling
   algorithm's id within the same family**, is rejected as unknown.
3. A nested id this build does not carry is rejected **before** `descriptor` and
   `state` are assembled into anything, with an error naming the variant and the
   feature.

Everything else is as merged: metadata is `metadata_version` alone for
`0x14 0x00` and `{metadata_version, window, k}` for `0x13 0x00`; the EH payload
is `[buckets, sizes, min_times, max_times, prototype]`, oldest bucket first; the
bucket count stays derived from `len(buckets)`; `l2_mass` and `merge_norm` stay
recomputed rather than carried, with the encode-side rejections intact; and
neither kind carries a hash-spec group, since every hash spec on the wire lives
inside a bucket's own `descriptor`.

## What changed in code

- `src/sketch_framework/eh_sketch_list/wire.rs` — the ten `*_VARIANT: &str`
  constants become the ten `*_KIND: &[u8]` registry ids;
  `variant_kind_id(&str) -> Option<&'static [u8]>` inverts into
  `variant_name(&[u8]) -> Option<&'static str>`, used only to build error text.
  `SketchState.variant: String` becomes `SketchState.kind_id: Vec<u8>` as
  `serde_bytes`. `sketch_state` tags each arm with its id; `rebuild_sketch`
  dispatches on `kind_id.as_slice()` through const slice patterns, with the
  three experimental arms `#[cfg]`-gated and `check_variant_available` rejecting
  their ids by name in a default-feature build.
- `src/sketch_framework/eh/wire.rs` — the bucket-relabelling test helpers and
  the module docs follow the same change.
- Module `//!` docs and both API docs describe the kind_id form.

## Tests

Updated in place, same count and same coverage:

- `eh_sketch_list_variant_tags_are_build_independent` becomes
  `eh_sketch_list_kind_ids_are_build_independent`: it asserts the ten
  `(kind_id, registry name)` pairs **and** that every variant emits the id the
  table gives it. Compiled and run in both builds.
- `eh_sketch_list_rejects_an_experimental_kind_id` and
  `eh_rejects_an_experimental_kind_id_in_a_bucket` keep the crafted-bytes,
  both-builds shape; in the default-feature build they assert the error names
  the variant and the feature.
- New: `eh_sketch_list_rejects_sibling_algorithm_kind_ids` — `0x01 0x01`,
  `0x01 0x03` and `0x06 0x01` are not the `HLL` and `KLL` arms.
- `eh_sketch_list_rejects_an_unknown_kind_id`,
  `eh_sketch_list_rejects_a_mismatched_kind_id_and_descriptor` and
  `eh_rejects_an_unknown_kind_id_in_a_bucket` assert on bytes instead of names.
- Unchanged: every variant's round trip and byte-stable re-serialization, the
  empty-EH single encoding, the non-empty prototype, the `l2_mass` (compared
  bit-exactly via `f64::to_bits`) and `merge_norm` derivability checks, every
  encode-side rejection, the parallel-length and impossible-bucket rejections,
  the `AltHasher` custom-profile rejections, and the cross-kind rejections.

## CI

| Command | Result |
| ------- | ------ |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` | pass |
| `cargo test --all-features --locked` | pass |
| `cargo test --locked` | pass |

`cargo clippy --workspace --all-targets --locked` (default features) still
reports the 4 pre-existing dead-code / unused-import warnings in
`tests/e2e_octo.rs` that are on `main`; nothing was added to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
