### PR TITLE
refactor(coco,elastic): build unconditionally and mark Ready

### DIFF
--- a/docs/api/api_coco.md
+++ b/docs/api/api_coco.md
@@ -1,6 +1,6 @@
 # API: Coco
 
-Status: `Unstable`
+Status: `Ready`
 
 > Warning: This API is kept for backward compatibility. It uses specialized substring semantics and does not match structured sketch interfaces.
 
@@ -129,7 +129,7 @@ let _ = sk.estimate_projected("region=us", |full| {
 
 ## Multi-core (OctoSketch)
 
-> **Feature gate:** also requires `octo-runtime` for the runtime itself.
+> **Feature gate:** requires `octo-runtime` for the runtime itself.
 
 ```rust
 let plan = CocoOctoPlan::new(1024, 2);
@@ -163,4 +163,4 @@ against the post-increment value.
 
 ## Status
 
-Unstable.
+Ready.

--- a/docs/api/api_elastic.md
+++ b/docs/api/api_elastic.md
@@ -1,6 +1,6 @@
 # API: Elastic
 
-Status: `Unstable`
+Status: `Ready`
 
 > Warning: This API is kept for backward compatibility. It does not follow the full structured API parity used by Ready sketches.
 
@@ -365,7 +365,7 @@ let _ = sk.query("flow".to_string());
 
 ## Multi-core (OctoSketch)
 
-> **Feature gate:** also requires `octo-runtime` for the runtime itself.
+> **Feature gate:** requires `octo-runtime` for the runtime itself.
 
 ```rust
 let plan = ElasticOctoPlan::new(256, 3, 4096);
@@ -407,4 +407,4 @@ must be asked for. See `docs/api/api_octo.md`.
 
 ## Status
 
-Unstable; migration work is tracked in `features.md`.
+Ready.

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -27,9 +27,9 @@ This is the canonical API entry point for `asap_sketchlib`.
 - [Bloom](./api/api_bloom.md) - `Ready`
   - Reference: Bloom, "Space/Time Trade-offs in Hash Coding with Allowable Errors," CACM 1970. [https://dl.acm.org/doi/10.1145/362686.362692](https://dl.acm.org/doi/10.1145/362686.362692)
   - Per-slice partitioning: Kirsch & Mitzenmacher, "Less Hashing, Same Performance," ESA 2006. [https://doi.org/10.1007/11841036_42](https://doi.org/10.1007/11841036_42)
-- [Elastic](./api/api_elastic.md) - `Unstable`
+- [Elastic](./api/api_elastic.md) - `Ready`
   - Reference: Chen et al., "Elastic Sketch: Adaptive and Fast Network-wide Measurements," SIGCOMM 2018. [https://dl.acm.org/doi/10.1145/3230543.3230544](https://dl.acm.org/doi/10.1145/3230543.3230544)
-- [Coco](./api/api_coco.md) - `Unstable`
+- [Coco](./api/api_coco.md) - `Ready`
   - Reference: CocoSketch paper. [https://dl.acm.org/doi/10.1145/3452296.3472892](https://dl.acm.org/doi/10.1145/3452296.3472892)
 - [UniformSampling](./api/api_uniform_sampling.md) - `Unstable`
 - [KMV](./api/api_kmv.md) - `Unstable`

--- a/src/sketch_framework/eh/wire.rs
+++ b/src/sketch_framework/eh/wire.rs
@@ -220,9 +220,7 @@ mod tests {
     use crate::sketch_framework::eh_sketch_list::wire::tests::{
         alt_profile_triple, populated_variants, relabelled, sample_input,
     };
-    use crate::sketch_framework::eh_sketch_list::wire::{
-        CM_KIND, COCO_KIND, ELASTIC_KIND, UNIFORM_KIND,
-    };
+    use crate::sketch_framework::eh_sketch_list::wire::{CM_KIND, UNIFORM_KIND};
     use crate::sketch_framework::eh_sketch_list::{EHSketchList, SketchNorm};
     use crate::{CountMin, DataInput, FastPath, Vector2D};
 
@@ -461,34 +459,26 @@ mod tests {
         assert!(eh.serialize_to_bytes().is_err());
     }
 
-    /// An experimental kind_id in a bucket is rejected without the feature.
+    /// The experimental kind_id in a bucket is rejected without the feature.
     /// Crafted bytes, so the test runs in both builds.
     #[test]
     fn eh_rejects_an_experimental_kind_id_in_a_bucket() {
         let sketch = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8));
-        for (kind_id, name) in [
-            (COCO_KIND, "Coco"),
-            (ELASTIC_KIND, "Elastic"),
-            (UNIFORM_KIND, "UniformSampling"),
-        ] {
-            let payload = EhPayload {
-                buckets: vec![relabelled(&sketch, kind_id)],
-                sizes: vec![1],
-                min_times: vec![0],
-                max_times: vec![0],
-                prototype: relabelled(&sketch, CM_KIND),
-            };
-            let message = ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload))
-                .expect_err("a relabelled bucket must not decode")
-                .to_string();
-            assert!(!message.is_empty());
-            #[cfg(not(feature = "experimental"))]
-            {
-                assert!(message.contains(name), "{message}");
-                assert!(message.contains("experimental"), "{message}");
-            }
-            #[cfg(feature = "experimental")]
-            let _ = name;
+        let payload = EhPayload {
+            buckets: vec![relabelled(&sketch, UNIFORM_KIND)],
+            sizes: vec![1],
+            min_times: vec![0],
+            max_times: vec![0],
+            prototype: relabelled(&sketch, CM_KIND),
+        };
+        let message = ExponentialHistogram::deserialize_from_bytes(&envelope_for(&payload))
+            .expect_err("a relabelled bucket must not decode")
+            .to_string();
+        assert!(!message.is_empty());
+        #[cfg(not(feature = "experimental"))]
+        {
+            assert!(message.contains("UniformSampling"), "{message}");
+            assert!(message.contains("experimental"), "{message}");
         }
     }
 

--- a/src/sketch_framework/eh_sketch_list.rs
+++ b/src/sketch_framework/eh_sketch_list.rs
@@ -23,7 +23,7 @@ pub enum SketchNorm {
 pub enum EHSketchList {
     /// Count-Min sketch.
     CM(CountMin<Vector2D<i32>, FastPath>),
-    #[cfg(feature = "experimental")]
+    /// CocoSketch.
     COCO(Coco),
     /// CountL2HH sketch.
     COUNTL2HH(CountL2HH),
@@ -31,7 +31,7 @@ pub enum EHSketchList {
     CS(Count<Vector2D<i32>, FastPath>),
     /// DDSketch.
     DDS(DDSketch),
-    #[cfg(feature = "experimental")]
+    /// Elastic sketch.
     ELASTIC(Elastic),
     /// HyperLogLog.
     HLL(HyperLogLog<ErtlMLE>),
@@ -50,14 +50,14 @@ impl EHSketchList {
         match self {
             EHSketchList::COUNTL2HH(_) | EHSketchList::UNIVMON(_) => norm == SketchNorm::L2,
             EHSketchList::CM(_)
+            | EHSketchList::COCO(_)
             | EHSketchList::CS(_)
             | EHSketchList::DDS(_)
+            | EHSketchList::ELASTIC(_)
             | EHSketchList::HLL(_)
             | EHSketchList::KLL(_) => norm == SketchNorm::L1,
             #[cfg(feature = "experimental")]
-            EHSketchList::COCO(_) | EHSketchList::ELASTIC(_) | EHSketchList::UNIFORM(_) => {
-                norm == SketchNorm::L1
-            }
+            EHSketchList::UNIFORM(_) => norm == SketchNorm::L1,
         }
     }
 
@@ -76,7 +76,6 @@ impl EHSketchList {
     pub fn insert(&mut self, val: &DataInput) {
         match self {
             EHSketchList::CM(sketch) => sketch.insert(val),
-            #[cfg(feature = "experimental")]
             EHSketchList::COCO(sketch) => match val {
                 DataInput::Str(s) => sketch.insert(s, 1),
                 DataInput::String(s) => sketch.insert(s.as_str(), 1),
@@ -87,7 +86,6 @@ impl EHSketchList {
             EHSketchList::DDS(sketch) => {
                 let _ = sketch.add_input(val);
             }
-            #[cfg(feature = "experimental")]
             EHSketchList::ELASTIC(sketch) => match val {
                 DataInput::String(s) => sketch.insert(s.to_string()),
                 DataInput::I32(i) => sketch.insert(i.to_string()),
@@ -129,7 +127,6 @@ impl EHSketchList {
                 s.merge(o);
                 Ok(())
             }
-            #[cfg(feature = "experimental")]
             (EHSketchList::COCO(s), EHSketchList::COCO(o)) => {
                 s.merge(o);
                 Ok(())
@@ -167,9 +164,7 @@ impl EHSketchList {
     pub fn query(&self, key: &DataInput) -> Result<f64, &'static str> {
         match (self, key) {
             (EHSketchList::CM(count_min), _) => Ok(count_min.estimate(key) as f64),
-            #[cfg(feature = "experimental")]
             (EHSketchList::COCO(coco), DataInput::Str(s)) => Ok(coco.estimate_key(s) as f64),
-            #[cfg(feature = "experimental")]
             (EHSketchList::COCO(coco), DataInput::String(s)) => {
                 Ok(coco.estimate_key(s.as_str()) as f64)
             }
@@ -205,7 +200,6 @@ impl EHSketchList {
                 "max" => dd.max().ok_or("DDSketch has no samples"),
                 _ => Err("Unsupported command for DDSketch"),
             },
-            #[cfg(feature = "experimental")]
             (EHSketchList::ELASTIC(elastic), DataInput::String(s)) => {
                 Ok(elastic.query(s.clone()) as f64)
             }
@@ -266,12 +260,10 @@ impl EHSketchList {
     pub fn sketch_type(&self) -> &'static str {
         match self {
             EHSketchList::CM(_) => "CountMin",
-            #[cfg(feature = "experimental")]
             EHSketchList::COCO(_) => "Coco",
             EHSketchList::COUNTL2HH(_) => "CountL2HH",
             EHSketchList::CS(_) => "CountSketch",
             EHSketchList::DDS(_) => "DDSketch",
-            #[cfg(feature = "experimental")]
             EHSketchList::ELASTIC(_) => "Elastic",
             EHSketchList::HLL(_) => "HLL",
             EHSketchList::KLL(_) => "KLL",

--- a/src/sketch_framework/eh_sketch_list/wire.rs
+++ b/src/sketch_framework/eh_sketch_list/wire.rs
@@ -24,8 +24,8 @@
 //! ## The kind_id namespace is fixed in every build
 //!
 //! All ten ids dispatch whatever features are on. A decoder built without
-//! `experimental` rejects `0x0c 0x00`, `0x0b 0x00` and `0x0d 0x00` by name with
-//! the feature named, and its encoder can never emit them.
+//! `experimental` rejects `0x0d 0x00` by name with the feature named, and its
+//! encoder can never emit it.
 
 use rmp_serde::{decode::Error as RmpDecodeError, encode::Error as RmpEncodeError, from_slice};
 use serde::{Deserialize, Serialize};
@@ -39,7 +39,7 @@ pub(crate) const EH_SKETCH_LIST_KIND: &[u8] = &[0x14, 0x00];
 
 /// Count-Min, the blocks [`EHSketchList::CM`] carries.
 pub(crate) const CM_KIND: &[u8] = &[0x02, 0x00];
-/// Coco, the blocks `EHSketchList::COCO` carries.
+/// Coco, the blocks [`EHSketchList::COCO`] carries.
 pub(crate) const COCO_KIND: &[u8] = &[0x0c, 0x00];
 /// CountL2HH, the blocks [`EHSketchList::COUNTL2HH`] carries.
 pub(crate) const COUNTL2HH_KIND: &[u8] = &[0x19, 0x00];
@@ -47,7 +47,7 @@ pub(crate) const COUNTL2HH_KIND: &[u8] = &[0x19, 0x00];
 pub(crate) const CS_KIND: &[u8] = &[0x04, 0x00];
 /// DDSketch, the blocks [`EHSketchList::DDS`] carries.
 pub(crate) const DDS_KIND: &[u8] = &[0x05, 0x00];
-/// Elastic, the blocks `EHSketchList::ELASTIC` carries.
+/// Elastic, the blocks [`EHSketchList::ELASTIC`] carries.
 pub(crate) const ELASTIC_KIND: &[u8] = &[0x0b, 0x00];
 /// HLL Ertl-MLE, the blocks [`EHSketchList::HLL`] carries. Classic
 /// (`0x01 0x01`) and HIP (`0x01 0x03`) are other algorithms.
@@ -114,11 +114,11 @@ pub(crate) fn unknown_variant(kind_id: &[u8]) -> RmpDecodeError {
     ))
 }
 
-/// Rejects the three variants a build without `experimental` does not carry.
+/// Rejects the variant a build without `experimental` does not carry.
 #[cfg(not(feature = "experimental"))]
 fn check_variant_available(kind_id: &[u8]) -> Result<(), RmpDecodeError> {
     match kind_id {
-        COCO_KIND | ELASTIC_KIND | UNIFORM_KIND => Err(RmpDecodeError::Uncategorized(format!(
+        UNIFORM_KIND => Err(RmpDecodeError::Uncategorized(format!(
             "ASAPv1 EHSketchList: variant {} (kind_id {kind_id:02x?}) needs the experimental feature",
             variant_name(kind_id).unwrap_or("unnamed")
         ))),
@@ -153,12 +153,10 @@ fn triple(kind: &'static [u8], bytes: &[u8]) -> Result<SketchState, RmpEncodeErr
 pub(crate) fn sketch_state(sketch: &EHSketchList) -> Result<SketchState, RmpEncodeError> {
     match sketch {
         EHSketchList::CM(s) => triple(CM_KIND, &s.serialize_to_bytes()?),
-        #[cfg(feature = "experimental")]
         EHSketchList::COCO(s) => triple(COCO_KIND, &s.serialize_to_bytes()?),
         EHSketchList::COUNTL2HH(s) => triple(COUNTL2HH_KIND, &s.serialize_to_bytes()?),
         EHSketchList::CS(s) => triple(CS_KIND, &s.serialize_to_bytes()?),
         EHSketchList::DDS(s) => triple(DDS_KIND, &s.serialize_to_bytes()?),
-        #[cfg(feature = "experimental")]
         EHSketchList::ELASTIC(s) => triple(ELASTIC_KIND, &s.serialize_to_bytes()?),
         EHSketchList::HLL(s) => triple(HLL_KIND, &s.serialize_to_bytes()?),
         EHSketchList::KLL(s) => triple(KLL_KIND, &s.serialize_to_bytes()?),
@@ -179,7 +177,6 @@ pub(crate) fn rebuild_sketch(triple: &SketchState) -> Result<EHSketchList, RmpDe
         CM_KIND => Ok(EHSketchList::CM(crate::CountMin::deserialize_from_bytes(
             &bytes,
         )?)),
-        #[cfg(feature = "experimental")]
         COCO_KIND => Ok(EHSketchList::COCO(crate::Coco::deserialize_from_bytes(
             &bytes,
         )?)),
@@ -192,7 +189,6 @@ pub(crate) fn rebuild_sketch(triple: &SketchState) -> Result<EHSketchList, RmpDe
         DDS_KIND => Ok(EHSketchList::DDS(crate::DDSketch::deserialize_from_bytes(
             &bytes,
         )?)),
-        #[cfg(feature = "experimental")]
         ELASTIC_KIND => Ok(EHSketchList::ELASTIC(
             crate::Elastic::deserialize_from_bytes(&bytes)?,
         )),
@@ -272,14 +268,12 @@ pub(crate) mod tests {
         let mut out = vec![EHSketchList::CM(
             CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 8),
         )];
-        #[cfg(feature = "experimental")]
         out.push(EHSketchList::COCO(crate::Coco::init_with_size(16, 2)));
         out.push(EHSketchList::COUNTL2HH(CountL2HH::with_dimensions(3, 256)));
         out.push(EHSketchList::CS(
             Count::<Vector2D<i32>, FastPath>::with_dimensions(3, 8),
         ));
         out.push(EHSketchList::DDS(DDSketch::new(0.01)));
-        #[cfg(feature = "experimental")]
         out.push(EHSketchList::ELASTIC(crate::Elastic::init_with_dimensions(
             8, 2, 256,
         )));
@@ -436,31 +430,23 @@ pub(crate) mod tests {
         }
     }
 
-    /// An experimental kind_id is rejected without the feature, with an error
+    /// The experimental kind_id is rejected without the feature, with an error
     /// naming the variant. Crafted bytes, so the test runs in both builds.
     #[test]
     fn eh_sketch_list_rejects_an_experimental_kind_id() {
-        for (kind_id, name) in [
-            (COCO_KIND, "Coco"),
-            (ELASTIC_KIND, "Elastic"),
-            (UNIFORM_KIND, "UniformSampling"),
-        ] {
-            let triple = SketchState {
-                kind_id: kind_id.to_vec(),
-                descriptor: Vec::new(),
-                state: Vec::new(),
-            };
-            let message = EHSketchList::deserialize_from_bytes(&envelope_for(&triple))
-                .expect_err("an empty variant state must not decode")
-                .to_string();
-            assert!(!message.is_empty());
-            #[cfg(not(feature = "experimental"))]
-            {
-                assert!(message.contains(name), "{message}");
-                assert!(message.contains("experimental"), "{message}");
-            }
-            #[cfg(feature = "experimental")]
-            let _ = name;
+        let triple = SketchState {
+            kind_id: UNIFORM_KIND.to_vec(),
+            descriptor: Vec::new(),
+            state: Vec::new(),
+        };
+        let message = EHSketchList::deserialize_from_bytes(&envelope_for(&triple))
+            .expect_err("an empty variant state must not decode")
+            .to_string();
+        assert!(!message.is_empty());
+        #[cfg(not(feature = "experimental"))]
+        {
+            assert!(message.contains("UniformSampling"), "{message}");
+            assert!(message.contains("experimental"), "{message}");
         }
     }
 

--- a/src/sketch_framework/mod.rs
+++ b/src/sketch_framework/mod.rs
@@ -58,17 +58,14 @@ pub use eh_univ_optimized::{EHMapBucket, EHUnivMonBucket, EHUnivOptimized, EHUni
 pub mod octo;
 pub use octo::{
     CmOctoAggregator, CmOctoPlan, CmOctoWorker, CmTopKOctoAggregator, CmTopKOctoPlan,
-    CmTopKOctoWorker, CmWorkerSketch, CountOctoAggregator, CountOctoPlan, CountOctoWorker,
-    CountTopKOctoAggregator, CountTopKOctoPlan, CountTopKOctoWorker, CountWorkerSketch,
-    DEFAULT_OCTO_TOP_K, DdOctoAggregator, DdOctoPlan, DdOctoWorker, DdWorkerSketch,
-    HllOctoAggregator, HllOctoPlan, HllOctoWorker, KeyedHashes, L2hhWorkerSketch, OctoAggregator,
-    OctoPlan, OctoWorker, RowHashes, UnivMonInput, UnivMonOctoAggregator, UnivMonOctoPlan,
-    UnivMonOctoWorker, max_hll_threshold, threshold_for_error, univmon_layer_threshold,
-};
-#[cfg(feature = "experimental")]
-pub use octo::{
-    CocoOctoAggregator, CocoOctoPlan, CocoOctoWorker, CocoWorkerSketch, ElasticOctoAggregator,
-    ElasticOctoPlan, ElasticOctoWorker, ElasticWorkerSketch, flow_key_string,
+    CmTopKOctoWorker, CmWorkerSketch, CocoOctoAggregator, CocoOctoPlan, CocoOctoWorker,
+    CocoWorkerSketch, CountOctoAggregator, CountOctoPlan, CountOctoWorker, CountTopKOctoAggregator,
+    CountTopKOctoPlan, CountTopKOctoWorker, CountWorkerSketch, DEFAULT_OCTO_TOP_K,
+    DdOctoAggregator, DdOctoPlan, DdOctoWorker, DdWorkerSketch, ElasticOctoAggregator,
+    ElasticOctoPlan, ElasticOctoWorker, ElasticWorkerSketch, HllOctoAggregator, HllOctoPlan,
+    HllOctoWorker, KeyedHashes, L2hhWorkerSketch, OctoAggregator, OctoPlan, OctoWorker, RowHashes,
+    UnivMonInput, UnivMonOctoAggregator, UnivMonOctoPlan, UnivMonOctoWorker, flow_key_string,
+    max_hll_threshold, threshold_for_error, univmon_layer_threshold,
 };
 #[cfg(feature = "octo-runtime")]
 pub use octo::{

--- a/src/sketch_framework/octo.rs
+++ b/src/sketch_framework/octo.rs
@@ -39,11 +39,9 @@ use crate::octo_delta::{
     DD_PROMASK, DdDelta, KeyedCmDelta, KeyedCountDelta, MAX_PROMASK, OctoThreshold, UNIVMON_PROMASK,
 };
 use crate::sketch_framework::univmon::{UnivMonDeltaFidelity, bottom_layer_for_hash};
-#[cfg(feature = "experimental")]
 use crate::sketches::coco::Coco;
 use crate::sketches::countminsketch_topk::CMSHeap;
 use crate::sketches::countsketch_topk::{CSHeap, l2hh_cell_for_row};
-#[cfg(feature = "experimental")]
 use crate::sketches::elastic::{Elastic, LAMBDA};
 use crate::{
     BOTTOM_LAYER_FINDER, CM_PROMASK, COUNT_PROMASK, Classic, CmDelta, Count, CountDelta, CountMin,
@@ -51,11 +49,8 @@ use crate::{
     RegularPath, UnivMon, Vector2D, hash64_seeded, hash128_seeded, heap_item_to_sketch_input,
     input_to_owned,
 };
-#[cfg(feature = "experimental")]
 use crate::{CANONICAL_HASH_SEED, COCO_PROMASK, CocoDelta, ELASTIC_PROMASK, ElasticDelta};
-#[cfg(feature = "experimental")]
 use rand::Rng;
-#[cfg(feature = "experimental")]
 use rand::rngs::ThreadRng;
 use smallvec::SmallVec;
 
@@ -512,7 +507,6 @@ impl L2hhWorkerSketch {
 /// so this worker keeps the keys and shrinks only the counters. Every step of
 /// `insert_emit_delta` mirrors `Coco::insert`, down to the uniform draw among
 /// tied minima and the `v / val` election, so the two cannot drift apart.
-#[cfg(feature = "experimental")]
 #[derive(Clone, Debug)]
 pub struct CocoWorkerSketch {
     keys: Vec<Option<String>>,
@@ -521,7 +515,6 @@ pub struct CocoWorkerSketch {
     d: usize,
 }
 
-#[cfg(feature = "experimental")]
 impl CocoWorkerSketch {
     /// Creates a `d` x `w` worker table, empty and cleared. The argument order
     /// is `Coco::init_with_size`'s.
@@ -650,7 +643,6 @@ impl CocoWorkerSketch {
 ///
 /// `eviction` carries the parent's own semantics -- set on takeover by
 /// eviction, clear on seating a previously unoccupied slot.
-#[cfg(feature = "experimental")]
 #[derive(Clone, Debug, Default)]
 struct ElasticWorkerBucket {
     flow_id: Option<String>,
@@ -667,14 +659,12 @@ struct ElasticWorkerBucket {
 /// ordinary [`CmWorkerSketch`], promoting cell deltas with no key attached, and
 /// takes the arrivals that lose a bucket contest. An evicted resident does not
 /// go there: it is handed over keyed, as [`ElasticDelta::Evicted`].
-#[cfg(feature = "experimental")]
 #[derive(Clone, Debug)]
 pub struct ElasticWorkerSketch {
     heavy: Vec<ElasticWorkerBucket>,
     light: CmWorkerSketch,
 }
 
-#[cfg(feature = "experimental")]
 impl ElasticWorkerSketch {
     /// Creates a worker mirroring an `Elastic` of these dimensions.
     pub fn new(bucket_count: usize, light_rows: usize, light_cols: usize) -> Self {
@@ -2172,7 +2162,6 @@ impl OctoAggregator for UnivMonOctoAggregator {
 /// Both sketches key on a `String`, so a plan has to settle on one rendering:
 /// this is what the aggregator will hold, and what `Coco::estimate_key` or
 /// `Elastic::query` must be asked for.
-#[cfg(feature = "experimental")]
 pub fn flow_key_string(input: &DataInput<'_>) -> String {
     use std::fmt::Write as _;
 
@@ -2204,13 +2193,11 @@ pub fn flow_key_string(input: &DataInput<'_>) -> String {
 }
 
 /// OctoSketch worker backed by a compact CocoSketch table.
-#[cfg(feature = "experimental")]
 pub struct CocoOctoWorker {
     sketch: CocoWorkerSketch,
     threshold: OctoThreshold,
 }
 
-#[cfg(feature = "experimental")]
 impl CocoOctoWorker {
     /// Creates a worker with a private threshold fixed at `COCO_PROMASK`.
     pub fn new(w: usize, d: usize) -> Self {
@@ -2231,7 +2218,6 @@ impl CocoOctoWorker {
     }
 }
 
-#[cfg(feature = "experimental")]
 impl OctoWorker for CocoOctoWorker {
     type Delta = CocoDelta;
     /// The rendered flow key; a Coco bucket is nothing without one.
@@ -2263,13 +2249,11 @@ impl OctoWorker for CocoOctoWorker {
 /// insertion logic, which for CocoSketch is the weighted `Coco::insert` - the
 /// aggregator picks its own victim bucket and runs its own election, so a key
 /// the worker held lands wherever the *parent's* table would have put it.
-#[cfg(feature = "experimental")]
 pub struct CocoOctoAggregator {
     /// Parent CocoSketch updated by worker deltas.
     pub sketch: Coco,
 }
 
-#[cfg(feature = "experimental")]
 impl CocoOctoAggregator {
     /// Creates an aggregator with a `d` x `w` parent table.
     pub fn new(w: usize, d: usize) -> Self {
@@ -2279,7 +2263,6 @@ impl CocoOctoAggregator {
     }
 }
 
-#[cfg(feature = "experimental")]
 impl OctoAggregator for CocoOctoAggregator {
     type Delta = CocoDelta;
 
@@ -2292,13 +2275,11 @@ impl OctoAggregator for CocoOctoAggregator {
 // -- Elastic sketch --
 
 /// OctoSketch worker backed by a compact Elastic sketch, both halves.
-#[cfg(feature = "experimental")]
 pub struct ElasticOctoWorker {
     sketch: ElasticWorkerSketch,
     threshold: OctoThreshold,
 }
 
-#[cfg(feature = "experimental")]
 impl ElasticOctoWorker {
     /// Creates a worker with a private threshold fixed at `ELASTIC_PROMASK`.
     pub fn new(bucket_count: usize, light_rows: usize, light_cols: usize) -> Self {
@@ -2329,7 +2310,6 @@ impl ElasticOctoWorker {
     }
 }
 
-#[cfg(feature = "experimental")]
 impl OctoWorker for ElasticOctoWorker {
     type Delta = ElasticDelta;
     /// The rendered flow key. The light half could travel as hashes alone, but
@@ -2365,13 +2345,11 @@ impl OctoWorker for ElasticOctoWorker {
 /// to the light layer as-is. A worker's evicted resident arrives keyed and goes
 /// through `Elastic::absorb_evicted`, which is where the parent learns that a
 /// flow it still holds has mass coming through the light layer.
-#[cfg(feature = "experimental")]
 pub struct ElasticOctoAggregator {
     /// Parent Elastic sketch updated by worker deltas.
     pub sketch: Elastic,
 }
 
-#[cfg(feature = "experimental")]
 impl ElasticOctoAggregator {
     /// Creates an aggregator with a `bucket_count` heavy table over a
     /// `light_rows` by `light_cols` light layer.
@@ -2382,7 +2360,6 @@ impl ElasticOctoAggregator {
     }
 }
 
-#[cfg(feature = "experimental")]
 impl OctoAggregator for ElasticOctoAggregator {
     type Delta = ElasticDelta;
 
@@ -2673,7 +2650,6 @@ impl OctoPlan for DdOctoPlan {
 }
 
 /// Builds `CocoOctoWorker`s; payloads are the rendered flow key.
-#[cfg(feature = "experimental")]
 #[derive(Clone, Debug)]
 pub struct CocoOctoPlan {
     w: usize,
@@ -2681,7 +2657,6 @@ pub struct CocoOctoPlan {
     threshold: OctoThreshold,
 }
 
-#[cfg(feature = "experimental")]
 impl CocoOctoPlan {
     /// Creates a plan at the CocoSketch default threshold.
     pub fn new(w: usize, d: usize) -> Self {
@@ -2704,7 +2679,6 @@ impl CocoOctoPlan {
     }
 }
 
-#[cfg(feature = "experimental")]
 impl OctoPlan for CocoOctoPlan {
     type Worker = CocoOctoWorker;
 
@@ -2718,7 +2692,6 @@ impl OctoPlan for CocoOctoPlan {
 }
 
 /// Builds `ElasticOctoWorker`s; payloads are the rendered flow key.
-#[cfg(feature = "experimental")]
 #[derive(Clone, Debug)]
 pub struct ElasticOctoPlan {
     bucket_count: i32,
@@ -2727,7 +2700,6 @@ pub struct ElasticOctoPlan {
     threshold: OctoThreshold,
 }
 
-#[cfg(feature = "experimental")]
 impl ElasticOctoPlan {
     /// Creates a plan at the Elastic sketch default threshold.
     pub fn new(bucket_count: i32, light_rows: usize, light_cols: usize) -> Self {
@@ -2769,7 +2741,6 @@ impl ElasticOctoPlan {
     }
 }
 
-#[cfg(feature = "experimental")]
 impl OctoPlan for ElasticOctoPlan {
     type Worker = ElasticOctoWorker;
 
@@ -3190,7 +3161,6 @@ mod worker_tests {
         worker.insert_hashes_emit_delta(&hashes, CM_PROMASK, &mut |_| {});
     }
 
-    #[cfg(feature = "experimental")]
     #[test]
     fn coco_worker_promotes_the_key_its_bucket_holds_and_clears_it() {
         let mut worker = CocoWorkerSketch::new(64, 2);
@@ -3212,7 +3182,6 @@ mod worker_tests {
         );
     }
 
-    #[cfg(feature = "experimental")]
     #[test]
     fn coco_promotion_conserves_the_inserted_mass() {
         // Every insert lands in exactly one bucket, so what the parent received
@@ -3237,7 +3206,6 @@ mod worker_tests {
         );
     }
 
-    #[cfg(feature = "experimental")]
     #[test]
     fn elastic_worker_promotes_each_half_on_its_own_terms() {
         let mut worker = ElasticWorkerSketch::new(1, 2, 64);

--- a/src/sketches/mod.rs
+++ b/src/sketches/mod.rs
@@ -39,11 +39,8 @@
 //! queries, while the `_topk` variants compose the sketch with heap
 //! bookkeeping for heavy-hitter workloads.
 
-#[cfg(feature = "experimental")]
 pub mod coco;
-#[cfg(feature = "experimental")]
 pub use coco::Coco;
-#[cfg(feature = "experimental")]
 pub use coco::CocoBucket;
 
 /// Fixed-counter heavy-hitter tracking over a Stream-Summary.
@@ -67,11 +64,8 @@ pub mod countminsketch;
 pub use crate::MatrixStorage;
 pub use countminsketch::{CountMin, QUICKSTART_COL_NUM, QUICKSTART_ROW_NUM};
 
-#[cfg(feature = "experimental")]
 pub mod elastic;
-#[cfg(feature = "experimental")]
 pub use elastic::Elastic;
-#[cfg(feature = "experimental")]
 pub use elastic::HeavyBucket;
 
 /// HyperLogLog implementations and aliases.
@@ -109,11 +103,10 @@ pub use countsketch_topk::{CountL2HH, l2hh_cell_for_row};
 
 pub mod octo_delta;
 pub use octo_delta::{
-    CM_PROMASK, COUNT_PROMASK, CmDelta, CountDelta, DD_PROMASK, DdDelta, HLL_PROMASK, HllDelta,
-    KeyedCmDelta, KeyedCountDelta, LayeredCountDelta, MAX_PROMASK, OctoThreshold, UNIVMON_PROMASK,
+    CM_PROMASK, COCO_PROMASK, COUNT_PROMASK, CmDelta, CocoDelta, CountDelta, DD_PROMASK, DdDelta,
+    ELASTIC_PROMASK, ElasticDelta, HLL_PROMASK, HllDelta, KeyedCmDelta, KeyedCountDelta,
+    LayeredCountDelta, MAX_PROMASK, OctoThreshold, UNIVMON_PROMASK,
 };
-#[cfg(feature = "experimental")]
-pub use octo_delta::{COCO_PROMASK, CocoDelta, ELASTIC_PROMASK, ElasticDelta};
 
 pub mod fold_cms;
 pub use fold_cms::{FoldCMS, FoldCell, FoldEntry};

--- a/src/sketches/octo_delta.rs
+++ b/src/sketches/octo_delta.rs
@@ -42,14 +42,12 @@ pub const HLL_PROMASK: u8 = 0;
 /// A Coco bucket counter is exactly as dense as a Count-Min cell - every
 /// insert lands on one of them and increments it by one - so it takes the same
 /// τ.
-#[cfg(feature = "experimental")]
 pub const COCO_PROMASK: u32 = 0x1f;
 
 /// Default promotion threshold τ for Elastic sketch workers.
 ///
 /// One τ covers both halves: a heavy-part vote counter and a light-part
 /// Count-Min counter each advance by one per insert.
-#[cfg(feature = "experimental")]
 pub const ELASTIC_PROMASK: u32 = 0x1f;
 
 /// Largest threshold a worker may be configured with.
@@ -134,7 +132,6 @@ pub struct KeyedCountDelta {
 /// aggregator replays the pair through the parent's own insertion logic. There
 /// is no cell index because the parent re-derives one - its victim choice
 /// depends on what its own buckets hold, not on the worker's.
-#[cfg(feature = "experimental")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CocoDelta {
     /// Key the promoted bucket holds.
@@ -154,7 +151,6 @@ pub struct CocoDelta {
 /// bucket carries an eviction flag that §4.4's rule has no way to move. The
 /// flag rides with the counter word it qualifies, and the evicted resident
 /// travels under its own key.
-#[cfg(feature = "experimental")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ElasticDelta {
     /// Heavy-part bucket: the resident flow, the votes it accumulated, and the

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ same conformance batteries before landing — copy an adapter from
 | `common/conformance.rs` | Capability traits + standard conformance batteries |
 | `conformance_kit.rs` | Reference adapters: established sketches running through the kit (copy these) |
 | `e2e_frequency.rs` / `e2e_cardinality.rs` / `e2e_quantiles.rs` / `e2e_frameworks.rs` | Deep per-family suites with hand-tuned tolerances |
-| `e2e_heavy_hitters.rs` | Space-Saving's error sandwich, `min_count` ceiling and Stream-Summary lists under sustained eviction, plus CocoSketch and Elastic (`feature = "experimental"`) through the batteries and the heavy-hitter properties no battery models |
+| `e2e_heavy_hitters.rs` | Space-Saving's error sandwich, `min_count` ceiling and Stream-Summary lists under sustained eviction, plus CocoSketch and Elastic through the batteries and the heavy-hitter properties no battery models |
 | `e2e_membership.rs` | Bloom: no false negative, exact union, and the delivered false-positive rate against its own sizing |
 | `e2e_octo.rs` | OctoSketch delta-promotion invariants, the `octo-runtime` pipeline, and conformance to the paper's Theorems 1-4 and its sketch-merge baseline |
 | `e2e_experimental.rs` | The remaining `feature = "experimental"` sketches: KMV, UniformSampling, EHUnivOptimized |

--- a/tests/e2e_experimental.rs
+++ b/tests/e2e_experimental.rs
@@ -2,8 +2,8 @@
 //! and shard merge, UniformSampling's retention rate and same-rate merge, and
 //! the EHUnivOptimized exact map tier.
 //!
-//! CocoSketch and the Elastic sketch are feature-gated too, but they are a
-//! family of their own; `tests/e2e_heavy_hitters.rs` covers them.
+//! CocoSketch and the Elastic sketch are a family of their own;
+//! `tests/e2e_heavy_hitters.rs` covers them.
 //!
 //! Compiled only under `--features experimental`.
 

--- a/tests/e2e_heavy_hitters.rs
+++ b/tests/e2e_heavy_hitters.rs
@@ -18,8 +18,7 @@
 //! over-attribution under substring matching, its point-query mass partition,
 //! its unbiasedness under eviction and its recall at the paper's worked
 //! operating point; Elastic's hot-flow tracking, its one-sided estimator under
-//! eviction pressure, and the reach of the light layer's dimensions. Both
-//! compile only under `--features experimental`.
+//! eviction pressure, and the reach of the light layer's dimensions.
 //!
 //! `tests/e2e_octo.rs` covers the multi-threaded OctoSketch variants of Coco
 //! and Elastic in its `heavy_hitters` module; everything here is the
@@ -731,7 +730,6 @@ fn the_default_summary_holds_the_default_capacity() {
 // CocoSketch and Elastic: the keyed-bucket tables
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "experimental")]
 mod keyed_bucket {
     use super::common::assert_between;
     use super::common::conformance::{self, FrequencyOps, FrequencySpec, MergeOps};

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -21,13 +21,12 @@
 //! gap is k*tau under either partition.
 //!
 //! The last section covers the two families that keep a flow key beside every
-//! counter - CocoSketch and the Elastic sketch, section 4.4 and appendix C -
-//! behind the `experimental` feature. Only the Octo variants are here; the
-//! single-threaded sketches are `tests/e2e_heavy_hitters.rs`. Neither family is
-//! covered by a theorem, and Coco's aggregator elects from an unseeded RNG, so
-//! those tests split: exact mass identities that hold under any interleaving,
-//! and the paper's own measured comparison against sketch-merge for everything
-//! else.
+//! counter - CocoSketch and the Elastic sketch, section 4.4 and appendix C.
+//! Only the Octo variants are here; the single-threaded sketches are
+//! `tests/e2e_heavy_hitters.rs`. Neither family is covered by a theorem, and
+//! Coco's aggregator elects from an unseeded RNG, so those tests split: exact
+//! mass identities that hold under any interleaving, and the paper's own
+//! measured comparison against sketch-merge for everything else.
 
 mod common;
 
@@ -2856,7 +2855,6 @@ fn a_flat_threshold_starves_the_deep_univmon_layers() {
 // everything else over enough runs to state a band in standard errors. Elastic
 // has no randomness and is asserted exactly throughout.
 
-#[cfg(feature = "experimental")]
 mod heavy_hitters {
     use super::*;
     use asap_sketchlib::CmWorkerSketch;


### PR DESCRIPTION
Coco and Elastic leave the `experimental` feature. They, their Octo workers,
aggregators and plans, their delta types and their `EHSketchList` arms now
compile in every build, and `docs/apis.md` marks both `Ready`.

## Still gated

`KMV`, `UniformSampling` and `EHUnivOptimized` are untouched and remain behind
`experimental`. A default build resolves none of the three.

## Gates removed, per file

| File | removed | left gated |
| --- | --- | --- |
| `src/sketch_framework/octo.rs` | 32 | 0 |
| `src/sketch_framework/eh_sketch_list.rs` | 10 | 11 (UniformSampling) |
| `src/sketches/mod.rs` | 7 | 4 (KMV, UniformSampling) |
| `src/sketch_framework/eh_sketch_list/wire.rs` | 6 | 6 (UniformSampling) |
| `src/sketches/octo_delta.rs` | 4 | 0 |
| `src/sketch_framework/mod.rs` | 1 | 2 (EHUnivOptimized) |
| `tests/e2e_octo.rs` | 1 | 0 |
| `tests/e2e_heavy_hitters.rs` | 1 | 0 |

`examples/accuracy_probe.rs` carries no Coco or Elastic gate — its four are
`UnivMonPyramid` and `EHUnivOptimized` — so it is untouched.

## The shared match arm

`EHSketchList::supports_norm` grouped the three gated variants in one arm.
Coco and Elastic join the unconditional L1 arm; `UNIFORM` keeps the gate as an
arm of its own. It was the only arm in the file shaped this way; every other
Coco/Elastic gate covered a single arm.

## Wire contract

All ten kind_ids still dispatch in every build. `check_variant_available` now
rejects `0x0d 0x00` alone, still by name and still naming the feature.
`0x0b 0x00` and `0x0c 0x00` reach the Elastic and Coco decoders in every build.
The two tests that assert the rejection — in `eh_sketch_list/wire.rs` and
`eh/wire.rs` — now assert it for `0x0d 0x00`.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --all-features --locked` — 18 suites, 0 failures
- `cargo test --locked` — 18 suites, 0 failures; the Coco/Elastic suites now
  run in the default build (9 `keyed_bucket` tests, 15 Octo `heavy_hitters`)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — the same 4
  pre-existing errors in `tests/e2e_octo.rs` as on `main`, unchanged. They are
  driven by `octo-runtime`, not `experimental`: adding `--features octo-runtime`
  alone clears all four, so this change neither fixes nor worsens them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
