### PR TITLE
docs(asapv1): document every implemented payload and refresh the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,34 @@ signals a backwards-compatible change.
   capability with the exact no-false-negative check, a false-positive-rate
   ceiling and a band around `predicted_fpp`, since the existing batteries are
   all frequency- or numeric-shaped.
+- **ASAPv1 wire payloads for every remaining implemented sketch.** `CMSHeap`
+  (`0x03 0x00`), `DDSketch` (`0x05 0x00`), `Hydra` over each of its five
+  counters (`0x07 0x00`-`0x07 0x04`), `CSHeap` (`0x0a 0x00`), `Elastic`
+  (`0x0b 0x00`), `Coco` (`0x0c 0x00`), `UniformSampling` (`0x0d 0x00`), `KMV`
+  (`0x0e 0x00`), `UnivMon` (`0x10 0x00`), `UnivMon Optimized` (`0x11 0x00`),
+  `ExponentialHistogram` (`0x13 0x00`), `EHSketchList` (`0x14 0x00`),
+  `CountL2HH` (`0x19 0x00`) and `UnivMon-Q` (`0x1a 0x00`) each serialize through
+  the shared envelope, with a closed metadata schema and a positional payload
+  specified in `docs/asapv1_wire_format.md` Section 3. A nested sketch is
+  inlined rather than wrapped in an envelope of its own, except where the nested
+  algorithm is data rather than a type: an `EHSketchList` carries the variant's
+  own `kind_id`, metadata block and payload block with the framing stripped, so
+  that variant's own decoder validates it. Every decoder fails closed — a
+  declared capacity never sizes an allocation, every geometry is bounds- and
+  overflow-checked before anything is sized from it, and a container whose
+  order does not survive a rebuild has its emitted order pinned, so a decoded
+  sketch re-serializes byte-identically.
 
 ### Changed
 
+- **BREAKING (wire format):** `serialize_to_bytes` / `deserialize_from_bytes`
+  emit and read the ASAPv1 envelope for every sketch the `kind_id` registry
+  marks implemented. Bytes produced by the earlier serde-derived form of those
+  types **do not decode**; there is no legacy read path, since a new encoding
+  takes a new `kind_id` rather than a payload version field. Golden byte-vector
+  fixtures exist for HLL, Count-Min, Count Sketch and compact KLL only, so the
+  other kinds have no cross-language drift guard yet and `portable` stays in
+  place until they do.
 - **Made `HHHeap::update` independent of capacity.** The key index was rebuilt
   in full after every accepted update, cloning each resident's key, so the top-k
   structure behind `CMSHeap`, `CSHeap`, `FoldCMS`, `FoldCS`, `UnivMon` and the

--- a/asapv1_golden/README.md
+++ b/asapv1_golden/README.md
@@ -5,6 +5,14 @@ These `.hex` files pin the exact bytes the ASAPv1 wire format (see
 are the machine-checked proof that the Rust (`asap_sketchlib`) and Go
 (`sketchlib-go`) implementations serialize **byte-identically**.
 
+**Coverage.** The fixtures below cover six `kind_id`s: HLL's three estimators,
+Count-Min, Count Sketch and compact KLL. Every other `kind_id` the wire-format
+registry marks *implemented* — Bloom, Space-Saving, CMSHeap, CSHeap, DDSketch,
+Hydra's five counter variants, Elastic, Coco, UniformSampling, KMV, the UnivMon
+family, CountL2HH, ExponentialHistogram and EHSketchList — has **no fixture and
+therefore no cross-language drift guard**. `docs/asapv1_wire_format.md` fixes
+their bytes; nothing here checks them.
+
 **The copy here and the copy in `sketchlib-go/asapv1_golden/` MUST stay
 byte-identical.** They are the same fixtures, checked into both repos so each
 side's test suite is self-contained. The bytes are authored by the Rust side
@@ -37,16 +45,16 @@ golden tests the **wire encoding**, isolated from the hash functions.
 
 The CMS i64 fixture deliberately spans the msgpack integer width boundaries
 (positive fixint / uint8 / uint16 / uint32) to lock the "non-negative integer →
-uint family, minimal width" rule (`docs/asapv1_wire_format.md` §5).
+uint family, minimal width" rule (`docs/asapv1_wire_format.md` Section 4).
 
 The Count Sketch fixtures cover the **negative** side, which no other fixture
 reaches, because Count Sketch cells are signed — it adds `±weight`: negative
 fixint / int8 / int16 / int32, alongside positive fixint / uint8 / uint32.
 
-All three hold the same matrix, so each pair isolates one metadata key: the two
-i64 files differ only by `mode`, and `cs_i32_regular_2x4` differs from
-`cs_i64_regular_2x4` in exactly **two bytes** — the `"i64"` / `"i32"` string in
-`counter_type`. The payloads are byte-identical, because msgpack encodes an
+All three Count Sketch files hold the same matrix, so each pair isolates one
+metadata key: the two i64 files differ only by `mode`, and `cs_i32_regular_2x4`
+differs from `cs_i64_regular_2x4` only in the `counter_type` value, `"i64"`
+against `"i32"`. The payloads are byte-identical, because msgpack encodes an
 integer at its minimal width whatever the source type is. So the i32 fixture
 pins that the counter type reaches the bytes, and that nothing else does.
 
@@ -57,7 +65,7 @@ compaction fires (`num_levels = 1`, one level `[1..50]`) and the state is fully
 deterministic. The fixed compaction seed (42) pins the carried coin state, which
 must match `sketchlib-go`'s coin for the same input. Only the compact KLL
 (`06 00`) has a golden; the dynamic variant (`06 01`) shares the payload shape but
-lacks a seeded constructor, so its cross-language golden is deferred.
+lacks a seeded constructor, so its fixture waits on one.
 
 ## Tests that consume these
 
@@ -66,6 +74,9 @@ lacks a seeded constructor, so its cross-language golden is deferred.
 - Go: `wire/asapmsgpack/golden_test.go` — `Unmarshal(golden)`→re-`Marshal` ==
   golden, **and** `Marshal(equivalent known state) == golden` (the cross-language
   parity proof).
+
+A `kind_id` that gains a fixture needs one on both sides at once: a new `.hex`
+here and in `sketchlib-go/asapv1_golden/`, plus the case in each test file.
 
 ## Regenerating
 

--- a/docs/api/api_cms_heap.md
+++ b/docs/api/api_cms_heap.md
@@ -53,10 +53,10 @@ fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self, RmpDecodeError>
 These produce/consume the **ASAPv1** wire envelope (kind `0x03 0x00`) — see the
 [ASAPv1 wire format spec](../asapv1_wire_format.md). They are **not** available
 on every `CMSHeap`: the impl exists only for wire-eligible configs
-`CMSHeap<Vector2D<T>, Mode, H>` where `T` is `i64` or `f64` (`CmsWireCounter`),
-`Mode` is `FastPath` or `RegularPath` (`CmsWireMode`), and `H: HashProfile`. An
-`i32`, `i128` or non-`Vector2D` sketch must be converted first (only you know if
-the mapping is lossless).
+`CMSHeap<Vector2D<T>, Mode, H>` where `T` is `i32`, `i64` or `f64`
+(`CmsWireCounter`), `Mode` is `FastPath` or `RegularPath` (`CmsWireMode`), and
+`H: HashProfile`. An `i128` or non-`Vector2D` sketch must be converted first
+(only you know if the mapping is lossless).
 
 A sketch travels as the base matrix plus the heap's entries: the metadata
 carries `rows`, `cols`, `counter_type`, `mode`, the heap capacity `k` and the

--- a/docs/asapv1_wire_format.md
+++ b/docs/asapv1_wire_format.md
@@ -12,7 +12,7 @@ If the doc feels long, these sections carry the key points:
 
 - [**Section 1, Envelope**](#section-1-envelope): the Layout table.
 - [**Section 2, Metadata**](#section-2-metadata): the fields table, the hash-spec table, the structural-params table.
-- [**Section 3, Payload**](#section-3-payload): the HLL payload, the Count-Min payload, and the KLL payload.
+- [**Section 3, Payload**](#section-3-payload): one subsection per kind_id, in registry order. The HLL, Count-Min and KLL payloads are the smallest worked examples.
 
 ## Terms
 
@@ -26,7 +26,7 @@ If the doc feels long, these sections carry the key points:
 
 ## Status
 
-- **Implementing (Rust).** HLL, Count-Min, Count Sketch, KLL (compact + dynamic), Bloom, and Space-Saving serialize through the shared `message_pack_format::envelope` module per this spec.
+- **Implemented (Rust).** Every kind_id the Section 1 registry marks *implemented* serializes through the shared `message_pack_format::envelope` module per this spec: HLL (three estimators), Count-Min, CMSHeap, Count Sketch, CSHeap, DDSketch, KLL (compact + dynamic), Hydra (five counter variants), Elastic, Coco, UniformSampling, KMV, UnivMon, UnivMon Optimized, ExponentialHistogram, EHSketchList, Bloom, Space-Saving, CountL2HH and UnivMon-Q.
 - **Self-describing.** The hash-spec metadata is derived from the hasher's `HashProfile` (read live, never hardcoded), so the bytes truthfully describe how a sketch was hashed; custom hash profiles are supported (Section 2).
 - **Byte-level encoding** is pinned in Section 4; the resolved decisions are summarized at the end.
 - **`sketchlib-go`** is aligned separately (see Cross-language contract).
@@ -60,6 +60,8 @@ If a payload looks complicated, either the sketch genuinely has that much state,
 
 A serialized sketch is one envelope, then one metadata, then one payload.
 
+The diagram fixes the framing, which every kind shares. Its four `PAYLOAD` branches are **four examples, not the whole set**: Section 3 carries one subsection per kind_id, and the Section 1 registry is the complete list.
+
 ```mermaid
 erDiagram
     SerializedSketch {
@@ -70,10 +72,10 @@ erDiagram
     SerializedSketch ||--|| ENVELOPE : carries-one
     SerializedSketch ||--|| METADATA : carries-one
     SerializedSketch ||--|| PAYLOAD : carries-one
-    PAYLOAD ||--o| HLL_PAYLOAD : kind-0x0101-0x0102
-    PAYLOAD ||--o| HLL_HIP_PAYLOAD : kind-0x0103
-    PAYLOAD ||--o| COUNTMIN_PAYLOAD : kind-0x0200
-    PAYLOAD ||--o| KLL_PAYLOAD : kind-0x0600-0x0601
+    PAYLOAD ||--o| HLL_PAYLOAD : example-kind-0x0101-0x0102
+    PAYLOAD ||--o| HLL_HIP_PAYLOAD : example-kind-0x0103
+    PAYLOAD ||--o| COUNTMIN_PAYLOAD : example-kind-0x0200
+    PAYLOAD ||--o| KLL_PAYLOAD : example-kind-0x0600-0x0601
     ENVELOPE {
         bytes magic
         u8 version
@@ -89,8 +91,8 @@ erDiagram
         string seed_derivation
         string input_encoding
         array seed_list
-        u32 seed_index "hash-spec group, per-sketch; absent for non-hashing sketches (KLL)"
-        mixed structural_params "structural group, per-sketch: precision(HLL); rows+cols+counter_type+mode(CMS); k+m+item_type(KLL)"
+        u32 seed_index "hash-spec group, per-sketch; absent for a non-hashing sketch and for a fixed algorithmic index"
+        mixed structural_params "structural group, per-sketch: precision(HLL); rows+cols+counter_type+mode(CMS); k+m+item_type(KLL); one set per kind, Section 2"
     }
     PAYLOAD {
         msgpack_array raw_state
@@ -172,9 +174,11 @@ Today `kind_id` is `[family, variant]` and names the sketch's **algorithm** (its
 ### kind_id registry (single source of truth, mirrored verbatim in `sketchlib-go`)
 
 The **family** bytes match `sketchlib-go`'s `wire/asapmsgpack/magic_ids.go` verbatim; `0x0a`+ are new allocations for sketches in [`apis.md`](./apis.md) that Go has not assigned yet.
-The HLL variants, Count-Min, and both KLL variants have designed payloads today; every other row reserves its family byte with variant `0x00` and payload **TBD**.
-Variant sub-ids are not invented ahead of a payload design; a family that later needs several algorithms allocates its variants when it is designed (as HLL did).
-This registry is the master list of algorithms still to design payloads for.
+Rows marked *implemented* have designed payloads; every other row is a reservation with payload **TBD**.
+
+A family carries one variant sub-id per algorithm being built under it — HLL's estimators, KLL's two forms, Hydra's counter types — and the rest of each family's variant range stays reserved until a concrete combination is taken up.
+
+This registry is the master list of algorithms still to design payloads for, and of the ids no algorithm may take.
 
 | kind_id | Sketch | Algorithm / variant | Payload | Status |
 | --------- | -------- | --------- | --------- | -------- |
@@ -183,35 +187,35 @@ This registry is the master list of algorithms still to design payloads for.
 | `0x01 0x02` | HLL | Ertl-MLE ("Datafusion") | Section 3.1 | implemented |
 | `0x01 0x03` | HLL | HIP | Section 3.1 | implemented |
 | `0x02 0x00` | Count-Min | Count-Min | Section 3.2 | implemented |
-| `0x03 0x00` | Count-Min-with-heap (CMSHeap) | - | TBD | assigned in Go / payload not designed |
+| `0x03 0x00` | Count-Min-with-heap (CMSHeap) | Count-Min + top-k heap | Section 3.7 | implemented |
 | `0x04 0x00` | Count Sketch | Count Sketch | Section 3.6 | implemented |
-| `0x05 0x00` | DDSketch | - | TBD | assigned in Go / payload not designed |
+| `0x05 0x00` | DDSketch | Logarithmic bucket store | Section 3.8 | implemented |
 | `0x06 0x00` | KLL | Compact | Section 3.3 | implemented |
 | `0x06 0x01` | KLL dynamic | Dynamic | Section 3.3 | implemented |
-| `0x07 0x00` | Hydra-KLL | - | TBD | assigned in Go / payload not designed |
-| `0x07 0x01` | Hydra | Count-Min counter | TBD | reserved / not designed |
-| `0x07 0x02` | Hydra | Count Sketch counter | TBD | reserved / not designed |
-| `0x07 0x03` | Hydra | HyperLogLog counter | TBD | reserved / not designed |
-| `0x07 0x04` | Hydra | UnivMon counter | TBD | reserved / not designed |
+| `0x07 0x00` | Hydra | KLL counter | Section 3.9 | implemented |
+| `0x07 0x01` | Hydra | Count-Min counter | Section 3.9 | implemented |
+| `0x07 0x02` | Hydra | Count Sketch counter | Section 3.9 | implemented |
+| `0x07 0x03` | Hydra | HyperLogLog counter | Section 3.9 | implemented |
+| `0x07 0x04` | Hydra | UnivMon counter | Section 3.9 | implemented |
 | `0x08 0x00` | SetAggregator | - | TBD | assigned in Go / payload not designed |
 | `0x09 0x00` | DeltaResult | - | TBD | assigned in Go / payload not designed |
-| `0x0a 0x00` | Count-Sketch-with-heap (CSHeap) | - | TBD | reserved / not designed |
-| `0x0b 0x00` | Elastic (`Unstable`) | - | TBD | reserved / not designed |
-| `0x0c 0x00` | Coco (`Unstable`) | - | TBD | reserved / not designed |
-| `0x0d 0x00` | UniformSampling (`Unstable`) | - | TBD | reserved / not designed |
-| `0x0e 0x00` | KMV (`Unstable`) | - | TBD | reserved / not designed |
+| `0x0a 0x00` | Count-Sketch-with-heap (CSHeap) | Count Sketch + top-k heap | Section 3.10 | implemented |
+| `0x0b 0x00` | Elastic | Heavy/light | Section 3.11 | implemented |
+| `0x0c 0x00` | Coco | CocoSketch | Section 3.12 | implemented |
+| `0x0d 0x00` | UniformSampling (`Unstable`) | Priority sampling | Section 3.13 | implemented |
+| `0x0e 0x00` | KMV (`Unstable`) | k-minimum-values | Section 3.14 | implemented |
 | `0x0f 0x00` | HashSketchEnsemble | - | TBD | reserved / not designed |
-| `0x10 0x00` | UnivMon | - | TBD | reserved / not designed |
-| `0x11 0x00` | UnivMon Optimized | - | TBD | reserved / not designed |
+| `0x10 0x00` | UnivMon | Pyramid | Section 3.15 | implemented |
+| `0x11 0x00` | UnivMon Optimized | Two-tier pyramid | Section 3.16 | implemented |
 | `0x12 0x00` | NitroBatch | - | TBD | reserved / not designed |
-| `0x13 0x00` | ExponentialHistogram | - | TBD | reserved / not designed |
-| `0x14 0x00` | EHSketchList | - | TBD | reserved / not designed |
+| `0x13 0x00` | ExponentialHistogram | Sliding window over sketch buckets | Section 3.17 | implemented |
+| `0x14 0x00` | EHSketchList | Nested-sketch union | Section 3.18 | implemented |
 | `0x15 0x00` | EHUnivOptimized (`Unstable`) | - | TBD | reserved / not designed |
 | `0x16 0x00` | OctoSketch | - | TBD | reserved / not designed |
 | `0x17 0x00` | Bloom | Partitioned | Section 3.4 | implemented |
 | `0x18 0x00` | Space-Saving | Stream-Summary | Section 3.5 | implemented |
-| `0x19 0x00` | CountL2HH | - | TBD | reserved / not designed |
-| `0x1a 0x00` | UnivMon-Q (`UnivMonQ`) | - | TBD | reserved / not designed |
+| `0x19 0x00` | CountL2HH | Count Sketch with L2 accumulators | Section 3.19 | implemented |
+| `0x1a 0x00` | UnivMon-Q (`UnivMonQ`) | Quantile pyramid | Section 3.20 | implemented |
 | `0x1b 0x00` | FoldCMS | - | TBD | reserved / not designed |
 | `0x1c 0x00` | FoldCS | - | TBD | reserved / not designed |
 | `0x1d 0x00` | - | - | TBD | retired / permanently reserved, never reassign |
@@ -222,7 +226,7 @@ This registry is the master list of algorithms still to design payloads for.
 - **Hydra.** `apis.md` lists the "Hydra" framework; Go's only Hydra id is `MagicHydraKLLSketch` (`0x07`), so Hydra maps here to the `0x07` family. Each base sketch under Hydra has its own variant: `0x07 0x00` KLL, `0x07 0x01` Count-Min, `0x07 0x02` Count Sketch, `0x07 0x03` HyperLogLog, `0x07 0x04` UnivMon. `0x07 0x05`-`0x07 0xff` are **reserved for Hydra over further base sketches**; a concrete variant is allocated when that combination's payload is designed.
 - **SetAggregator / DeltaResult** (`0x08` / `0x09`) come from Go's `magic_ids.go` and do not appear as sketches in `apis.md` (they are aggregation and delta-result envelopes, distinct from stand-alone sketches). They are kept here so the family space stays mirrored verbatim with Go.
 - **`0x19`-`0x1c`.** CountL2HH, UnivMon-Q, FoldCMS and FoldCS have no counterpart in Go's `magic_ids.go`; their family bytes are allocated here first, and Go mirrors them from this registry.
-- **`Unstable`** rows mirror the `Unstable` status those sketches carry in `apis.md`; their kind_id is reserved but the payload (and the sketch API) may still change.
+- **`Unstable`** rows mirror the `Unstable` status those sketches carry in `apis.md`. The kind_id is permanent either way; the payload and the sketch API may still change, and a change to the payload takes a new id (Q-VER).
 
 ### Decoder rules
 
@@ -265,7 +269,7 @@ The metadata map is **two groups** of fields, written on the wire in this order:
 | Group | Role | Fields |
 | ----- | ---- | ------ |
 | **Hash spec** | how keys were hashed (check mergeability + re-hash a query key) | `metadata_version`, `hash_profile_id`, `hash_algorithm`, `seed_derivation`, `input_encoding`, `seed_list`, + the seed index(es) it uses |
-| **Structural params** | parameters that shape the payload | `precision` (HLL); `rows`, `cols`, `counter_type`, `mode` (Count-Min); `k`, `m`, `item_type`, optional `seed` (KLL); `rows`, `cols`, `mode` (Bloom); `capacity`, `key_type` (Space-Saving) |
+| **Structural params** | parameters that shape the payload | one fixed set per kind: `precision` (HLL); `rows`, `cols`, `counter_type`, `mode` (Count-Min); `k`, `m`, `item_type`, optional `seed` (KLL); and so on through the registry |
 
 The two tables below are the field-by-field detail of each group.
 
@@ -281,26 +285,38 @@ The two tables below are the field-by-field detail of each group.
 | `seed_derivation` | string | yes | `"seed_list_index_wrap"` |
 | `input_encoding` | string | yes | `"projectasap.input.v1"` |
 | `seed_list` | `array<u64>` | **yes (inlined)** | the 20 seeds, carried inline so the bytes self-describe the hash |
-| `canonical_seed_index` | u32 | **per-sketch** | index into `seed_list` (`5`); HLL uses it |
-| `matrix_seed_index` | u32 | **per-sketch** | `0`; Count-Min uses it |
-| `hydra_seed_index` | u32 | **per-sketch** | `6`; include only if used |
-| `univmon_bottom_layer_seed_index` | u32 | **per-sketch** | `19`; include only if used |
+| `canonical_seed_index` | u32 | **per-sketch** | index into `seed_list` (`5`); HLL, KMV and Hydra's HLL counter use it |
+| `matrix_seed_index` | u32 | **per-sketch** | `0`; Count-Min, Count Sketch, CMSHeap, CSHeap, Elastic and Hydra's matrix counters use it |
+
+These two are the only seed-index keys, because `HashProfile` declares exactly two seed-index constants — `CANONICAL_SEED_INDEX` and `MATRIX_SEED_INDEX` — and a sketch's key is derived from one of them.
+
+**A sketch carries a seed-index key only for a hash whose index it reads off the profile.** An index fixed by the algorithm gets no key: Space-Saving hashes at `0`, Coco hashes array `i` at index `i`, Elastic's heavy table hashes at the canonical index, Hydra fans a record out at `HYDRA_SEED`, and the UnivMon family finds a bottom layer at `BOTTOM_LAYER_FINDER`. No key would describe those truthfully, and a field that can be wrong is worse than none. A sketch that mixes the two carries a key for the profile-derived hash alone: Elastic carries `matrix_seed_index` for its inlined light Count-Min and nothing for its heavy table.
 
 **Structural params**
 
 | Key | Type | Applies to | Meaning |
 | ------- | ------ | -------- | --------- |
 | `precision` | u8 | HLL | `12` / `14` / `16`; register count = `2^precision` |
-| `rows` | u32 | Count-Min, Bloom | matrix depth; for Bloom the number of slices |
-| `cols` | u32 | Count-Min, Bloom | matrix width; for Bloom the bits per slice |
-| `counter_type` | string | Count-Min | `"i32"`, `"i64"` or `"f64"`; element type of `counts`, never widened |
-| `mode` | string | Count-Min, Bloom | `"fast"` or `"regular"`; key-to-column derivation |
+| `rows` | u32 | Count-Min, Count Sketch, CMSHeap, CSHeap, Bloom, Coco, CountL2HH, Hydra | matrix depth; for Bloom the number of slices; for Coco the arrays an insert scans; for Hydra the grid depth |
+| `cols` | u32 | Count-Min, Count Sketch, CMSHeap, CSHeap, Bloom, Coco, CountL2HH, Hydra | matrix width; for Bloom the bits per slice; for Coco the buckets per array; for Hydra the grid width |
+| `counter_type` | string | Count-Min, CMSHeap | `"i32"`, `"i64"` or `"f64"`; element type of `counts`, never widened |
+| `counter_type` | string | Count Sketch, CSHeap, UnivMon-Q | `"i32"` or `"i64"`; signed cells, never widened |
+| `mode` | string | Count-Min, Count Sketch, CMSHeap, CSHeap, Bloom | `"fast"` or `"regular"`; key-to-column derivation |
 | `k` | u32 | KLL | compactor capacity (accuracy parameter) |
+| `k` | u32 | CMSHeap, CSHeap, KMV, ExponentialHistogram | a retention bound: the heap capacity, the digests kept, or the histogram's merge parameter |
 | `m` | u32 | KLL | minimum level capacity |
 | `item_type` | string | KLL | `"f64"` or `"i64"`; element type of `items` |
+| `item_type` | string | UniformSampling | `"f64"`; element type of `values` |
 | `capacity` | u32 | Space-Saving | monitored-counter budget |
-| `key_type` | string | Space-Saving | exact `HeapItem` variant of `keys`, never widened (Section 3.5) |
+| `key_type` | string | Space-Saving, CMSHeap, CSHeap, UnivMon, UnivMon Optimized | exact `HeapItem` variant of `keys`, never widened (Section 3.5) |
+| `seed_index` | u32 | CountL2HH, UnivMon-Q | a per-instance seed offset the caller chose; a structural param, not a profile constant |
+| `alpha` | f64 | DDSketch | relative accuracy, in `(0, 1)`; every bucket index derives from it |
+| `sample_rate` | f64 | UniformSampling | the construction rate, in `(0, 1]` |
+| `schema` | array | Hydra | the key-column labels; the escaped forms are rebuilt from them |
+| `window` | u64 | ExponentialHistogram | the sliding window's span |
 | `seed` | u64 | KLL | **optional**; the reproducible compaction seed, present only when the sketch carries one, else the key is omitted. Compact KLL only (`KLLDynamic` never emits it). The one optional key in v1. |
+
+The names above are the ones more than one kind shares. **Each kind's full structural-param set, in its canonical wire order, is in that kind's Section 3 subsection** — including the prefixed forms a kind gives an inlined sub-sketch's params (Elastic's `heavy_buckets` / `light_rows` / `light_cols` / `light_counter_type` / `light_mode`, Hydra's `counter_*`, the UnivMon family's `layer_size` / tier widths / `heap_size`, UnivMon-Q's config).
 
 Count-Min's matrix dimensions are **configuration** (they shape the payload, like HLL's `precision`), so per the config-to-metadata rule they live here.
 Count-Min's canonical structural-param order is `... matrix_seed_index, rows, cols, counter_type, mode`; this is the wire contract and Go must mirror it verbatim.
@@ -321,11 +337,11 @@ seed_list        = [0xcafe3553, 0xade3415118, 0x8cc70208, 0x2f024b2b, 0x451a3df5
                     0x9159015a, 0x152fecd8, 0x67332667, 0x8eb44a87, 0xdb0c2e0d]
 canonical_seed_index            = 5
 matrix_seed_index               = 0
-hydra_seed_index                = 6
-univmon_bottom_layer_seed_index = 19
 seed_derivation  = "seed_list_index_wrap"
 input_encoding   = "projectasap.input.v1"
 ```
+
+The seed list also holds the two indices the algorithms fix for themselves — `HYDRA_SEED` at `6` and `BOTTOM_LAYER_FINDER` at `19`. Neither is a `HashProfile` constant and neither reaches the metadata as a key: a sketch hashing at a fixed index carries no seed-index key at all (see above).
 
 ### Custom hash profiles
 
@@ -417,7 +433,7 @@ Its structural parameters — the grid dimensions (`rows` / `cols`) and the colu
 
 **Wire-eligible geometries.** The wire covers what `Bloom::with_capacity` produces: `1 <= rows <= 20` (`BLOOM_MAX_SLICES`, the seed list length), a **power-of-two** `cols`, and `rows * cols <= 2^31` (`BLOOM_MAX_BITS`).
 `Bloom::with_dimensions` is free to build a filter outside that subset — more rows than there are seeds (which duplicate an earlier slice bit for bit), or a modulo-folded width — and such a filter is rejected on **both** sides, so the format never emits bytes it would refuse to read back.
-This mirrors Count-Min, whose wire covers i64/f64 counters while the in-memory type stays freer (Section 3.2, Section 5).
+This mirrors Count-Min, whose wire covers i32/i64/f64 counters while the in-memory type stays freer (Section 3.2, Section 5).
 
 **Decode rules** (all fail closed, per Section 1's decoder rules):
 
@@ -464,7 +480,7 @@ Count-Min's counter type is a Rust type parameter, fixed at compile time. A Spac
 
 `"f32"` is the one place a float is *not* widened to float64: the key's variant is the identity, so narrowing or widening it would change which key it is. Section 4's "always float64" rule governs *counter* and *sample* values, which have no identity to preserve.
 
-**Why not widen (e.g. `i32` to `i64`, as Count-Min does for counters).** A Count-Min counter is a number and widening it is lossless. A Space-Saving key is an *identity*, and the variant is part of it. `HeapItem`'s equality against a query `DataInput` is variant-exact — `HeapItem::I64(5)` does **not** equal `DataInput::I32(5)`. The digest, however, is variant-blind: the whole signed family hashes its value widened to `u64`, so a widened key lands in the **same index slot** and then fails the equality check. The result is not an error; it is `estimate` returning `0` for a key the summary is holding, with nothing anywhere to indicate a problem. So the wire records the variant exactly and the decoder rebuilds it exactly.
+**Why a key is never widened (e.g. `i32` to `i64`).** A counter is a number, and its width is a storage choice. A Space-Saving key is an *identity*, and the variant is part of it. `HeapItem`'s equality against a query `DataInput` is variant-exact — `HeapItem::I64(5)` does **not** equal `DataInput::I32(5)`. The digest, however, is variant-blind: the whole signed family hashes its value widened to `u64`, so a widened key lands in the **same index slot** and then fails the equality check. The result is not an error; it is `estimate` returning `0` for a key the summary is holding, with nothing anywhere to indicate a problem. So the wire records the variant exactly and the decoder rebuilds it exactly.
 
 Two summaries have no encoding and **fail to serialize** rather than being coerced:
 
@@ -500,7 +516,7 @@ The payload is a **1-element positional array `[counts]`**.
 
 Wire counter types are **`"i32"` and `"i64"`**. Count Sketch counters must be signed and negatable, so Count-Min's `f64` has no counterpart here, and `i128` has no msgpack integer form (the same line Count-Min draws). Non-`Vector2D` storage must be converted first; see Section 5, "Converting an exotic in-memory sketch".
 
-**`i32` is carried at its own width, not widened to `i64`.** Count-Min widens `i32` because a Count-Min counter is a number and the caller reads it back through a type they chose. A Count Sketch is different in one respect that matters: the `Vector2D<i32>` variants of `HydraCounter` and `EHSketchList` are *nested* sketches, decoded back into the enum variant they were stored as. Widening would make `i32` unrepresentable on the wire, so a nested sketch could not round-trip. Since the narrower type must be recorded anyway, it is recorded exactly, and the decoder pins it: `i32` bytes do not decode into an `i64` sketch, or the reverse.
+**`i32` is carried at its own width, not widened to `i64`**, exactly as Count-Min's is (§3.2). The `Vector2D<i32>` variants of `HydraCounter` and `EHSketchList` are *nested* sketches, decoded back into the enum variant they were stored as, so the width is part of the identity; the decoder pins it, and `i32` bytes do not decode into an `i64` sketch, or the reverse.
 
 Cells carry a sign: Count Sketch adds `±weight`, so a counter may be negative and a decoder must not assume monotonicity.
 
@@ -513,30 +529,583 @@ Cells carry a sign: Count Sketch adds `±weight`, so a counter may be negative a
 
 Rule 4 is enforced on the **encode** side too: a matrix whose cell count disagrees with its own dimensions (`Vector2D::init` reserves without filling) fails to serialize, so the format never emits bytes it would refuse to read back.
 
-### 3.7 onward: payloads not yet designed
+### 3.7: CMSHeap payload (`0x03 0x00`)
 
-The remaining `kind_id`s reserve a family byte with payload TBD (Section 1 registry has their "assigned in Go" status). Likely shape when designed:
+`CMSHeap` is a Count-Min sketch (§3.2) paired with an `HHHeap` of the keys it has seen most. The base sketch's counters are **inlined** rather than nested in an envelope of their own, so the payload is Count-Min's `counts` array followed by the heap's two parallel arrays:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counts` | array | the Count-Min matrix, packed **row-major**, `rows*cols` cells; element type = `counter_type` |
+| 1 | `keys` | array | one key per heap entry; element type = `key_type`; homogeneous |
+| 2 | `heap_counts` | array | i64 count, parallel to `keys` |
+
+**The heap's index does not reach the wire.** `HHHeap` is a capacity-bounded min-heap beside a digest-to-position index; `slots` and `positions` are `#[serde(skip)]` in the type itself and are rebuilt from the entries on load, so the payload carries the entries only — the same argument §3.5 makes for Space-Saving's arenas, with the same benefit: with no index on the wire, no crafted payload can point one out of bounds or into a cycle. The entry count is `len(keys)` (derived, so not stored), and the heap's array order and its `is_full` state are recomputed.
+
+**Metadata vs payload.** Everything the payload's structure depends on is configuration and lives in the metadata, in this canonical order (hash-spec group first, then structural params; Go must mirror it verbatim):
+
+```md
+metadata_version, hash_profile_id, hash_algorithm, seed_derivation, input_encoding,
+seed_list, matrix_seed_index, rows, cols, counter_type, mode, k, key_type
+```
+
+`rows` / `cols` / `counter_type` / `mode` are exactly Count-Min's (§3.2, Q-CMS-DIMS), in exactly Count-Min's order; `k` and `key_type` are the heap's and follow them. `k` is the heap's one sizing parameter, chosen at construction (`HHHeap::new(k)`), so per the config-to-metadata rule it is a descriptor field, like `capacity` in §3.5. It is a `u32`; a heap whose `k` exceeds that fails the encode rather than emitting a capacity no decode would accept.
+
+Wire counter types are the base Count-Min's: **`"i32"`, `"i64"` and `"f64"`**. `mode` records `RegularPath` vs `FastPath` because they place a key in different columns. A counter type outside that set, or non-`Vector2D` storage, must be converted first (Section 5).
+
+**`key_type` names the exact key variant, and is never widened.** This is §3.5's rule, and the thirteen names and their `HeapItem` variants are the table there. A heap whose keys are of different variants has no single `key_type` and **fails to serialize** with an error naming the mismatch; `HeapItem::I128` / `U128` have no msgpack integer form and are not wire types. An empty heap has no variant to report: it emits `key_type = "u64"` with two empty arrays, so an empty heap has exactly one encoding rather than one per producer.
+
+**Emitted order (cross-language contract).** `counts` is row-major. Heap entries are written in **descending `heap_counts`**, ties broken by a **total order over the key**: the variant tag first, in `HeapItem`'s declaration order, so every string sorts after every numeric key; then the value. This is required, not cosmetic: the heap's in-memory array order follows the sift path taken while it filled, and that order does not survive a rebuild, so an unordered payload would re-serialize to different bytes than it decoded from. With the order pinned, two heaps holding the same entries emit the same bytes whatever order they were seated in. Go must mirror the same comparator.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x03 0x00`; any other id is rejected — including `0x02 0x00` (a plain Count-Min) and `0x0a 0x00` (a CSHeap), which carry a structurally identical metadata map.
+2. The metadata's hash spec, `counter_type` and `mode` must equal the target type's own, with `rows` / `cols` / `k` / `key_type` echoed back since those are properties of the stored sketch rather than of the target. Every key is required: a map missing one, or carrying an unknown one, does not decode.
+3. `rows` and `cols` are both non-zero, checked **before** the matrix is built: the column mask is derived from `cols.ilog2()`, which panics on `cols == 0`.
+4. `key_type` is one of §3.5's thirteen names; anything else is rejected before the payload is read. The `keys` array is then read **as** that type, so string-keyed bytes relabelled `"u64"` do not decode.
+5. `keys` and `heap_counts` have equal length.
+6. `len(counts) == rows * cols` exactly, checked **before** the allocation, so crafted dimensions cannot drive a huge reserve.
+7. `len(keys) <= k`, and no key appears twice.
+8. `k` **never sizes an allocation.** Rule 7 is checked before the heap is built and the heap is then filled entry by entry, so a payload declaring `k = 2^32 - 1` with two entries costs two entries.
+
+`slots`, `positions` and the heap array are recomputed from the validated entries; nothing about them is trusted from the wire. Rule 6 is enforced on the **encode** side too — a matrix whose cell count disagrees with its own dimensions (`Vector2D::init` reserves without filling) fails to serialize — as is the `k` bound, so the format never emits bytes it would refuse to read back.
+
+### 3.8: DDSketch payload (`0x05 0x00`)
+
+`DDSketch` maps a positive value to the logarithmic bucket index `floor(ln(v) / ln(gamma))` and keeps a dense count per bucket. The relative accuracy `alpha` is its one construction parameter and lives in the metadata, so the payload is the bucket store plus the running scalars the buckets do not determine:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counts` | array | dense per-bucket sample counts, u64; the bucket index of `counts[i]` is `offset + i`. Carried verbatim, growth padding included |
+| 1 | `offset` | int | absolute bucket index of `counts[0]`; **signed**, since a value below `1.0` maps to a negative index. `0` when `counts` is empty |
+| 2 | `sum` | f64 | exact sum of every ingested value; `0.0` when empty |
+| 3 | `min` | f64 | smallest ingested value; `+inf` when empty |
+| 4 | `max` | f64 | largest ingested value; `-inf` when empty |
+
+**Metadata vs payload.** `alpha` shapes every bucket index and is chosen at construction, so per the config-to-metadata rule it is a structural param, like HLL's `precision`. `gamma`, `log_gamma` and `inv_log_gamma` are derived from it (`gamma = (1 + alpha) / (1 - alpha)`) and appear nowhere: the decoder re-derives them exactly as `DDSketch::new` does. The store's dimensions are not configuration — the store grows with the data — so there is no `rows`/`cols` analogue; `counts` is self-delimiting and `offset` positions it. The metadata is `metadata_version` then `alpha`.
+
+**DDSketch carries no hash-spec group.** It never hashes: it maps a raw `f64` through a logarithm and carries no hasher type parameter at all. The hash spec answers "how were keys hashed", and a sketch that does not hash has no truthful answer, so the group is omitted entirely. This is the Q-KLL precedent, and the reason DDSketch's metadata schema is not `HashProfile`-derived the way HLL's and Count-Min's are.
+
+**One positive-range store, no zero bucket.** `add` drops non-positive, non-finite and non-indexable values, so there is no negative-range store and no zero-count bucket to encode. Bucket *indices* are still signed, and `offset` carries that as a msgpack int per Section 4. The three payload floats are always float64.
+
+**Emitted order (cross-language contract).** `counts` is the dense store in its own bucket-index order, ascending from `offset`, with the `GROW_CHUNK` padding zeros left in place and `offset` left where the sketch put it. Nothing is trimmed and nothing is sorted, so a decoded sketch re-serializes byte-identically and `store_counts()` / `store_offset()` mean the same thing on both sides.
+
+**`count` is not carried.** Every path that advances `count` advances the bucket store by the same amount — `add` by one, `apply_delta` by the delta's value, `merge` by the other side's total — so the total sample count is exactly `sum(counts)` and is recomputed on decode. `sum`, `min` and `max` are *not* recoverable, since the buckets only bound them to within `alpha`, so all three are carried. **Consequence for `sketchlib-go`:** Go must not emit a count field, and must recover the total by summing the bucket counts with an overflow check, since a crafted payload can otherwise wrap the u64 total.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x05 0x00`; any other id is rejected.
+2. The metadata map is exact: `metadata_version` and `alpha` are both required and no other key is accepted. `alpha` is a property of the *stored* sketch rather than of the target type, so it is echoed back into the expected block rather than pinned — the same treatment Count-Min gives `rows` / `cols`.
+3. `alpha` is finite and strictly inside `(0, 1)`, the domain `DDSketch::new` asserts. Checked **before** the payload is read, so a crafted accuracy never reaches the store. Outside that range the `gamma` derivation is non-positive or infinite and every bucket index is meaningless.
+4. An empty `counts` sits at `offset == 0`, so an empty store has exactly one encoding.
+5. A populated `counts` has its highest bucket index `offset + len - 1` representable as an `i32`, checked in `i64` so the check itself cannot overflow. Applied from the declared offset and the array length alone, **before** the store is rebuilt.
+6. The total sample count is the **checked** sum of `counts`; an overflowing total is rejected rather than wrapping into a count the quantile walk would disagree with.
+7. The scalars are consistent with that total: a zero total carries `sum == 0.0`, `min == +inf` and `max == -inf`; a non-zero one carries finite `sum` / `min` / `max` with `0 < min <= max` and `sum >= min`.
+
+Rules 3, 5, 6 and 7 are enforced on the **encode** side too, so the format never emits bytes it would refuse to read back.
+
+### 3.9: Hydra payload (`0x07 0x00`-`0x07 0x04`)
+
+A Hydra is a `rows x cols` grid of counters over a fixed set of named key columns; each record fans out into its `2^D - 1` subpopulations, and each subkey is hashed to one column per row. **The kind_id names the counter variant**, so the five ids are one algorithm over five cell types: `0x07 0x00` KLL, `0x07 0x01` Count-Min, `0x07 0x02` Count Sketch, `0x07 0x03` HyperLogLog, `0x07 0x04` UnivMon. The payload carries no variant tag, per cell or otherwise, and a grid mixing variants has no encoding.
+
+**Counters are inlined, not nested.** A cell's raw state goes straight into Hydra's positional array in the shape that counter's own section fixes; no cell carries an envelope, a magic or a metadata map of its own.
+
+**`0x07 0x01` Count-Min counter, `0x07 0x02` Count Sketch counter** — the fixed-size matrix counters tile one array:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counts` | array | the cells' counters packed **grid row-major**, `rows*cols` runs of `counter_rows*counter_cols`, each run **row-major** inside itself; element type `i32`, **signed** for `0x07 0x02` |
+
+**`0x07 0x03` HyperLogLog counter:**
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `registers` | bin | the cells' register runs packed **grid row-major**; one byte per register, length `rows*cols*2^counter_precision` |
+
+**`0x07 0x00` KLL counter:**
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `cells` | array | one element per grid cell, **row-major**; each element is that cell's §3.3 array `[levels, items, coin]`, with `items` typed by `counter_item_type` |
+
+**`0x07 0x04` UnivMon counter:**
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `cells` | array | one element per grid cell, **row-major**; each element is that cell's §3.15 pyramid array `[counts, l2, heap_lens, keys, heap_counts, candidate_complete, bucket_size, update_mode]`, with `keys` typed by `counter_key_type` |
+
+A fixed-size counter tiles one array whose length the metadata fixes exactly (`rows*cols*per_cell`, overflow-checked before anything is sized from it). A variable-size counter has no such stride, so its cells are carried one element each, in the counter's own payload shape.
+
+**Metadata vs payload.** Everything a Hydra is *configured* with is metadata: the grid `rows` / `cols`, the key-column `schema`, and the counter's structural params. The payload is state alone. The counter geometry is carried once rather than per cell, because every cell is a clone of one prototype. The five kind_ids use **four** metadata schemas, each closed and fully required — Count-Min and Count Sketch share one, exactly as the two KLL kind_ids share one:
+
+| kind_id | Hash-spec group | Structural params (canonical order) |
+| --- | --- | --- |
+| `0x07 0x00` KLL | yes, no seed index | `rows`, `cols`, `schema`, `counter_k`, `counter_m`, `counter_item_type` |
+| `0x07 0x01` / `0x07 0x02` | yes, `matrix_seed_index` | `rows`, `cols`, `schema`, `counter_rows`, `counter_cols`, `counter_type`, `counter_mode` |
+| `0x07 0x03` HLL | yes, `canonical_seed_index` | `rows`, `cols`, `schema`, `counter_precision` |
+| `0x07 0x04` UnivMon | yes, no seed index | `rows`, `cols`, `schema`, `counter_layer_size`, `counter_sketch_row`, `counter_sketch_col`, `counter_heap_size`, `counter_key_type` |
+
+`schema` is carried as the label list alone. `KeySchema` holds `labels` plus a pre-escaped cache; the cache is a pure function of the labels (the `\`, `:` and `;` escape), so only `labels` reaches the wire and `TryFrom<Vec<String>>` rebuilds and re-validates the rest. `schema` must round-trip exactly: changing it would invalidate every subkey already hashed into the grid.
+
+Hydra always hashes — it hashes every subkey to place it in the grid — so every schema carries the hash-spec group, and that group describes **Hydra's own** subkey hash. `0x07 0x00` is therefore a hashing sketch holding non-hashing counters: what the KLL counter contributes is only its structural params, with no hash spec of its own, exactly as §3.3 prescribes. Hydra fans a record out at `HYDRA_SEED`, a fixed index rather than a profile choice, so no seed-index key names it; the `matrix_seed_index` on `0x07 0x01` / `0x07 0x02` and the `canonical_seed_index` on `0x07 0x03` describe the **counters'** own hashing, which does read the profile.
+
+The KLL counter's optional compaction `seed` is not carried, so the bounded cost Q-KLL-SEED describes applies to a Hydra KLL cell: only a decoded-then-`clear()`ed cell loses cross-run byte reproducibility, never correctness.
+
+`counter_type`, `counter_mode`, `counter_item_type` and `counter_precision` are carried although the kind_id fixes them, because they name the element type and column derivation a reader needs to cut and interpret the payload without resolving a Rust enum definition — the job `light_counter_type` / `light_mode` do for Elastic's inlined Count-Min (§3.11). `HydraCounter::CM` and `::CS` both hold `Vector2D<i32>` on the fast path, so both read `"i32"` / `"fast"`, and `i32` is carried at its own width.
+
+**Emitted order (cross-language contract).** Cells are emitted **row-major over the grid** and, within a cell, in the order that counter's own section fixes: §3.2 / §3.6 row-major counters, §3.1 register bytes, §3.3 top-most-level-first `levels` / `items`, §3.15's layers ascending with each heap in descending count. A decoded Hydra re-serializes byte-identically.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is one of the five; the decoder routes on it and each variant's decoder owns exactly one id.
+2. The hash-spec group matches the target's `HashProfile` (Hydra hashes through the crate default, `DefaultXxHasher`). `counter_type` (`"i32"`), `counter_mode` (`"fast"`), `counter_item_type` (`"f64"`) and `counter_precision` are pinned, since the counter variant fixes them; `rows` / `cols` / `schema` and the remaining counter dimensions are properties of the *stored* grid, so they are echoed back and then validated on their own.
+3. `rows` and `cols` are non-zero and `rows * cols` is overflow-checked. For the tiled variants the counter dimensions are non-zero and `rows * cols * per_cell` is overflow-checked too, and for `0x07 0x04` every one of `counter_layer_size` / `counter_sketch_row` / `counter_sketch_col` / `counter_heap_size` is non-zero. All **before** anything is sized from them.
+4. The payload's length is measured against the declared geometry — `len(counts) == rows*cols*counter_rows*counter_cols`, `len(registers) == rows*cols*2^counter_precision`, `len(cells) == rows*cols` — before any grid or matrix is allocated. A declared grid larger than the payload carries costs nothing.
+5. `0x07 0x04` reads `cells` as `counter_key_type`, which must be one of §3.5's thirteen names; a payload whose keys are not of the declared type is rejected by the msgpack decode itself.
+6. Each cell is then rebuilt through its own counter's decoder, so every rule that decoder enforces holds for a Hydra cell too: KLL's level layout and `k` / `m` bounds, HLL's register count, UnivMon's per-layer geometry and heap runs.
+7. `schema` is re-validated through `KeySchema::try_from`: non-empty, at most `MAX_KEY_COLUMNS` labels, no duplicates.
+8. `type_to_clone` is rebuilt as a fresh counter of the declared geometry; nothing about it is read from the payload.
+
+Rules 3 and 4 are enforced on the **encode** side too, along with a grid whose declared `rows` / `cols` disagree with its storage, a grid mixing counter variants, a cell whose geometry differs from the prototype's, UnivMon cells mixing `HeapItem` key variants, and a `type_to_clone` holding data. So the format never emits bytes it would refuse to read back.
+
+### 3.10: CSHeap payload (`0x0a 0x00`)
+
+`CSHeap` is a Count Sketch (§3.6) paired with an `HHHeap`, and its payload is §3.7's with the Count Sketch counter domain:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counts` | array | the Count Sketch matrix, packed **row-major**, `rows*cols` cells; element type = `counter_type`, **signed** |
+| 1 | `keys` | array | heap keys; element type = `key_type`; homogeneous (§3.7) |
+| 2 | `heap_counts` | array | i64 heap count, parallel to `keys` (§3.7) |
+
+**Metadata vs payload.** One schema serves both top-k sketches, with §3.7's canonical key order:
+
+```md
+metadata_version, hash_profile_id, hash_algorithm, seed_derivation, input_encoding,
+seed_list, matrix_seed_index, rows, cols, counter_type, mode, k, key_type
+```
+
+Wire counter types are the base Count Sketch's: **`"i32"` and `"i64"`** (§3.6, Q-CS). Count Sketch counters must be signed and negatable, so Count-Min's `"f64"` has no counterpart here, and `i128` has no msgpack integer form. `i32` is carried at its own width and the decoder pins it: i32 bytes do not decode into an i64 sketch, or the reverse. Cells carry a sign, so a decoder must not assume monotonicity.
+
+**Emitted order (cross-language contract).** §3.7's, unchanged: `counts` row-major, then heap entries in descending count with ties broken by the total order over the key.
+
+**Decode rules.** §3.7's rules 2 through 8 apply verbatim, with two differences:
+
+1. `kind_id` is `0x0a 0x00`; any other id is rejected — including `0x04 0x00` (a plain Count Sketch) and `0x03 0x00` (a CMSHeap).
+2. `"f64"` is not a CSHeap `counter_type` and decodes into neither wire-eligible type.
+
+The same encode-side checks apply, so the format never emits bytes it would refuse to read back.
+
+`CountL2HH`, which also lives in `countsketch_topk.rs`, is a different algorithm with its own kind_id (§3.19) and is not serialized here.
+
+### 3.11: Elastic payload (`0x0b 0x00`)
+
+`Elastic` is a heavy/light frequency estimator: a heavy hash table of `<flow_id, vote+, vote-, eviction>` buckets over a Count-Min light layer that absorbs evicted and unelected flows. Both parts are sized at construction, so both geometries live in the metadata and the payload is the two parts' raw state plus the one flag nothing else determines:
+
+| Pos | Field | Type | Notes |
+| --- | ----- | ---- | ----- |
+| 0 | `flow_ids` | array | one entry per heavy bucket, dense in bucket index order; `nil` when the bucket is free, `str` otherwise; length `heavy_buckets` |
+| 1 | `vote_pos` | array | i32 positive votes, parallel to `flow_ids`; `0` exactly when the bucket is free |
+| 2 | `vote_neg` | array | i32 negative votes, parallel to `flow_ids` |
+| 3 | `evictions` | array | bool light-layer flag, parallel to `flow_ids` |
+| 4 | `stale_copies` | bool | pre-expansion copies may still sit in the half they no longer hash to |
+| 5 | `light_counts` | array | the light Count-Min's counters, packed **row-major**, `light_rows*light_cols` cells; element type `i32` |
+
+**Metadata vs payload.** The heavy table's bucket count and the light layer's dimensions are sizing parameters chosen at construction, so per the config-to-metadata rule they are descriptor fields. `light_counter_type` and `light_mode` are structural params in the Count-Min `counter_type` / `mode` sense: they fix the element type of `light_counts` and the column derivation a reader must reproduce to query it. Structural-param order is `... matrix_seed_index, heavy_buckets, light_rows, light_cols, light_counter_type, light_mode`; this is the wire contract and Go must mirror it verbatim.
+
+**The light layer is inlined, not nested.** `Elastic::light` is a `CountMin<Vector2D<i32>, RegularPath, H>`. Its counters are inlined into `light_counts` and its structural params into this metadata, so an Elastic binary is **one** envelope; a nested envelope would repeat a magic, a version and a hash-spec map the outer one already carries.
+
+**Seed indices.** Elastic hashes, so it carries the hash-spec group, derived live from the hasher's `HashProfile`. It carries exactly one seed-index key, `matrix_seed_index`, the inlined Count-Min's. The heavy part hashes every flow id at the fixed canonical seed index, a part of the algorithm rather than a profile choice, so no `canonical_seed_index` would describe it truthfully (§2).
+
+**A free heavy bucket is msgpack `nil`.** A bucket holds a flow exactly while `vote_pos != 0` (`HeavyBucket::is_vacant`), and `Elastic::insert` accepts any `String`, `""` included. So an inserted empty flow id is a **reachable and genuinely occupied** bucket that `query("")` answers for, and it must not share an encoding with a free slot. `flow_ids[i]` is `nil` (`0xc0`) for a free bucket and a `str` otherwise. In every state the algorithm reaches, a free bucket's `flow_id` is empty, so the encoding is lossless. **Consequence for `sketchlib-go`:** `flow_ids` must be modelled as a nullable string slice, never as `[]string` with `""` standing in for absent.
+
+**`stale_copies` is carried.** `expand_heavy` appends a copy of the table, doubles `bktlen` and sets the flag; every duplicated resident then sits in both halves, and the half it no longer hashes to is a stale copy, dropped lazily. `stale_at` is `stale_copies && !is_vacant() && bucket_index(flow_id) != idx`, so the flag **gates** that test and nothing in the buckets replaces it: right after a `compress_heavy` or a `merge` the flag is false while buckets whose resident hashes elsewhere still legitimately exist. A decoder that ignored it would report every expanded flow **twice** from `resident_flows`, so `heavy_hitters` and `heavy_changes` double-report, and `insert` would add votes to a dead copy instead of seating the arrival over it.
+
+**`bktlen` is derived, not carried.** It is the heavy table's sizing parameter and appears in the descriptor as `heavy_buckets`; the payload omits it and the decoder sets `bktlen = heavy_buckets`. `bktlen` is a public field, so an out-of-step value is constructible, and the encode side rejects it rather than emitting bytes with two different lengths in them.
+
+**Emitted order (cross-language contract).** The four heavy arrays are dense over the whole table in **bucket index order**, and `light_counts` is **row-major**, the layout Count-Min packs `counts` in. Every bucket is emitted, free ones included, so two sketches holding the same state emit the same bytes and a decoded sketch re-serializes byte-identically.
+
+**Wire-eligible configuration.** `Elastic<H>` fixes its light layer to `Vector2D<i32>` + `RegularPath` in the struct definition, so the wire covers exactly that one configuration. The two names are still written into the metadata and **pinned on both sides**: `light_counter_type` reads `"i32"` and `light_mode` reads `"regular"`, so bytes from any other light layer are rejected rather than misread. `i32` is carried at its own width.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x0b 0x00`; any other id is rejected.
+2. The metadata's hash spec, `light_counter_type` and `light_mode` must equal the target type's own, with `heavy_buckets` / `light_rows` / `light_cols` echoed back since those are structural and both parts are sized from them. Cross-profile bytes are rejected.
+3. `heavy_buckets`, `light_rows` and `light_cols` are all non-zero, `heavy_buckets` fits an `i32` (`bktlen`'s type), and `light_rows * light_cols` does not overflow. Checked **before** anything is sized from the declared geometry, so a hostile geometry never reaches an allocation.
+4. `len(flow_ids) == len(vote_pos) == len(vote_neg) == len(evictions) == heavy_buckets`, and `len(light_counts) == light_rows * light_cols`, both checked before the table and the matrix are built.
+5. `flow_ids[i]` is `nil` **exactly when** `vote_pos[i] == 0`. The two encode the same fact, occupancy, and a payload where they disagree describes a table no insert could produce.
+
+Rules 3, 4 and 5 are enforced on the **encode** side too, along with `bktlen == heavy.len()` and a light layer whose cell count agrees with its own dimensions (`Vector2D::init` reserves without filling), so the format never emits bytes it would refuse to read back.
+
+### 3.12: Coco payload (`0x0c 0x00`)
+
+`Coco` is the CocoSketch of SIGCOMM '21 section 4.1: a `rows x cols` table of buckets, each holding the one key it currently represents and the mass attributed to it. The table geometry is construction config, so it lives in the metadata as `rows` (the sketch's `d`, the arrays an insert scans) and `cols` (its `w`, the buckets per array), named the way Count-Min and Bloom name their grid. The payload is the bucket state alone:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `keys` | array | one entry per bucket, packed **row-major**, `rows*cols` entries; `nil` for an unoccupied bucket, `str` for an occupied one |
+| 1 | `values` | array | u64 mass attributed to that bucket, parallel to `keys`; `values[i] == 0` wherever `keys[i]` is `nil` |
+
+The two arrays are parallel, dense and equal-length. Nothing else in the struct reaches the wire: every query the sketch answers — `estimate_key`, `recorded_flows`, `group_by`, `estimate_projected` — is recomputed from the buckets on demand, so there is no summary to carry.
+
+**Metadata vs payload.** `rows` and `cols` are the sketch's only construction parameters, so per the config-to-metadata rule they belong in the descriptor and the decoder sizes the table from them. Structural-param order is `... seed_list, rows, cols`. There is **no `key_type`**: a Coco key is a `String` at every entry point (`insert(&str, u64)`), so the kind_id already fixes the element type of `keys`, and a field the kind_id determines does not belong on the wire.
+
+Coco carries the hash-spec group — it hashes, and a consumer must reproduce that hash to query a key — but carries **no seed-index key**. Array `i` is hashed with `hash64_seeded(i, ..)`, starting at index `0` and walking the seed list, which is a fixed part of the algorithm rather than a profile choice (§2).
+
+**Emitted order (cross-language contract).** The payload is dense over the whole table in **row-major index order**: bucket `(r, c)` is at position `r*cols + c` in both arrays, the same layout Count-Min packs `counts` in. Every bucket is emitted, occupied or not, so the order is the table's own and nothing has to be sorted. A decoded sketch re-serializes byte-identically.
+
+**An unoccupied bucket is msgpack `nil`, never an empty string.** A bucket's key is `Option<String>` in memory, and `insert` accepts any `&str`, `""` included. An inserted `""` produces `Some("")`: a genuinely occupied bucket that `estimate_key("")` answers for and that `recorded_flows` yields. Encoding a free bucket as `""` would make the two indistinguishable on the wire, and a decoder would resurrect an empty-string flow holding the free bucket's mass. So `keys[i]` is msgpack `nil` (`0xc0`) when the bucket is free and a msgpack `str` (`0xa0` for the empty key) when it is occupied. **Consequence for `sketchlib-go`:** the `keys` array is heterogeneous — nil or str — and must be modelled as `[]*string` or an equivalent nullable string, never as `[]string` with `""` standing in for absent.
+
+**Bucket values are never negative.** Mass is `u64` and only ever grows by `+= v`, so every `values[i]` goes in the msgpack **uint** family at minimal width per Section 4. Coco has nothing like Count Sketch's signed cells.
+
+**Wire-eligible geometries.** `rows >= 1` and `cols >= 1`. `cols == 0` is not representable at all — `Vector2D` derives its column mask through `cols.ilog2()`, which panics on zero — and a table with no arrays records nothing. Both are rejected on **both** sides. There is no power-of-two constraint on `cols`, since Coco folds with `% w` rather than a mask, and no upper bound on `rows`: a table with more arrays than there are seeds has arrays that wrap onto duplicate seeds, but its state still round-trips exactly, so it stays wire-eligible.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x0c 0x00`; any other id is rejected.
+2. The metadata's hash spec must equal the target type's own, with `rows` / `cols` echoed back since those are structural and the table is sized from them. Cross-profile bytes are rejected.
+3. `rows` and `cols` are both non-zero. Checked **before** anything is sized from the declared geometry, so a hostile geometry never reaches an allocation and never reaches `cols.ilog2()`.
+4. `len(keys) == len(values) == rows * cols` exactly, and that product must not overflow. Checked **before** the table is built, so crafted dimensions cannot drive a huge reserve.
+5. `values[i] == 0` wherever `keys[i]` is `nil`. An unoccupied bucket holds no mass — `insert` always elects a key into the bucket it credits — so no encoder can produce such an entry, and rejecting it keeps the decoded table canonical. This mirrors Bloom's trailing-padding rule (§3.4, rule 5).
+
+Rules 3 and 4 are enforced on the **encode** side too: a zero dimension, or a table whose bucket count disagrees with the sketch's own dimensions, fails to serialize.
+
+### 3.13: UniformSampling payload (`0x0d 0x00`)
+
+`UniformSampling` is a priority-sampling reservoir: each update draws a 64-bit priority, the entry is inserted into a priority-ordered list, and the list is truncated to `ceil(total_seen * sample_rate)`. The retained state is the `(priority, value)` pairs plus the two running scalars nothing else determines:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `priorities` | array | u64 draw per retained entry, **ascending**; parallel to `values` |
+| 1 | `values` | array | the retained samples, parallel to `priorities`; element type = `item_type` |
+| 2 | `total_seen` | u64 | stream elements offered to the sampler, saturating at `u64::MAX` |
+| 3 | `rng_state` | u64 | the SplitMix64 word the next priority is drawn from |
+
+The two arrays are parallel and equal-length; the number of retained samples is `len(values)` (derived, so not stored), and the target size `ceil(total_seen * sample_rate)` is derived from the metadata and position 2.
+
+`priorities` is **not** derivable from `values` and is carried: `merge` re-sorts both sides by priority and truncates, and `update` binary-searches the list on that key, so a payload carrying only the values would decode into a sampler that made different retention decisions from the one that was encoded. `total_seen` is likewise not derivable — two samplers holding the same 100 samples at rate `0.1` differ in their next update's target size if they have seen different stream lengths.
+
+**Metadata vs payload.** The metadata is structural params only, in the order `metadata_version`, `sample_rate`, `item_type`:
+
+| Key | Type | Meaning |
+| ------- | ------ | --------- |
+| `metadata_version` | u8 | `1` |
+| `sample_rate` | f64 | the construction rate, in `(0, 1]`; with `total_seen` it fixes the retained-sample bound |
+| `item_type` | string | `"f64"`; the element type of `values` |
+
+`sample_rate` is the sampler's one sizing parameter, chosen at construction, so per the config-to-metadata rule it belongs in the descriptor. It is a property of the *stored* sampler rather than of the target type, so decode echoes it back rather than pinning it — the same treatment Count Sketch gives `rows` / `cols`. `metadata_version` and `item_type` are pinned by that comparison.
+
+**UniformSampling omits the hash-spec group entirely.** It never hashes: `update_input` widens a numeric `DataInput` to `f64` and `update` draws a SplitMix64 priority from the sampler's own RNG. No hasher is ever invoked and the type carries no `H: HashProfile` parameter, so `hash_profile_id`, `seed_list` and a seed index have no truthful value here. This is the Q-KLL precedent.
+
+**`item_type` is `"f64"`, exact and never widened.** The sampler stores every retained sample as `f64`; `update` takes an `f64` and `update_input` widens `I32` / `I64` / `U32` / `U64` / `F32` to one, rejecting every non-numeric `DataInput`. The key is carried and pinned: decode rejects any other name, so `values` is read as float64 (`0xcb`) per Section 4 without a Go decoder needing the registry's element-type detail out of band.
+
+**`rng_state` is resumable, not opaque.** It is the SplitMix64 **pre-increment** state — the word the next draw adds the golden gamma `0x9E3779B97F4A7C15` to — with the reference constants `0xBF58476D1CE4E5B9` and `0x94D049BB133111EB` and the shifts 30 / 27 / 31, all wrapping. A decoded sampler continues the same draw sequence rather than reseeding, so it retains the same samples the original would have. `merge` mixes the two states as `state ^ rotate_left(other, 19)`, falling back to the golden gamma when the result is `0`; Go must mirror both. There is no metadata `seed` key: `with_seed` writes its argument straight into `rng_state`, which then evolves, and the sampler has no `clear()` to re-seed from. `rng_state == 0` is legal, since `next_random`'s wrapping add can land on it mid-stream and SplitMix64 has no bad state.
+
+**Emitted order (cross-language contract).** Entries are written in **ascending `priority`**, ties broken by `f64::total_cmp` on the parallel value. This is required, not cosmetic: the in-memory list is priority-ordered, but the position of two entries drawing the *same* priority depends on insertion history, so an unpinned order would let a decoded sampler re-serialize to different bytes than it decoded from. Decode requires the order, which also keeps `insert_entry`'s binary search intact on the next update. An empty sampler has exactly one encoding for a given rate and RNG position.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x0d 0x00`; any other id is rejected.
+2. `sample_rate` is finite and in `(0, 1]`. Checked **before** anything is derived from it: `0.0`, a negative, a value above `1`, `NaN` and the infinities are all rejected, matching the constructor's own assertion, so a crafted rate can never reach the target-size computation.
+3. `metadata_version == 1` and `item_type == "f64"`; `sample_rate` is echoed back rather than pinned.
+4. `priorities` and `values` have equal length.
+5. `len(values) <= ceil(total_seen * sample_rate)` — the retention bound the algorithm maintains after every `update` and `merge`. More retained samples than the declared stream length and rate allow is not a state the algorithm reaches.
+6. The entries are in ascending `priority`, ties ordered by `total_cmp` of the parallel value. Anything else is rejected, which makes the decoded form canonical.
+7. `total_seen` and `sample_rate` **never size an allocation.** The entry vector is sized from `len(values)`, so a payload declaring `total_seen = u64::MAX` at rate `1.0` with two samples costs two samples (§3.5, rule 8).
+
+Rules 2 and 5 are enforced on the **encode** side too, so the format never emits bytes it would refuse to read back.
+
+A `NaN` sample is legal: `update(f64::NAN)` is legal in memory and `total_cmp` gives it a total order, so it round-trips rather than being rejected.
+
+### 3.14: KMV payload (`0x0e 0x00`)
+
+`KMV` is the k-minimum-values distinct-count estimator: it hashes each key once and retains the `k` smallest 64-bit digests it has seen. The retention bound `k` is construction config and lives in the metadata, so the payload is the retained digests alone:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `hashes` | array | the retained 64-bit digests, **strictly ascending**; `len(hashes) <= k` |
+
+The payload is a **1-element positional array `[hashes]`**, mirroring Count-Min's `[counts]`. How many digests are retained is `len(hashes)` (derived, so not stored), and the estimate is a closed form over `k` and the largest retained digest, so it is not carried either. KMV keeps no insertion counter, no displaced-weight scalar and no eviction ceiling: unlike Bloom's `inserted` or Space-Saving's `floor`, there is no running state the retained set does not already determine.
+
+**Metadata vs payload.** `k` is the sketch's one sizing parameter, chosen at construction, so per the config-to-metadata rule it belongs in the descriptor. It is carried as a `u32`; a `k` past that field fails to serialize rather than being truncated. Structural-param order is `... canonical_seed_index, k`.
+
+KMV carries the **hash-spec group** — it hashes, and a consumer must reproduce that hash to fold a key in — and it carries `canonical_seed_index`. It hashes each key exactly once with `hash64_seeded(CANONICAL_HASH_SEED, ..)`, the same single-digest call HLL makes, and `HashProfile::CANONICAL_SEED_INDEX` is defined as the index a single-hash sketch uses.
+
+**Hash width.** Retained values are the 64-bit digests `hash64_seeded` returns and travel at that width, neither widened to `u128` nor narrowed. `hashes` is a msgpack array of unsigned integers under Section 4's family/width rule; a digest above `2^63` is still `uint`, never the `int` family.
+
+**Emitted order (cross-language contract).** The retained set lives in a bounded max-heap whose array order follows the sequence the keys arrived in and does not survive a rebuild, so an unordered payload would re-serialize to different bytes than it decoded from. `hashes` is therefore written in **strictly ascending** digest order. Two sketches holding the same retained set emit the same bytes whatever order they were inserted in. Strict ascent also makes the duplicate check free: `insert_by_hash` never seats the same digest twice, so equal neighbours are rejected. A decoder rebuilds the heap by reversing the run — a descending run already satisfies the max-heap invariant — so no re-heapify is needed and the rebuilt root is the largest retained digest. A sketch that retains nothing emits an empty `hashes` array beside its `k`, so an empty KMV has exactly one encoding.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x0e 0x00`; any other id is rejected.
+2. The hash-spec group matches the **target hasher's** `HashProfile`. `k` is a property of the *stored* sketch rather than of the target type, so it is echoed back into the expected metadata rather than pinned — the same treatment Count-Min gives `rows` / `cols` and Space-Saving gives `capacity`.
+3. `k >= 1`, checked before anything is sized. A `k` of zero has no estimate defined.
+4. `len(hashes) <= k`.
+5. `hashes` is strictly ascending, which rejects both a wrong order and a repeated digest.
+6. `k` **never sizes an allocation.** The heap's backing vector is sized from `len(hashes)`, so a payload declaring `k = 2^32 - 1` with two digests costs two digests. The bound still governs the decoded sketch: a further digest is appended, not evicted.
+
+The encode side enforces rules 3 and 4 as well, and rejects a sketch holding the same digest twice, so the format never emits bytes it would refuse to read back.
+
+### 3.15: UnivMon payload (`0x10 0x00`)
+
+`UnivMon` is a pyramid of `layer_size` layers, each a `CountL2HH` (§3.19) of `sketch_row x sketch_col` plus an `HHHeap` of capacity `heap_size`. Every layer has the same dimensions and the same heap capacity, and layer `i` hashes at seed index `i`, so all of that is metadata or derived and the payload is the layers' raw state:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counts` | array | the layers' `CountL2HH` counters concatenated in layer order, each layer row-major; length `layer_size * sketch_row * sketch_col` |
+| 1 | `l2` | array | the layers' L2 accumulators concatenated in layer order; length `layer_size * sketch_row` |
+| 2 | `heap_lens` | array | u32 entries held by each layer's heap, one per layer |
+| 3 | `keys` | array | every layer's heap keys concatenated, cut by `heap_lens`; element type = `key_type`; homogeneous |
+| 4 | `heap_counts` | array | i64 heap count, parallel to `keys` |
+| 5 | `candidate_complete` | array | one bool per layer |
+| 6 | `bucket_size` | u64 | total weight recorded |
+| 7 | `update_mode` | u8 | `0` unset, `1` standard, `2` terminal-only |
+
+**A layer's `CountL2HH` is inlined, not nested.** The layer's `counts` and `l2` are appended to the outer sketch's own positional arrays, and its `rows` / `cols` / `seed_index` come from the outer metadata plus the layer's position. No nested envelope, magic, version or metadata map is emitted per layer.
+
+**Metadata vs payload.** `layer_size`, `sketch_row`, `sketch_col` and `heap_size` are `init_univmon`'s four arguments — configuration that shapes the payload, so the descriptor carries them and every derived length is checked rather than re-stored. `key_type` is a structural param in the §3.5 sense: it fixes the element type of `keys`, and the payload cannot be read without it. One `key_type` covers every layer; a pyramid whose layers mix `HeapItem` variants has no single one and fails to serialize, as a Space-Saving summary does. Structural-param order is `layer_size, sketch_row, sketch_col, heap_size, key_type`.
+
+UnivMon carries the hash-spec group — it hashes, and a consumer must reproduce that hash to query a key — but carries **no seed-index key**. It hashes the bottom-layer finder at `BOTTOM_LAYER_FINDER` unconditionally: a fixed part of the algorithm, not a profile choice, exactly as Space-Saving's index 0 is (§3.5). The per-layer counter seed index *is* a real value, but it equals the layer's position, so it is derived and not stored, and the encoder rejects a layer whose seed index is not its position. `UnivMon` has no hasher type parameter, so its metadata is derived from `DefaultXxHasher`'s `HashProfile` — read live, never hardcoded — and a custom-profile envelope is different bytes and is rejected on decode.
+
+`update_mode` and `candidate_complete` are both **carried**:
+
+- `update_mode` is acquired from the first update rather than configured, and it selects the query recurrence (`calc_terminal_g_sum` versus the standard layer recurrence). A decoder that guessed it would answer entropy and cardinality from the wrong reconstruction.
+- `candidate_complete` is not derivable. `len < heap_size` implies complete, but a full heap is ambiguous — exactly-filled-never-evicted and evicted-since look identical — and `mark_candidates_incomplete`, the OctoSketch delta path, lowers the flag with no observable trace. A decoder that re-derived it from heap fullness would call an evicted-from layer complete, which sends `heavy_threshold` down the permissive branch (threshold `0` instead of `l2 / sqrt(heap_size)`) and counts every candidate including noise: overstated `calc_card` and `calc_entropy`, with nothing anywhere to indicate a problem.
+
+`bucket_size` is the exact L1 and is not recoverable from the counters, so it is carried. Everything else UnivMon reports — `calc_l2`, `calc_entropy`, `calc_card` — is recomputed from the layers and appears nowhere.
+
+**`L2HH` carries no variant tag.** `L2HH` is a single-variant enum (`COUNT(CountL2HH)`), and `kind_id` fixes the payload's structure, so the wire spells out the CountL2HH state directly with no tag — the same rule that keeps a variant tag out of every other payload. A second `L2HH` variant needs either a new metadata structural param naming the per-layer counter kind, as Count-Min does with `counter_type`, or a new `kind_id`; `0x10 0x00` and `0x11 0x00` are defined as all-`COUNT`.
+
+**Emitted order (cross-language contract).** Layers ascend, `0 .. layer_size`, in every array. Within a layer the heap's entries are written in **descending `count`**, ties broken by the total order over the key — the same order §3.7 pins for CMSHeap and CSHeap. This is required, not cosmetic: `HHHeap`'s array order follows the sift path and does not survive a rebuild, so an unordered payload would re-serialize to different bytes than it decoded from. The heap's digest index (`slots`, `positions`) is rebuilt from the entries, so no index reaches the wire and no crafted payload can point one out of bounds or into a cycle.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x10 0x00`; any other id is rejected.
+2. The hash-spec group matches `DefaultXxHasher`'s `HashProfile`. `layer_size`, `sketch_row`, `sketch_col`, `heap_size` and `key_type` are properties of the stored sketch, so they are echoed back rather than pinned.
+3. `layer_size >= 1` and `heap_size >= 1`.
+4. `key_type` is one of §3.5's thirteen names; the `keys` array is read **as** that type, so a payload whose keys are not of the declared type is rejected by the msgpack decode itself, and `keys` and `heap_counts` have equal length.
+5. `sketch_row * layer_size == len(l2)` exactly, checked **before** the layer geometry is built, so a declared `layer_size` far larger than the payload carries never reserves anything.
+6. `len(heap_lens) == len(candidate_complete) == layer_size`; every layer's `rows` and `cols` are non-zero (`cols.ilog2()` panics on zero); the layers' total cell count and total accumulator count are computed with checked arithmetic and must equal `len(counts)` and `len(l2)`; and `len(keys) == len(heap_counts) == sum(heap_lens)`.
+7. Each layer's entry count is `<= heap_size`, and no key appears twice within a layer. `heap_size` **never sizes an allocation**: each heap is seated from the entries the payload actually carries.
+8. `bucket_size` fits this target's `usize`.
+9. `update_mode` is `0`, `1` or `2`; any other value is rejected.
+
+The encode side enforces the same shape rules — a layer that is not the declared size, a layer hashing at another layer's seed index, mixed or 128-bit keys, a layer count that disagrees with the declared `layer_size` — so the format never emits bytes it would refuse to read back.
+
+### 3.16: UnivMon Optimized payload (`0x11 0x00`)
+
+`UnivMonPyramid` is UnivMon with two tiers: layers `0 .. elephant_layers` use `elephant_row x elephant_col` counters and the rest use `mouse_row x mouse_col`. Nothing else about it differs, so it **shares §3.15's payload byte for byte** and differs only in its metadata — the way HLL Classic and Ertl-MLE share one payload and differ only by `kind_id`:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counts` | array | the layers' `CountL2HH` counters concatenated in layer order, each layer row-major; length is the layers' total cell count under the two-tier layout |
+| 1 | `l2` | array | the layers' L2 accumulators concatenated in layer order; length `min(elephant_layers, layer_size) * elephant_row + max(0, layer_size - elephant_layers) * mouse_row` |
+| 2 | `heap_lens` | array | u32 entries held by each layer's heap, one per layer |
+| 3 | `keys` | array | every layer's heap keys concatenated, cut by `heap_lens`; element type = `key_type`; homogeneous |
+| 4 | `heap_counts` | array | i64 heap count, parallel to `keys` |
+| 5 | `candidate_complete` | array | one bool per layer |
+| 6 | `bucket_size` | u64 | total weight recorded |
+| 7 | `update_mode` | u8 | `0` unset, `1` standard, `2` terminal-only |
+
+**Metadata vs payload.** `UnivMonPyramid::new`'s arguments are the configuration, so the descriptor carries `layer_size`, `elephant_layers`, `elephant_row`, `elephant_col`, `mouse_row`, `mouse_col` and `heap_size`, in that order, followed by the heaps' `key_type`. Layer `i`'s dimensions are the elephant pair while `i < elephant_layers` and the mouse pair after — **derived**, so no per-layer geometry is stored, and a pyramid whose every layer is an elephant falls out of the same rule with no special case. The hash-spec discussion, the absent seed-index key, the `L2HH` no-variant-tag rule and the treatment of `update_mode` / `candidate_complete` / `bucket_size` are all exactly §3.15's.
+
+**Emitted order (cross-language contract).** Identical to §3.15's: layers ascend in every array, and within a layer heap entries are descending `count` with ties broken by the total order over the key. A decoded pyramid re-serializes byte-identically.
+
+**Decode rules.** §3.15's rules, with the two-tier layout in place of the single geometry:
+
+1. `kind_id` is `0x11 0x00`; any other id is rejected.
+2. The hash-spec group matches `DefaultXxHasher`'s `HashProfile`; the seven layout fields and `key_type` are echoed back rather than pinned.
+3. `layer_size >= 1` and `heap_size >= 1`.
+4. The declared layout's accumulator count — `min(elephant_layers, layer_size) * elephant_row + max(0, layer_size - elephant_layers) * mouse_row` — equals `len(l2)` exactly, computed with checked arithmetic and checked **before** the geometry is built, so a crafted `layer_size` or tier width never reserves anything.
+5. §3.15's rules 4, 6, 7, 8 and 9 apply verbatim over the derived per-layer geometry.
+
+**`UnivSketchPool` is not a wire kind.** It is a free list of pre-allocated scratch `UnivMon`s with a `total_allocated` counter — an allocator, not a sketch, with nothing an observer could query. `0x11 0x00` is `UnivMonPyramid`'s alone.
+
+### 3.17: ExponentialHistogram payload (`0x13 0x00`)
+
+`ExponentialHistogram` is a sliding window over sketch-bearing buckets. `window` and `k` are chosen at construction, so per the config-to-metadata rule they live in the metadata, whose keys are `metadata_version`, `window`, `k`. The payload is the buckets and what the buckets themselves record:
+
+| Pos | Field | Type | Notes |
+| --- | ----- | ---- | ----- |
+| 0 | `buckets` | array | one inlined EHSketchList triple per bucket (§3.18), **oldest to newest** |
+| 1 | `sizes` | array | u64 aggregate size, parallel to `buckets`; each `>= 1` |
+| 2 | `min_times` | array | u64 earliest timestamp, parallel to `buckets` |
+| 3 | `max_times` | array | u64 latest timestamp, parallel to `buckets`; `min_times[i] <= max_times[i]` |
+| 4 | `prototype` | array | the EHSketchList triple new buckets are cloned from |
+
+The four bucket arrays are parallel and equal-length. **The bucket count is not carried**: it is `len(buckets)`, derived, so no declared count exists for a crafted payload to inflate.
+
+**Metadata vs payload.** `window` and `k` are the histogram's two construction parameters — they shape the merge policy the way Count-Min's `rows` / `cols` shape its matrix — so they are the descriptor, in the order `metadata_version`, `window`, `k`. Both are properties of the *stored* histogram rather than of the target, so decode echoes them back rather than pinning them, and `k >= 1` is enforced by range on both sides.
+
+**No hash-spec group.** The histogram itself never hashes. Its buckets' sketches do, differently per variant, and three variants do not hash at all — so no single hash spec on `0x13 0x00` could be truthful, and per Q-KLL a field with no truthful value must not exist. The hash spec that matters is the one inside each bucket's own `descriptor`, written by the sketch that owns it and validated by that sketch's decoder.
+
+**`size` is genuine state.** It counts the updates folded into a bucket — 1 on creation, summed on merge — and is not recoverable from the sketch: an HLL bucket that saw the same key five times has `size = 5` and cardinality 1.
+
+**`l2_mass` and `merge_norm` are derived and are not carried.** `compute_l2_mass(s)` is `s.eh_l2_mass().unwrap_or(0.0)`, and `eh_l2_mass` answers `Some` only for the `COUNTL2HH` and `UNIVMON` arms; both are pure functions of the sketch's decoded state, and both call sites that write the field assign exactly `compute_l2_mass(&bucket)`. `infer_merge_norm(&type_to_clone)` reads `supports_norm` and is a pure function of the prototype's variant. So the decoder recomputes both, per the derived-field rule that keeps Count-Min's `l1` / `l2` off the wire, and the encoder rejects a histogram whose cached `l2_mass` disagrees with its sketch or whose `merge_norm` disagrees with its prototype.
+
+**The prototype carries its full state.** Nothing constrains it to be empty: `new(k, window, eh_type)` takes whatever the caller hands it, and `update_with` clones it for every new bucket without ever mutating it. A prototype seeded with data therefore seeds every future bucket, so it is carried as a full EHSketchList triple, the same shape a bucket uses.
+
+**Emitted order (cross-language contract).** Buckets are emitted **oldest to newest**, the order `ExponentialHistogram::payload` maintains and the order the merge rules depend on: `merge_volumes_l1` walks the vector backwards comparing adjacent sizes, and `find_l2_merge_candidate` accumulates the mass of everything newer. Reversing or reordering would change which buckets merge next. `sizes`, `min_times` and `max_times` follow the same index order, and each bucket's triple is emitted at its own index, so a decoded histogram re-serializes byte-identically.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x13 0x00`; any other id is rejected.
+2. The metadata is exactly `{metadata_version, window, k}`; an unknown key or a missing key is rejected. `window` and `k` are properties of the stored histogram rather than of the target, so they are echoed back into the expected block.
+3. `k >= 1`.
+4. `len(sizes) == len(min_times) == len(max_times) == len(buckets)`. Checked before any bucket is rebuilt.
+5. Each `sizes[i] >= 1` — a bucket enters the histogram at size 1 and only grows by merging — each `sizes[i]` fits this target's `usize`, and `min_times[i] <= max_times[i]`.
+6. Each bucket triple and the prototype are decoded by §3.18's rules, so a feature-gated id, an unknown id, a crafted geometry or a foreign hash profile inside any bucket rejects the whole histogram.
+7. Nothing is sized from a declared count. `k` sizes no allocation, and the bucket count is the payload's own array length, so a hostile `k` or a hostile parallel-array length costs nothing.
+8. `l2_mass` and `merge_norm` are recomputed, never read.
+
+Rules 3 and 5 are enforced on the **encode** side too, along with rule 8's two consistency checks, so the format never emits bytes it would refuse to read back. Rule 4 needs no encode-side check: the four arrays are built from one walk of the bucket vector, so they are parallel by construction.
+
+### 3.18: EHSketchList payload (`0x14 0x00`)
+
+`EHSketchList` is a union over ten sketch algorithms. Its encoding is one positional triple, and that triple is the unit that travels wherever an `EHSketchList` appears:
+
+| Pos | Field | Type | Notes |
+| --- | ----- | ---- | ----- |
+| 0 | `kind_id` | bin | the nested variant's own registry `kind_id`, the same bytes the envelope would carry (2 bytes today) |
+| 1 | `descriptor` | bin | that variant's own ASAPv1 metadata block, verbatim |
+| 2 | `state` | bin | that variant's own ASAPv1 payload block, verbatim |
+
+All three are msgpack `bin` (`0xc4` family) — never `str`, never an array of integers. The standalone `0x14 0x00` payload **is** this triple; an `ExponentialHistogram` bucket inlines the same triple as a nested 3-element array. One encoding, two places.
+
+**A nested block is the variant's own envelope with the framing stripped.** `magic`, `version`, `kind_id_len`, `metadata_len` and `payload_len` are dropped, since the enclosing msgpack supplies the lengths; `kind_id`, `metadata` and `payload` survive unchanged. Two consequences a reader must act on:
+
+- The encoding of each variant is, byte for byte, the section that variant already has. There is nothing new to specify per variant.
+- Every geometry check, allocation guard, structural-param cross-check and hash-profile pin the variant already enforces runs on a nested block untouched. Bytes hashed under a different profile do not decode into an `EHSketchList`, exactly as they do not decode into the bare sketch.
+
+The `kind_id` is carried rather than a name, because Section 1's registry is already the single place that maps an algorithm to an id: a parallel name namespace would be a second place to keep in sync. A bucket's `descriptor` repeats that sketch's metadata map, which is not pure redundancy — a bucket's descriptor genuinely varies per bucket, since `UnivMon`'s `key_type` is derived from the keys its heaps hold, so two buckets of the same histogram can legitimately carry different descriptors.
+
+**Metadata vs payload.** The union has no construction configuration of its own: which algorithm it holds, and that algorithm's configuration, both belong to the value being carried rather than to the wrapper. So `0x14 0x00`'s metadata is `metadata_version` alone, and `kind_id` sits at position 0 of the payload — read before `descriptor` and `state`, which is all a positional decoder needs. This is what keeps the encoding identical in both places: an EH bucket has no metadata map of its own to put an id in.
+
+**No hash-spec group.** `EHSketchList` does not hash; the sketch inside it does, each in its own way, and three of the ten — `KLL`, `DDSketch`, `UniformSampling` — do not hash at all. A hash-spec group on the wrapper would have no truthful value, so per Q-KLL it does not exist. Every hash spec on the wire is the one inside a `descriptor`, written by the variant that owns it.
+
+**Nested kind_ids**
+
+| Nested `kind_id` | Registry name | Rust arm | Build |
+| ---------------- | ------------- | -------- | ----- |
+| `0x01 0x02` | HLL Ertl-MLE | `HLL(HyperLogLog<ErtlMLE>)` | always |
+| `0x02 0x00` | Count-Min | `CM(CountMin<Vector2D<i32>, FastPath>)` | always |
+| `0x04 0x00` | Count Sketch | `CS(Count<Vector2D<i32>, FastPath>)` | always |
+| `0x05 0x00` | DDSketch | `DDS(DDSketch)` | always |
+| `0x06 0x00` | KLL compact | `KLL(KLL)` | always |
+| `0x0b 0x00` | Elastic | `ELASTIC(Elastic)` | `experimental` |
+| `0x0c 0x00` | Coco | `COCO(Coco)` | `experimental` |
+| `0x0d 0x00` | UniformSampling | `UNIFORM(UniformSampling)` | `experimental` |
+| `0x10 0x00` | UnivMon | `UNIVMON(UnivMon)` | always |
+| `0x19 0x00` | CountL2HH | `COUNTL2HH(CountL2HH)` | always |
+
+**Each id names one algorithm, and its siblings are not it.** `0x01 0x01`, `0x01 0x03` and `0x06 0x01` are rejected as unknown here: the arms hold `HyperLogLog<ErtlMLE>` and the compact `KLL` and nothing else. `CM` and `CS` both hold `Vector2D<i32>` on the `FastPath`, so their descriptors carry `counter_type = "i32"` and `mode = "fast"`; `i32` is never widened, since a nested sketch must decode back into the arm it was stored as (Q-CS).
+
+**Feature-gating contract (cross-language; Go must honour it).**
+
+1. The nested-id namespace is **fixed and identical in every build**. All ten ids dispatch whether or not the `experimental` feature is on. An id is registry bytes, never an enum ordinal and never a discriminant, so no id's meaning can shift because a variant is compiled out.
+2. A decoder built **without** `experimental` that meets `0x0b 0x00`, `0x0c 0x00` or `0x0d 0x00` **fails closed**, before the blocks are assembled into anything, with an error naming the variant (`Elastic`, `Coco`, `UniformSampling`) **and** the feature. It never misparses, skips, substitutes another variant, or falls through the unknown-id path.
+3. An encoder built **without** `experimental` can never emit those three ids: the enum arms do not exist.
+4. An id outside the ten is rejected as unknown.
+5. The id-to-name lookup exists for **error messages only**. Encoding and decoding both dispatch on the bytes; the name influences neither.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x14 0x00`; any other id is rejected. The metadata is `metadata_version = 1` and nothing else; an unknown key or a missing key is rejected.
+2. The nested `kind_id` is one of the ten; anything else, **including a sibling algorithm's id within the same family**, is rejected as unknown.
+3. A nested id this build does not carry is rejected **before** `descriptor` and `state` are assembled into anything, with an error naming the variant and the feature.
+4. `descriptor` and `state` are handed to that variant's own decoder, wrapped in the variant's own `kind_id`. Every check that decoder makes applies here: geometry bounds, length agreement, allocation guards, and the hash-profile pin.
+5. A `descriptor` / `state` pair that does not belong to the declared id fails inside that variant's decoder; no partial state is produced.
+
+The encode side re-splits the bytes the variant produced and rejects an id that is not the arm's own, so the tag and the blocks can never disagree.
+
+### 3.19: CountL2HH payload (`0x19 0x00`)
+
+`CountL2HH` is a Count Sketch whose rows also carry a running L2 accumulator. Its counters are always `i64` and its column derivation is fixed by the algorithm, so — unlike Count-Min (§3.2) and Count Sketch (§3.6) — its metadata carries neither a `counter_type` nor a `mode`: `kind_id` already determines both. What is left is the geometry and the seed-list index it hashes with:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counts` | array | packed **row-major**, `rows*cols` cells; `i64`, **signed** |
+| 1 | `l2` | array | one `i64` accumulator per row, length `rows`; every entry `>= 0` |
+
+**Metadata vs payload.** `rows`, `cols` and `seed_index` are chosen at construction (`CountL2HH::with_dimensions_and_seed`), so per the config-to-metadata rule they live in the descriptor and the payload omits them. Structural-param order is `seed_index, rows, cols`, mirroring Count-Min's `matrix_seed_index, rows, cols, ...`.
+
+`seed_index` is **not** a profile constant. Count-Min's `matrix_seed_index` is `H::MATRIX_SEED_INDEX`, read off the hasher; a CountL2HH's seed offset is per-instance state a caller chose, and UnivMon gives layer `i` the value `i`. So it is a **structural param echoed back on decode**, not a hash-spec field pinned against the target — the same treatment `rows` / `cols` get.
+
+`l2` is carried rather than recomputed. It is *not* `sum(counts[row]^2)`: `fast_insert_with_count_without_l2_and_hash` moves counters without touching it, and the accumulator clamps to `[0, i64::MAX]` one way, so a decoder that recomputed it would report a different `get_l2` than the sketch it read.
+
+**The shared sub-payload.** Positions 0 and 1 are the CountL2HH sub-payload. When a CountL2HH is a UnivMon layer it is **inlined**, not wrapped: the layer's `counts` and `l2` are appended to the outer sketch's own positional arrays, and its `rows` / `cols` / `seed_index` are derived from the outer metadata plus the layer's position.
+
+**Emitted order (cross-language contract).** `counts` is row-major, row 0 first; `l2` is in row order. There is one encoding per state, so a decoded sketch re-serializes byte-identically, and an empty sketch has exactly one encoding.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x19 0x00`; any other id is rejected.
+2. The hash-spec group matches the **target hasher's** `HashProfile`. `seed_index`, `rows` and `cols` are properties of the *stored* sketch, so they are echoed back into the expected metadata rather than pinned.
+3. `rows` and `cols` are both non-zero. Checked before the matrix is built: the column mask is derived from `cols.ilog2()`, which panics on `cols == 0`.
+4. `len(counts) == rows * cols` exactly, checked **before** the allocation, so crafted dimensions cannot drive a huge reserve.
+5. `len(l2) == rows`.
+6. Every `l2[i] >= 0` — a negative accumulator is not a state a sum of squares reaches.
+
+Rules 3 to 6 are enforced on the **encode** side too — a matrix whose cell count disagrees with its own dimensions fails to serialize, as Count Sketch's does — so the format never emits bytes it would refuse to read back.
+
+### 3.20: UnivMon-Q payload (`0x1a 0x00`)
+
+`UnivMonQ` encodes each numeric value into an order-preserving `u64` key, keeps one `PackedCountSketch` and one bounded candidate table per level, and keeps a coordinated bottom-k sample of stream *occurrences* keyed by `(source_id, local_sequence)`. The whole `UnivMonQConfig` is construction config, so the per-level widths, the hash layout and each level's candidate capacity are all derived and the payload is raw state only:
+
+| Pos | Field | Type | Notes |
+| ----- | ------- | ------ | ------- |
+| 0 | `counters` | array | the levels' Count Sketch rows concatenated in level order, each level row-major over `level_width(i) * depth`; element type = `counter_type` |
+| 1 | `candidate_lens` | array | u32 candidates held at each level, one per level |
+| 2 | `candidate_keys` | array | u64 candidate keys concatenated, cut by `candidate_lens` |
+| 3 | `candidate_scores` | array | u64 recorded score, parallel to `candidate_keys` |
+| 4 | `ever_evicted` | array | one bool per level |
+| 5 | `count` | u64 | observations recorded, duplicates included |
+| 6 | `min` | u64 or nil | order-preserving encoding of the exact minimum; nil when empty |
+| 7 | `max` | u64 or nil | order-preserving encoding of the exact maximum; nil when empty |
+| 8 | `source_id` | u64 | identity the occurrence priorities are drawn from |
+| 9 | `next_sequence` | u64 | next local sequence number |
+| 10 | `occurrence_priority_high` | array | u64 high word of each retained occurrence's 128-bit priority |
+| 11 | `occurrence_priority_low` | array | u64 low word, parallel |
+| 12 | `occurrence_keys` | array | u64 key, parallel |
+
+**Metadata vs payload.** Everything in `UnivMonQConfig` shapes the payload and is chosen at construction, so it all lives in the descriptor, in the order `seed_index`, `levels`, `width`, `width_halving_period`, `depth`, `counter_type`, `candidates`, `ordered_samples`. `level_width(config, i)` and the `HashLayout` follow from those, so no per-level width and no bucket-bit count is stored; `candidate_capacity` is `candidates` on every level, so it is not stored either.
+
+`counter_type` is `"i32"` or `"i64"` and names the element type of `counters`, exactly as Count Sketch's does (§3.6): the counters are signed, so Count-Min's `"f64"` has no counterpart, and `i128` has no msgpack integer form. It stands in for the in-memory `counter_bits` rather than joining it, since carrying both would be one field derivable from the other. Like `seed_index` for CountL2HH (§3.19), the hash seed here is a config value rather than a profile constant, so it is a structural param echoed back on decode.
+
+`min` and `max` are exact stream extrema and are **not** derivable from the sketch, so they are carried; absent is msgpack **nil**, the encoding Coco already uses for a free bucket. They are nil exactly when `count == 0`, and that biconditional is checked on both sides.
+
+`source_id` and `next_sequence` are genuinely-carried sequence state. An occurrence's priority is `hash128(hash_seed ^ domain, (source_id << 64) | sequence)`, so a decoded sketch that restarted its sequence would re-draw identities it had already used and corrupt the coordinated sample the moment it was merged. `ever_evicted` is carried for the same reason `candidate_complete` is on §3.15: a full candidate table does not say whether it ever displaced anything, and guessing "full means evicted" would widen the recovery threshold on a level that never lost a key.
+
+**Emitted order (cross-language contract).** Levels ascend, `0 .. levels`, in every array. Within a level, candidates are written **ascending by key**. Occurrences are written **ascending by `(priority_high, priority_low, key)`**, the record's own total order. Both are required, not cosmetic: the candidate min-heap and the ordered sample are array orders that do not survive a rebuild — the same argument §3.5 makes for Space-Saving's arenas and §3.7 makes for `HHHeap`. Both heaps are rebuilt from the ordered arrays on decode, so no heap index reaches the wire and a decoded sketch re-serializes byte-identically.
+
+**Decode rules.** Fail **closed** on each, with an error and never a panic:
+
+1. `kind_id` is `0x1a 0x00`; any other id is rejected.
+2. `counter_type` is `"i32"` or `"i64"`; anything else is rejected, and `counters` is read **as** that type, so a relabelled payload does not decode.
+3. The hash-spec group matches the target's `HashProfile`; the config is echoed back rather than pinned.
+4. The config is valid on its own terms before anything is sized from it: `2 <= levels <= 63`, `width >= 1`, `depth` odd and non-zero, `candidates >= 1`, and the hash layout fits in 128 bits. Checked **before** `HashLayout::new`, whose `width - 1` underflows on `width == 0`.
+5. `len(counters)` equals the sum over levels of `level_width(i) * depth`, computed with checked arithmetic, **before** any level is built.
+6. `len(candidate_lens) == len(ever_evicted) == levels`, every `candidate_lens[i] <= candidates`, and `len(candidate_keys) == len(candidate_scores) == sum(candidate_lens)`.
+7. The three occurrence arrays are parallel and equal-length, `len <= ordered_samples`, no occurrence repeats, and an `ordered_samples == 0` config carries none.
+8. `count == 0` if and only if `min` and `max` are both nil, and `min <= max` when both are present.
+9. `candidates` and `ordered_samples` **never size an allocation.** Each level's candidate map and heap are sized from the run the payload carries, and the ordered heap is built from the occurrences it carries, so a payload declaring `candidates = 2^32 - 1` with two candidates costs two candidates. The sketch is built field by field rather than through `with_hasher_and_source_id`, which reserves from the declared capacities.
+10. No candidate key repeats within a level, and each candidate's key hashes into the level it is stored at.
+
+The encode side refuses the same states: a level count that disagrees with the config, a level whose Count Sketch layout is not the declared one, levels mixing counter widths, an over-capacity candidate table, a candidate at the wrong terminal level, a duplicate or over-capacity occurrence, and an inconsistent `count` / `min` / `max` triple. So the format never emits bytes it would refuse to read back.
+
+### 3.21: payloads not yet designed
+
+The remaining `kind_id`s reserve a family byte with payload TBD (the Section 1 registry carries their status). Likely shape when designed:
 
 | kind_id | Sketch | Likely payload |
 | --------- | -------- | --------- |
-| `0x03 0x00` | Count-Min-with-heap (CMSHeap) | similar to current CMS |
-| `0x05 0x00` | DDSketch | straightforward bucket |
-| `0x07 0x00` | Hydra-KLL | wraps KLL payloads (§3.3); nest one per counter |
 | `0x08 0x00` | SetAggregator | aggregation envelope, distinct from a stand-alone sketch (Section 1 mapping notes) |
 | `0x09 0x00` | DeltaResult | delta-result envelope, distinct from a stand-alone sketch (Section 1 mapping notes) |
-| `0x0a 0x00` | Count-Sketch-with-heap (CSHeap) | similar to current CMS |
-| `0x0b 0x00` | Elastic (`Unstable`) | "key" needs thought, else similar to CMS; sketch needs optimization first, worth one combined PR |
-| `0x0c 0x00` | Coco (`Unstable`) | "key" needs thought, else similar to CMS |
-| `0x0d 0x00` | UniformSampling (`Unstable`) | straightforward |
-| `0x0e 0x00` | KMV (`Unstable`) | straightforward |
 | `0x0f 0x00` | HashSketchEnsemble | may not need serialization |
-| `0x10 0x00` | UnivMon | more complex but doable |
-| `0x11 0x00` | UnivMon Optimized | TBD |
 | `0x12 0x00` | NitroBatch | may want another serialization abstraction in Storage |
-| `0x13 0x00` | ExponentialHistogram | needs to re-use other sketches' serialization |
-| `0x14 0x00` | EHSketchList | TBD |
 | `0x15 0x00` | EHUnivOptimized (`Unstable`) | TBD |
 | `0x16 0x00` | OctoSketch | TBD |
+| `0x1b 0x00` | FoldCMS | TBD |
+| `0x1c 0x00` | FoldCS | TBD |
 
 ---
 
@@ -566,7 +1135,11 @@ Golden byte-vectors lock it.
 
 - A msgpack **array**, elements in the Section 3 position order.
 - `registers`: msgpack `bin` (one byte per register; matches Go's `[]byte`).
-- `counts`: msgpack array; each element is an integer (per the family/width rule) when `counter_type == "i64"`, a **float64** when `"f64"`.
+- `counts`: msgpack array; each element is an integer (per the family/width rule) when `counter_type` is `"i32"` or `"i64"`, a **float64** when `"f64"`.
+- `keys` / `items` / `values`: msgpack array; the element type is the one the metadata's `key_type` / `item_type` names, per the table in §3.5.
+- A nullable slot (an unoccupied Coco bucket, a free Elastic heavy bucket, an absent UnivMon-Q extremum) is msgpack **nil** (`0xc0`), never an empty string and never a zero.
+- Booleans are msgpack `true` / `false` (`0xc3` / `0xc2`).
+- A nested sketch's `kind_id`, `descriptor` and `state` blocks (§3.18) are msgpack **bin** (`0xc4` family), never `str` and never an array of integers.
 - HLL HIP `hip_*`: **float64**.
 
 (Count-Min `rows` / `cols` are carried as metadata integers per the family/width rule; see Section 2.)
@@ -582,11 +1155,13 @@ Guidance for future development; this is outside the byte contract. It covers ho
 Fail **closed** on any mismatch:
 
 1. `kind_id` is in the registry.
-2. Every hash-spec field matches the **target hasher's** `HashProfile`: decode compares the read metadata against `hll_metadata::<H>` / `cms_metadata::<H>` for the exact type being decoded into, so it does not merely accept the standard profile. Bytes carrying a different profile are rejected.
-3. Structural params are consistent with `kind_id` and the payload:
+2. Every hash-spec field matches the **target hasher's** `HashProfile`: decode compares the read metadata against the block that type's own metadata builder produces (`hll_metadata::<H>`, `cms_metadata::<H>`, and one per kind) for the exact type being decoded into, so it does not merely accept the standard profile. Bytes carrying a different profile are rejected. A sketch with no hasher type parameter compares against `DefaultXxHasher`'s profile, read live.
+3. Structural params are consistent with `kind_id` and the payload. Each kind's full list is in its Section 3 subsection; the recurring shapes are:
    - HLL: `registers.len() == 2^precision ==` the target storage's register count.
    - Count-Min: `counts` element type matches `counter_type` (`"i32"`/`"i64"`/`"f64"`, never widened); `counts.len() == rows*cols`.
    - Count Sketch: `counts` element type matches `counter_type` (`"i32"`/`"i64"`, never widened); `counts.len() == rows*cols`.
+   - Every declared dimension is checked for zero and for overflow **before** it sizes anything, and every parallel array is measured against the declared geometry **before** an allocation. A declared capacity never sizes an allocation.
+4. A nested sketch's blocks are validated by that sketch's own decoder, so every rule above applies inside a Hydra cell (§3.9), a UnivMon layer (§3.15) and an EHSketchList triple (§3.18) exactly as it does at the top level.
 
 ### Converting an exotic in-memory sketch to a wire form
 
@@ -617,6 +1192,8 @@ Good direction (more compact, higher fidelity, less Rust-internal duplication), 
 2. **Golden byte-vector fixtures** checked into both repos; both languages decode and re-encode them byte-identically. These replace the `portable`-as-oracle round-trip test that guards drift today.
 3. **This registry**, mirrored, never independently allocated.
 
+Fixtures exist for six `kind_id`s — HLL's three estimators, Count-Min, Count Sketch and compact KLL — and `sketchlib-go` mirrors those. Every other kind this spec fixes has a payload here and **no fixture and no Go mirror**, so this document is the only contract for it; `asapv1_golden/README.md` lists the gap.
+
 **Hash profile on the Go side.**
 Rust derives the hash spec from a generic `HashProfile` bound on the hasher type; Go has no generic hasher type, so there is nothing to derive from.
 On the Go side the profile is simply **written into** the metadata on encode and **read from** it on decode.
@@ -639,4 +1216,17 @@ Keep it through the transition, retire `portable` once goldens are in place.
 - **Q-CS**: Count Sketch is one `kind_id` (`0x04 0x00`) and mirrors Count-Min's metadata and `[counts]` payload, including `counter_type`. Its type domain differs: `"i32"` and `"i64"`, with no `"f64"` (counters must be signed and negatable) and no `i128` (no msgpack integer form). Structural-param order matches Q-CMS: `... matrix_seed_index, rows, cols, counter_type, mode`. **`i32` is not widened to `i64`** — unlike Count-Min, whose counters are plain numbers, a Count Sketch appears *nested* inside `HydraCounter` and `EHSketchList` as `Vector2D<i32>` and must decode back into that variant, so the width is identity and is recorded exactly. Cells are signed, so a decoder must not assume monotonicity.
 - **Q-CMS-DIMS**: Count-Min `rows`/`cols` are **metadata** and the payload omits them. They are configuration that shapes the payload (like HLL's `precision`), so per the config-to-metadata rule they belong in the descriptor. The payload is then just `[counts]`. Canonical structural-param order: `... matrix_seed_index, rows, cols, counter_type, mode`.
 - **Q-VER**: no payload version field. A new incompatible encoding gets a **new `kind_id`**; retired ids are reserved forever and never recycled.
+- **Q-NEST**: a nested sketch's state is **inlined**, never wrapped in an envelope of its own. By the time a decoder reaches the payload it has read `kind_id` and the metadata, and together those fix the shape completely, so a nested envelope would repeat a magic sentinel, a version, an id, two length prefixes and a metadata map the outer one already carries — and would create a second place for the same fact to live, which a decoder would then have to cross-check. This governs CMSHeap's and CSHeap's base matrix (§3.7, §3.10), Elastic's light Count-Min (§3.11), Hydra's counter cells (§3.9) and UnivMon's `CountL2HH` layers (§3.15).
+- **Q-NEST-HET**: a **heterogeneous** nested sketch — one whose algorithm is data rather than a type — carries the variant's own registry `kind_id` plus its metadata and payload blocks with the framing stripped (§3.18). No name string, no second identity namespace beside the Section 1 registry, and no per-variant encoding to specify: the blocks are byte for byte what that variant's own section fixes, and the variant's own decoder runs on them unchanged, so its geometry checks, allocation guards and hash-profile pin all apply inside the wrapper. `EHSketchList` (`0x14 0x00`) is the triple, and `ExponentialHistogram` (`0x13 0x00`) inlines one per bucket.
+- **Q-NEST-GATE**: the nested-id namespace is **fixed and identical in every build**. An id is registry bytes, never an enum ordinal, so no id's meaning shifts because a variant is compiled out. A decoder that meets an id its build does not carry fails **closed**, before the blocks are assembled, with an error naming the variant and the feature; it never misparses, skips, substitutes, or falls through the unknown-id path.
+- **Q-HYDRA-IDS**: Hydra allocates **one `kind_id` per counter base sketch** (`0x07 0x00` KLL, `0x07 0x01` Count-Min, `0x07 0x02` Count Sketch, `0x07 0x03` HyperLogLog, `0x07 0x04` UnivMon), so the payload carries no variant tag and a grid mixing counter variants has no encoding. `0x07 0x05`-`0x07 0xff` stay reserved for Hydra over further base sketches. The five ids use four metadata schemas; Count-Min and Count Sketch share one, as the two KLL ids share one.
+- **Q-NOHASH**: a sketch that never hashes its inputs omits the **hash-spec group entirely** — the group answers "how were keys hashed", and there is no truthful answer. This is Q-KLL generalized: KLL (§3.3), DDSketch (§3.8) and UniformSampling (§3.13) never hash, and `ExponentialHistogram` (§3.17) and `EHSketchList` (§3.18) do not hash either, since the sketch inside them does. Their metadata is structural-only and is not `HashProfile`-derived. A sketch that *does* hash carries the group, derived live from the hasher's profile, even when its counters do not hash (Hydra's KLL and UnivMon variants, §3.9).
+- **Q-SEEDIDX**: a **seed-index key is carried only for a hash whose index the sketch reads off the profile.** `HashProfile` declares two such constants, `CANONICAL_SEED_INDEX` and `MATRIX_SEED_INDEX`, and the metadata carries `canonical_seed_index` or `matrix_seed_index` accordingly. An index the algorithm fixes gets no key: Space-Saving's `0` (§3.5), Coco's per-array `i` (§3.12), Elastic's heavy table (§3.11), Hydra's subkey fan-out at `HYDRA_SEED` (§3.9) and the UnivMon family's `BOTTOM_LAYER_FINDER` (§3.15). A per-instance seed a caller chose is a **structural param**, not a hash-spec field: `seed_index` on CountL2HH (§3.19) and UnivMon-Q (§3.20) is echoed back on decode rather than pinned against the target.
+- **Q-ORDER**: a payload whose in-memory container order does not survive a rebuild **pins an emitted order**, as a cross-language contract. Heaps, arenas and hash maps all have this property, so the rule reaches Space-Saving's triples (§3.5), the top-k heap entries (§3.7), KMV's digests (§3.14), UniformSampling's entries (§3.13), UnivMon-Q's candidates and occurrences (§3.20), and every layer- and bucket-indexed array. Two sketches holding the same state then emit the same bytes whatever order they were built in, and a decoded sketch re-serializes byte-identically. The heap key comparator is the same everywhere: descending count, ties by variant tag then value.
+- **Q-CAP**: **a declared capacity never sizes an allocation.** Every structure is built from the run the payload actually carries, and the declared bound is checked against that run first; a payload naming a capacity of `2^32 - 1` with two entries costs two entries. This holds for Space-Saving's `capacity`, the top-k heaps' `k`, KMV's `k`, UniformSampling's `total_seen`, UnivMon's `heap_size`, UnivMon-Q's `candidates` and `ordered_samples`, and Hydra's grid and counter dimensions.
+- **Q-KEYTYPE**: `key_type` names the **exact `HeapItem` variant** and is never widened, wherever heap keys reach the wire — Space-Saving (§3.5), CMSHeap and CSHeap (§3.7, §3.10), the UnivMon family (§3.15, §3.16) and Hydra's UnivMon counter (§3.9). A container whose keys mix variants has no single name and **fails to serialize**; `HeapItem::I128` / `U128` have no msgpack integer form and are not wire types. An empty container emits `"u64"`, so it has exactly one encoding.
+- **Q-DERIVED**: state a decoder can recompute exactly is **not carried**, and state it cannot is. Recomputed: DDSketch's `count` from its buckets (§3.8), `ExponentialHistogram`'s `l2_mass` and `merge_norm` (§3.17), Elastic's `bktlen` from the declared bucket count (§3.11), every heap's digest index and array order, and every summary a sketch answers from its own state. Carried: DDSketch's `sum` / `min` / `max`, Elastic's `stale_copies`, UnivMon's `update_mode`, `candidate_complete` and `bucket_size`, UnivMon-Q's `ever_evicted`, `source_id` and `next_sequence`, UniformSampling's `priorities`, `total_seen` and `rng_state`, and CountL2HH's `l2`. Where a cached derived field exists in memory, the encoder rejects a value that disagrees with what the decoder would recompute.
+- **Q-NIL**: an absent slot is msgpack **nil** (`0xc0`), never a sentinel value. An empty string is a reachable key in Coco (§3.12) and a reachable flow id in Elastic (§3.11), so `""` cannot double as "free"; UnivMon-Q's absent extrema are nil for the same reason (§3.20). Go must model these as nullable, never as a zero value standing in for absent.
+- **Q-RNG**: RNG state is carried **resumable** when the generator is cheap to reproduce in another language, and opaque otherwise. UniformSampling's `rng_state` is one SplitMix64 word with published constants, so a decoded sampler continues the same draw sequence (§3.13); KLL's `coin` carries the compaction RNG's position and its `seed` is opaque state Go preserves without interpreting (Q-KLL-SEED).
+- **Q-UNIVMON-SCOPE**: `L2HH` carries no variant tag — it is a single-variant enum and `kind_id` fixes the payload's structure — so `0x10 0x00` and `0x11 0x00` are defined as all-`COUNT`, and a second variant needs a new structural param or a new id. `UnivSketchPool` is a free list of scratch pyramids with nothing an observer could query, so it is not a wire kind and holds no id.
 - **Encoding**: metadata + payload are both msgpack; payload is a positional array. Byte-level rules in Section 4.

--- a/docs/features.md
+++ b/docs/features.md
@@ -107,7 +107,7 @@ Insertion throughput measured on 10,000,000 Zipf-distributed `int64` values (s=1
 
 ### Serialization
 
-MessagePack (`rmp-serde`) support. **serde support** means the type derives `Serialize`/`Deserialize` and can be used with any serde-compatible serializer. **Built-in helpers** (`serialize_to_bytes` / `deserialize_from_bytes`) provide one-call round-tripping without requiring users to depend on `rmp-serde` directly. For HyperLogLog, Count-Min, Count Sketch, KLL, Bloom and Space-Saving these helpers emit the self-describing **ASAPv1** wire envelope (see the [ASAPv1 wire format spec](./asapv1_wire_format.md)); other sketches are not yet converted.
+MessagePack (`rmp-serde`) support. **serde support** means the type derives `Serialize`/`Deserialize` and can be used with any serde-compatible serializer. **Built-in helpers** (`serialize_to_bytes` / `deserialize_from_bytes`) provide one-call round-tripping without requiring users to depend on `rmp-serde` directly. These helpers emit the self-describing **ASAPv1** wire envelope (see the [ASAPv1 wire format spec](./asapv1_wire_format.md)) for every sketch the spec's `kind_id` registry marks *implemented*; NitroBatch, FoldCMS, FoldCS, HashSketchEnsemble, EHUnivOptimized and OctoSketch are not converted.
 
 | Component | serde support | Built-in helpers |
 | --- | --- | --- |
@@ -117,18 +117,19 @@ MessagePack (`rmp-serde`) support. **serde support** means the type derives `Ser
 | DDSketch | Yes | Yes |
 | KLL / KLLDynamic | Yes | Yes |
 | KMV | Yes | Yes |
-| Elastic | Yes | In Progress |
-| Coco | Yes | In Progress |
-| UniformSampling | Yes | In Progress |
+| Elastic | Yes | Yes |
+| Coco | Yes | Yes |
+| UniformSampling | Yes | Yes |
 | FoldCMS / FoldCS | Yes | In Progress |
-| CMSHeap / CSHeap | In Progress | In Progress |
+| CMSHeap / CSHeap | In Progress | Yes |
 | SpaceSaving | Yes | Yes |
 | Bloom | Yes | Yes |
 | Hydra | Yes | Yes |
-| UnivMon | Yes | Yes |
-| UnivMonQ (experimental) | Internal wire DTO | Yes (native MessagePack) |
+| UnivMon / UnivMon Optimized | Yes | Yes |
+| UnivMonQ (experimental) | Internal wire DTO | Yes |
 | NitroBatch | Yes | In Progress |
-| EHSketchList | Yes | In Progress |
+| EHSketchList | Yes | Yes |
+| ExponentialHistogram | Yes | Yes |
 
 Protobuf (prost): `.proto` definitions exist for CountMin, Count, HLL, DDSketch, KLL, Elastic, Coco, Hydra, and UnivMon. Rust conversion code is in progress.
 

--- a/docs/library_map.md
+++ b/docs/library_map.md
@@ -12,15 +12,20 @@
 - **`src/sketches/`** - Sketch implementations (status source: [apis.md](./apis.md))
   - `Ready` in API index: `countminsketch.rs`, `countsketch.rs`, `hll.rs`, `kll.rs`, `ddsketch.rs`, `countminsketch_topk.rs`, `countsketch_topk.rs`, `space_saving.rs`, `bloom.rs`
   - `Unstable` in API index: `coco.rs`, `elastic.rs`, `uniform.rs`, `kmv.rs`
-  - Sketches converted to the ASAPv1 wire format use a `<sketch>.rs` (algorithm) + `<sketch>/wire.rs` (serialization) split: `hll.rs`, `countminsketch.rs`, `countsketch.rs`, `kll.rs`, `kll_dynamic.rs`, `bloom.rs` and `space_saving.rs` today (see [asapv1_wire_format.md](./asapv1_wire_format.md))
+  - Not in the API index: `fold_cms.rs`, `fold_cs.rs`, `octo_delta.rs`, `mode.rs`
+  - A sketch on the ASAPv1 wire format uses a `<sketch>.rs` (algorithm) + `<sketch>/wire.rs` (serialization) split: `hll.rs`, `countminsketch.rs`, `countminsketch_topk.rs`, `countsketch.rs`, `countsketch_topk.rs`, `kll.rs`, `kll_dynamic.rs`, `ddsketch.rs`, `elastic.rs`, `coco.rs`, `uniform.rs`, `kmv.rs`, `bloom.rs` and `space_saving.rs` (see [asapv1_wire_format.md](./asapv1_wire_format.md))
+  - Two of those directories carry a second, shared wire module: `countminsketch_topk/heap_wire.rs` holds the top-k heap encoding CMSHeap and CSHeap share, and `countsketch_topk/l2hh_wire.rs` holds CountL2HH's own encoding plus the layer sub-payload the UnivMon family inlines
 
 - **`src/sketch_framework/`** - Orchestration and serving layers (status source: [apis.md](./apis.md))
   - `Ready` in API index: `hydra.rs`, `hashlayer.rs`, `univmon.rs`, `univmon_optimized.rs`, `nitro.rs`, `eh.rs`, `eh_sketch_list.rs`
+  - `Experimental` in API index: `univmon_q.rs`
   - `Unstable` in API index: `eh_univ_optimized.rs`
-  - Infrastructure module: `orchestrator/` (node-level manager used by framework APIs)
+  - Not in the API index: `octo.rs`, `tumbling.rs`, `sketch_catalog.rs`
+  - The same `<framework>.rs` + `<framework>/wire.rs` split carries the ASAPv1 wire format for `hydra.rs`, `univmon.rs`, `univmon_optimized.rs`, `univmon_q.rs`, `eh.rs` and `eh_sketch_list.rs`
 
 - **`src/message_pack_format/`** - Serialization plumbing ([message_pack_format.md](./message_pack_format.md)). The current format is **ASAPv1**, specified in [asapv1_wire_format.md](./asapv1_wire_format.md)
-  - `envelope.rs` — the shared, sketch-agnostic ASAPv1 framing (magic/version/`kind_id` + length prefixes, `encode`/`split`); every per-sketch `wire.rs` calls into it
+  - `envelope.rs` — the shared, sketch-agnostic ASAPv1 framing (magic/version/`kind_id` + length prefixes, `encode`/`split`); every `wire.rs` under `src/sketches/` and `src/sketch_framework/` calls into it
+  - `codec.rs` — the `MessagePackCodec` trait; `error.rs` — the unified `Error`
   - `portable/` — **deprecated**, being retired. The older per-sketch wire types (`CountMinSketch`, `HllSketch`, …); ASAPv1 (per-sketch `wire.rs`) is now what `sketchlib-go` mirrors, not these
   - `native/` — **deprecated**, being retired. Older `MessagePackCodec` shims over `src/sketches/` byte serialization
 
@@ -33,8 +38,8 @@
 
 ## Utilities
 
-- The large precomputed hash/sample tables are no longer checked-in arrays;
-  they are built lazily at runtime via `std::sync::LazyLock` in
+- The large precomputed hash/sample tables are built lazily at runtime via
+  `std::sync::LazyLock` in
   `src/common/precompute_hash.rs`, `src/common/precompute_sample.rs`, and
   `src/common/precompute_sample2.rs`.
 

--- a/docs/message_pack_format.md
+++ b/docs/message_pack_format.md
@@ -26,10 +26,20 @@ Every serialized sketch is one self-delimiting envelope:
   the bytes truthfully describe how the sketch was hashed and custom hash
   profiles serialize self-describingly. Each sketch has its own fixed metadata
   schema with `#[serde(deny_unknown_fields)]` (fail-closed on unknown/missing
-  keys).
+  keys). A sketch that never hashes its inputs omits the hash-spec group
+  entirely and carries structural params alone — KLL, DDSketch and
+  UniformSampling, plus the two wrappers `ExponentialHistogram` and
+  `EHSketchList`, whose hash specs live inside the sketch each one carries.
 - **Payload** — a positional msgpack **array** of the raw sketch state only
   (registers, counter matrix). No field names, and nothing the `kind_id` or
   metadata already determines.
+- **A nested sketch is inlined, not wrapped in an envelope of its own.** A
+  CMSHeap's base matrix, an Elastic's light Count-Min, a Hydra cell and a
+  UnivMon layer all write their raw state straight into the enclosing positional
+  array. Where the nested algorithm is data rather than a type, the nested block
+  is that variant's own envelope with the framing stripped: the
+  `[kind_id, descriptor, state]` triple `EHSketchList` carries and
+  `ExponentialHistogram` inlines per bucket.
 
 `kind_id` + metadata together fix the payload structure completely. See
 [`asapv1_wire_format.md`](./asapv1_wire_format.md) for the `kind_id` registry,
@@ -46,20 +56,30 @@ and framing — it does **not** know the `kind_id` registry or any sketch. Rule
 "which `kind_id` do I own?" and all metadata validation happen in each sketch's
 decoder.
 
-### Per-sketch serialization — `src/sketches/<sketch>/wire.rs`
+### Per-sketch serialization — `<sketch>/wire.rs`
 
-Serialization now lives **with each sketch**, split from the algorithm:
+Serialization lives **with each sketch**, split from the algorithm, under
+`src/sketches/` and `src/sketch_framework/` alike:
 
-- `src/sketches/<sketch>.rs` — the **algorithm** (struct, marker types, aliases,
+- `<sketch>.rs` — the **algorithm** (struct, marker types, aliases,
   insert/estimate/merge). It declares `mod wire;`.
-- `src/sketches/<sketch>/wire.rs` — the **serialization** (metadata/payload DTOs,
+- `<sketch>/wire.rs` — the **serialization** (metadata/payload DTOs,
   `kind_id` consts, wire-variant/counter/mode marker traits, and the
   `serialize_to_bytes` / `deserialize_from_bytes` impls). Because `wire` is a
   child submodule of the sketch, it reads the struct's **private** fields
   (`self.registers`, `self.counts`) directly — no field is widened for
   serialization.
 
-Converted today:
+Two encodings are shared by more than one sketch and live in a second module
+beside `wire.rs`, declared `pub(crate)` so the other user can import it by path:
+
+- `src/sketches/countminsketch_topk/heap_wire.rs` — the top-k heap metadata
+  schema, payload, `key_type` mapping, emitted order and heap rebuild that
+  CMSHeap (`0x03 0x00`) and CSHeap (`0x0a 0x00`) share.
+- `src/sketches/countsketch_topk/l2hh_wire.rs` — CountL2HH (`0x19 0x00`), plus
+  the `[counts, l2]` layer sub-payload the whole UnivMon family inlines.
+
+Converted:
 
 - **HLL** (`src/sketches/hll/wire.rs`) — all variants (Classic → `0x01 0x01`,
   Ertl-MLE → `0x01 0x02`, HIP → `0x01 0x03`) × precisions (P12/P14/P16) ×
@@ -68,9 +88,10 @@ Converted today:
   profile only.)
 - **Count-Min** (`src/sketches/countminsketch/wire.rs`, kind `0x02 0x00`) —
   restricted to wire-eligible configs:
-  `CountMin<Vector2D<T>, Mode, H>` where `T` is `i64` or `f64` (`CmsWireCounter`),
-  `Mode` is `FastPath` or `RegularPath` (`CmsWireMode`), and `H: HashProfile`.
-  The default `Vector2D<i32>` CMS is **not** wire-eligible; convert first. `rows`
+  `CountMin<Vector2D<T>, Mode, H>` where `T` is `i32`, `i64` or `f64`
+  (`CmsWireCounter`), `Mode` is `FastPath` or `RegularPath` (`CmsWireMode`), and
+  `H: HashProfile`. `i32` is carried at its own width rather than widened.
+  `i128` and non-`Vector2D` storage must be converted first. `rows`
   and `cols` live in the metadata; the payload is just `[counts]`.
 - **Count Sketch** (`src/sketches/countsketch/wire.rs`, kind `0x04 0x00`) — the
   same shape as Count-Min: `Count<Vector2D<T>, Mode, H>` where `T` is `i32` or
@@ -91,8 +112,35 @@ Converted today:
 - **Space-Saving** (`src/sketches/space_saving/wire.rs`, kind `0x18 0x00`) — the
   payload is the `(key, count, error)` triples plus `total` and `floor`; the
   Stream-Summary's links and arenas are rebuilt on decode.
+- **CMSHeap** (`src/sketches/countminsketch_topk/wire.rs`, `0x03 0x00`) and
+  **CSHeap** (`src/sketches/countsketch_topk/wire.rs`, `0x0a 0x00`) — a base
+  matrix inlined ahead of the shared top-k heap entries.
+- **DDSketch** (`src/sketches/ddsketch/wire.rs`, `0x05 0x00`) — the bucket store
+  verbatim plus `offset`, `sum`, `min` and `max`; no hash-spec group.
+- **Elastic** (`src/sketches/elastic/wire.rs`, `0x0b 0x00`) — the heavy table's
+  four parallel arrays, the `stale_copies` flag, and the inlined light Count-Min.
+- **Coco** (`src/sketches/coco/wire.rs`, `0x0c 0x00`) — the dense bucket table as
+  parallel nullable-key and mass arrays.
+- **UniformSampling** (`src/sketches/uniform/wire.rs`, `0x0d 0x00`) — the
+  priority-ordered sample pairs plus `total_seen` and the SplitMix64 state; no
+  hash-spec group.
+- **KMV** (`src/sketches/kmv/wire.rs`, `0x0e 0x00`) — the retained digests,
+  strictly ascending.
+- **CountL2HH** (`src/sketches/countsketch_topk/l2hh_wire.rs`, `0x19 0x00`) —
+  `[counts, l2]`.
+- **Hydra** (`src/sketch_framework/hydra/wire.rs`, `0x07 0x00`-`0x07 0x04`) — one
+  `kind_id` per counter variant; the cells' state tiles or nests one array.
+- **UnivMon** (`src/sketch_framework/univmon/wire.rs`, `0x10 0x00`) and
+  **UnivMon Optimized** (`src/sketch_framework/univmon_optimized/wire.rs`,
+  `0x11 0x00`) — one payload shape, two metadata schemas.
+- **UnivMon-Q** (`src/sketch_framework/univmon_q/wire.rs`, `0x1a 0x00`) — the
+  levels' counters, candidates, extrema and coordinated occurrence sample.
+- **ExponentialHistogram** (`src/sketch_framework/eh/wire.rs`, `0x13 0x00`) and
+  **EHSketchList** (`src/sketch_framework/eh_sketch_list/wire.rs`, `0x14 0x00`) —
+  one `[kind_id, descriptor, state]` triple, standalone and per bucket.
 
-Other sketches are **not yet converted** to `wire.rs`.
+NitroBatch, FoldCMS, FoldCS, HashSketchEnsemble, EHUnivOptimized and OctoSketch
+have **no `wire.rs`**; their `kind_id`s are reserved with payload TBD.
 
 ## `portable/` and `native/` are being retired
 
@@ -101,13 +149,13 @@ unified `Error` at the module root) are the **older** serialization path and are
 being **phased out** in favor of the per-sketch `wire.rs` + the shared
 `envelope.rs`.
 
-- `portable/` was previously described as "the cross-language wire format shared
-  with Go." That is no longer the direction: **ASAPv1 (per-sketch `wire.rs`) is
-  what `sketchlib-go` mirrors.** The custom per-sketch payload replaces the
-  `portable` types.
-- `native/` was a set of thin `MessagePackCodec` shims over the sketches'
-  `serialize_to_bytes` / `deserialize_from_bytes`. Those methods now emit the
-  ASAPv1 envelope directly.
+- `portable/` holds a set of per-sketch wire types that predate the envelope.
+  **`sketchlib-go` mirrors ASAPv1, not these**: the per-sketch payload under
+  `wire.rs` is the cross-language format, and the `portable` types are internal
+  to Rust.
+- `native/` is a set of thin `MessagePackCodec` shims over the sketches'
+  `serialize_to_bytes` / `deserialize_from_bytes`. Every type it wraps emits the
+  ASAPv1 envelope, so each shim is a pass-through.
 
 Sequencing note (from the spec): `portable` is not deleted until the golden
 byte-vector fixtures are the drift guard on both sides.
@@ -119,7 +167,14 @@ Cross-language parity with `sketchlib-go` is proven by **golden byte-vectors** i
 [`tests/asapv1_golden.rs`](../tests/asapv1_golden.rs)): both languages must
 decode → re-encode them byte-identically. The `kind_id` registry is mirrored
 verbatim with Go's `wire/asapmsgpack/magic_ids.go`, never independently
-allocated. These goldens replace the old `portable`-as-oracle round-trip test.
+allocated.
+
+That proof covers the six `kind_id`s a fixture exists for — HLL's three
+estimators, Count-Min, Count Sketch and compact KLL. Every other implemented
+kind has **no golden and therefore no cross-language drift guard**;
+[`asapv1_golden/README.md`](../asapv1_golden/README.md) lists what is covered.
+`portable` is not deleted until the goldens are the drift guard on both sides,
+so it stays until that gap closes.
 
 ## Cross-Reference
 
@@ -127,5 +182,3 @@ allocated. These goldens replace the old `portable`-as-oracle round-trip test.
   byte-level spec (envelope, metadata schema, per-sketch payloads, encoding
   rules, wire coverage).
 - Generated rustdoc: `cargo doc --no-deps --all-features --open`.
-</content>
-</invoke>

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -14,6 +14,8 @@ cargo test
 
 Test file: [`src/sketches/countminsketch.rs`](../src/sketches/countminsketch.rs)
 
+Wire tests: [`src/sketches/countminsketch/wire.rs`](../src/sketches/countminsketch/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `dimension_test` | Default/custom dimensions initialize zeroed counters. | Verifies default dimensions (`rows=3`, `cols=4096`), custom dimensions (`3x17`), and zero-initialized counters after construction. |
@@ -23,9 +25,13 @@ Test file: [`src/sketches/countminsketch.rs`](../src/sketches/countminsketch.rs)
 | `countmin_apply_delta_increments_parent_counter` | Apply delta increments parent counter. | Constructs a `CmDelta{row=1, col=5, value=CM_PROMASK}`, applies it to a `3x64` parent CMS, and verifies the target counter at `(1,5)` equals `CM_PROMASK`. |
 | `cm_regular_path_correctness` | Regular-path hashing, counters, and estimates are exact on a deterministic stream. | Recomputes expected counter indices for `I32(0..9)` using per-row hashing, asserts exact full-matrix equality after one pass, doubled counters after second pass, and estimate `== 2` for each inserted key. |
 | `cm_fast_path_correctness` | Fast-path counter placement matches bit-sliced hash mapping. | Recomputes expected fast-path indices for `I32(0..9)` from one hash plus row bit-slices/mask bits and asserts exact full-matrix equality. |
-| `cm_error_bound_zipf` | Zipf-stream error bound holds for regular and fast paths. | On `200_000` Zipf samples with domain `8192` and exponent `1.1`, checks both paths satisfy: number of distinct queried keys with `\|estimate - true\| < epsilon * N` is `> (1 - delta) * distinct_key_count`, with `epsilon = e / cols`, `delta = e^-rows`. |
-| `cm_error_bound_uniform` | Uniform-stream error bound holds for regular and fast paths. | On `200_000` uniform samples in `[100.0, 1000.0]`, checks both paths satisfy: number of distinct queried keys with `\|estimate - true\| < epsilon * N` is `> (1 - delta) * distinct_key_count`, with `epsilon = e / cols`, `delta = e^-rows`. |
 | `count_min_round_trip_serialization` | Serialization round trip preserves full sketch state. | Serializes/deserializes a populated `3x8` regular-path sketch and verifies dimensions plus the full counter array are unchanged. |
+| `count_min_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For a `3x8` sketch over a hasher declaring its own `HashProfile`, verifies the counter array round-trips, the bytes differ from the standard-profile sketch's over the same inserts, and a standard-profile decode rejects them. |
+| `count_min_f64_and_mode_in_metadata_round_trip` | The `f64` counter type and the `mode` both travel in the metadata. | Round-trips a `4x16` fast-path `Vector2D<f64>` sketch fed fractional weights, verifies the counter array is preserved, then that the same bytes fail to decode as an `i64` regular-path sketch. |
+| `count_min_rejects_zero_dimension_payload` | A zero dimension is a decode error, not a `Vector2D::from_fn` panic. | Verifies a crafted `4x0` envelope with an empty `counts` payload fails rather than panicking in the `cols.ilog2()` mask derivation. |
+| `cms_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the eleven `CmsMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `CmsMetadata`. |
+| `count_min_i32_round_trips_and_is_pinned_by_counter_type` | The `i32` wire config round-trips and its width is identity, not a detail. | Round-trips a `2x4` `Vector2D<i32>` sketch, then verifies its bytes differ from the numerically equal `i64` sketch's, that `i32` bytes fail to decode as `i64`, and that `i64` bytes fail to decode as `i32`. |
+| `count_min_counter_types_reject_each_other` | Each wire counter type refuses the others' bytes. | Verifies a `2x4` `f64` envelope fails to decode as both an `i32` and an `i64` sketch, and that an `i32` envelope fails to decode as an `f64` one. |
 
 ### Count
 
@@ -54,30 +60,24 @@ Wire tests: [`src/sketches/countsketch/wire.rs`](../src/sketches/countsketch/wir
 | `count_sketch_rejects_foreign_kind_id` | Count-Min's kind_id is refused although the payload shape is identical. | Verifies a `3x8` `CountMin<Vector2D<i64>, RegularPath>` envelope fails to decode as a `Count`. |
 | `count_sketch_rejects_zero_dimension_payload` | A zero dimension is a decode error, not a `Vector2D::from_fn` panic. | Verifies a crafted `4x0` envelope with an empty `counts` payload fails rather than panicking in the `cols.ilog2()` mask derivation. |
 | `count_sketch_rejects_dimension_length_mismatch` | The length check fires from the declared dimensions, before any allocation is sized from them. | Verifies a crafted envelope declaring `1024x1024` while carrying three counters fails. |
-| `count_sketch_rejects_serializing_an_unfilled_matrix` | The encode side refuses a matrix its own decoder would reject. | Verifies `Vector2D::init(2, 4)`, which reserves four cells without filling them, fails to serialize rather than emitting a `2x4` envelope carrying an empty `counts` array. |
+| `count_sketch_rejects_serializing_an_unfilled_matrix` | The encode side refuses a matrix its own decoder would reject. | Verifies `Vector2D::init(2, 4)`, which reserves eight cells without filling them, fails to serialize rather than emitting a `2x4` envelope carrying an empty `counts` array. |
 | `cs_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the eleven `CsMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `CsMetadata`. |
 | `cs_metadata_rejects_a_missing_counter_type_key` | `counter_type` is required and can never be silently defaulted. | Encodes the other ten `CsMetadata` fields as a named map with `counter_type` omitted and verifies it does not decode as `CsMetadata`. |
 | `cs_metadata_rejects_a_foreign_counter_type_name` | A Count-Min-only counter type name is not a Count Sketch one. | Wraps metadata naming `counter_type: "f64"` around a valid 2x4 payload and verifies both the `i64` and the `i32` sketch reject it. |
 | `count_sketch_i32_round_trips_and_is_pinned_by_counter_type` | The `i32` wire config round-trips and its width is identity, not a detail. | Round-trips a `2x4` `Vector2D<i32>` sketch, then verifies its bytes differ from the numerically equal `i64` sketch's, that `i32` bytes fail to decode as `i64`, and that `i64` bytes fail to decode as `i32`. |
-| `countl2hh_estimates_and_l2_are_consistent` | CountL2HH updates keep estimate and L2 consistent. | For `CountL2HH(3x32)`, applies `+5` then `-2` to one key, verifies estimates `5.0` then `3.0`, and asserts non-trivial L2 (`>= 3.0`). |
-| `countl2hh_merge_combines_frequency_vectors` | CountL2HH merge combines per-key frequencies. | Merges two `CountL2HH(3x32)` sketches with same key counts `4` and `9`, then verifies merged estimate `== 13.0`. |
-| `countl2hh_round_trip_serialization` | CountL2HH serialization round trip preserves estimate and L2. | Serializes/deserializes `CountL2HH::with_dimensions_and_seed(3,32,7)` after updates, verifying rows/cols and that both estimate and L2 remain unchanged (within `f64::EPSILON`). |
 
 ### HyperLogLog
 
 Test file: [`src/sketches/hll.rs`](../src/sketches/hll.rs)
 
+Wire tests: [`src/sketches/hll/wire.rs`](../src/sketches/hll/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `hll_child_insert_emits_on_improvement` | Child insert emits delta only on register improvement. | Inserts a key via `insert_emit_delta` into `HyperLogLog<Classic>`; verifies exactly `1` delta emitted on the first insert and `0` additional deltas on a duplicate insert. |
-| `hyperloglog_accuracy_within_two_percent` | Classic HyperLogLog stays within 2% relative error across scale checkpoints. | Inserts sequential unique `U64` values and checks at targets `[10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000]` that relative error `\|estimate-truth\|/truth <= 0.02`. |
-| `hll_ertl_accuracy_within_two_percent` | ErtlMLE HyperLogLog stays within 2% relative error across scale checkpoints. | Applies the same checkpointed unique-stream accuracy test as classic HLL, requiring relative error `<= 0.02` at each target cardinality. |
-| `hllds_accuracy_within_two_percent` | HIP HyperLogLog stays within 2% relative error across scale checkpoints. | Applies the same checkpointed unique-stream accuracy test to `HyperLogLogHIP`, requiring relative error `<= 0.02` at each target cardinality. |
 | `hyperloglog_p12_accuracy_within_two_percent` | P12 Classic HyperLogLog stays within P12 error tolerance across scale checkpoints. | Applies the same checkpointed unique-stream accuracy test to `HyperLogLogP12<Classic>`, requiring relative error `<= P12_ERROR_TOLERANCE` at each target cardinality. |
 | `hll_ertl_p12_accuracy_within_two_percent` | P12 ErtlMLE HyperLogLog stays within P12 error tolerance across scale checkpoints. | Applies the same checkpointed accuracy test to `HyperLogLogP12<ErtlMLE>`, requiring relative error `<= P12_ERROR_TOLERANCE`. |
 | `hllds_p12_accuracy_within_two_percent` | P12 HIP HyperLogLog stays within P12 error tolerance across scale checkpoints. | Applies the same checkpointed accuracy test to `HyperLogLogHIPP12`, requiring relative error `<= P12_ERROR_TOLERANCE`. |
-| `hyperloglog_merge_within_two_percent` | Classic HyperLogLog merge remains within 2% relative error. | Splits unique stream into even keys (left) and odd keys (right), merges sketches at each target checkpoint, and requires merged relative error `<= 0.02`. |
-| `hll_ertl_merge_within_two_percent` | ErtlMLE HyperLogLog merge remains within 2% relative error. | Uses the same even/odd split merge scenario and requires merged relative error `<= 0.02` at each target checkpoint. |
 | `hyperloglog_p12_merge_within_two_percent` | P12 Classic HyperLogLog merge remains within P12 error tolerance. | Applies the same even/odd split merge scenario to `HyperLogLogP12<Classic>`, requiring merged relative error `<= P12_ERROR_TOLERANCE`. |
 | `hll_ertl_p12_merge_within_two_percent` | P12 ErtlMLE HyperLogLog merge remains within P12 error tolerance. | Applies the same even/odd split merge scenario to `HyperLogLogP12<ErtlMLE>`, requiring merged relative error `<= P12_ERROR_TOLERANCE`. |
 | `hyperloglog_round_trip_serialization` | Classic HyperLogLog round trip preserves bytes and estimate stability. | After inserting `100_000` unique values, verifies serialized payload is non-empty, `deserialize -> reserialize` bytes are identical, and estimate drift is within `0.02 * max(original_est, 1.0)`. |
@@ -87,16 +87,24 @@ Test file: [`src/sketches/hll.rs`](../src/sketches/hll.rs)
 | `hll_ertl_p12_round_trip_serialization` | P12 ErtlMLE HyperLogLog round trip preserves bytes and estimate stability. | Applies the same `100_000`-value serialization round-trip checks for `HyperLogLogP12<ErtlMLE>`: non-empty bytes, byte-for-byte reserialization equality, and bounded estimate drift. |
 | `hllds_p12_round_trip_serialization` | P12 HIP HyperLogLog round trip preserves bytes and estimate stability. | Applies the same `100_000`-value serialization round-trip checks for `HyperLogLogHIPP12`: non-empty bytes, byte-for-byte reserialization equality, and bounded estimate drift. |
 | `hll_correctness_test` | Register update logic matches expected bucket/index behavior for all HLL variants. | Runs fixed hashed inserts against Classic, ErtlMLE, and HIP variants; asserts exact expected register values at specific bucket indices and confirms an untouched bucket remains zero. |
+| `hll_envelope_structure_and_kind_id_guard` | The envelope frames an Ertl-MLE sketch under kind_id `0x01 0x02`, and a Classic decoder refuses it. | For 1,000 inserts into `HyperLogLog<ErtlMLE>`, verifies the bytes open with the ASAPv1 magic, `envelope::VERSION`, a `kind_id_len` of `2`, and `0x01 0x02`, that the decoded registers match the source, and that a `HyperLogLog<Classic>` decode fails. |
+| `hll_hip_round_trip_preserves_state` | The HIP running scalars travel beside the registers. | For 1,000 inserts into `HyperLogLogHIP`, verifies the bytes carry kind_id `0x01 0x03` and that the decoded sketch matches the source on the registers and on `kxq0`, `kxq1`, and `est`. |
+| `native_and_portable_hll_bytes_match` | The native and portable encoders emit the same envelope. | For 1,000 inserts each, verifies an `ErtlMLE` sketch's bytes equal the portable `HllSketch` `Datafusion` encoding of its registers, and a `HyperLogLogHIP` sketch's bytes equal the portable `Hip` encoding of its registers plus `kxq0`, `kxq1`, and `est`. |
+| `hll_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For a P14 `ErtlMLE` sketch over a hasher declaring its own `HashProfile`, verifies the registers round-trip, the bytes differ from the standard-profile sketch's over the same 1,000 inserts, and a standard-profile decode rejects them. |
+| `hll_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the eight `HllMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `HllMetadata`. |
+| `hll_precision_cross_rejection` | The metadata `precision` pins the register storage the bytes belong to. | Verifies a populated `HyperLogLogP12<Classic>` envelope fails to decode as the P14 `HyperLogLog<Classic>`. |
+| `hll_hip_kind_id_rejected_by_classic` | The HIP kind_id is refused by the Classic decoder. | Verifies a populated `HyperLogLogHIP` envelope fails to decode as `HyperLogLog<Classic>`. |
 
 ### KLL
 
 Test file: [`src/sketches/kll.rs`](../src/sketches/kll.rs)
 
+Wire tests: [`src/sketches/kll/wire.rs`](../src/sketches/kll/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `coin_bit_cache_behavior` | Coin consumes cached random bits in deterministic bit order. | From a fixed seed, validates 3 successive 64-bit RNG blocks are consumed bit-by-bit (`0..63`) before refill, matching expected xorshift-derived bits exactly. |
 | `coin_state_never_zero` | Coin state is never zero, including zero-seed initialization. | Verifies `Coin::from_seed(0)` normalizes to non-zero state and remains non-zero across 128 tosses. |
-| `distributions_quantiles_stay_within_rank_error` | KLL quantiles stay within 2% rank tolerance across distributions and scales. | For `k=200`, checks quantiles `{0,0.1,0.25,0.5,0.75,0.9,1}` on Uniform (`0..100,000,000`) and Zipf (`1,000,000..10,000,000`, domain `8192`, exponent `1.1`) streams at sizes `[1_000, 5_000, 20_000, 100_000, 1_000_000, 5_000_000]`; each estimate must fall within truth interval defined by `q +/- 0.02`. |
 | `test_data_input_api` | DataInput numeric API is accepted and non-numeric input is rejected. | Inserts `I32`, `I64`, `F64`, `F32`, and `U32` values, checks median query lies between `20.0` and `40.2`, and verifies string input returns error `KLL sketch only accepts numeric inputs`. |
 | `test_forced_compact` | Small-capacity KLL triggers compaction and keeps median in valid compacted outcomes. | With `KLL::init(3,3)` and inserts `[10,20,30,40,50]`, asserts median query is one of `{30.0, 40.0}` under forced compaction. |
 | `test_no_compact` | Larger-capacity KLL avoids compaction for small stream and returns exact median. | With `KLL::init_kll(8)` and inserts `[10,20,30,40,50]`, asserts median query equals `30.0`. |
@@ -104,14 +112,27 @@ Test file: [`src/sketches/kll.rs`](../src/sketches/kll.rs)
 | `cdf_handles_empty_sketch` | Empty KLL CDF queries return zero-valued defaults. | For empty `KLL::init_kll(64)`, asserts `cdf.quantile(123.0) == 0.0`, `cdf.query(0.5) == 0.0`, and `cdf.query_li(0.5) == 0.0`. |
 | `kll_round_trip_rmp` | RMP round trip preserves KLL structure, packed data, and queried quantiles. | Serializes/deserializes `KLL::init_kll(256)` after 5,000 uniform updates (`0..1,000,000`, seed `0xDEAD_BEEF`), verifies non-empty bytes, core fields and packed arrays (`levels`, `items`) are identical, and CDF queries at `{0,0.1,0.25,0.5,0.75,0.9,1}` match within `f64::EPSILON`. |
 | `generic_kll_i64_sanity` | Generic `KLL<T>` path works for non-`f64` numeric types. | Builds `KLL<i64>`, inserts `1..=20_000` through the typed `update(&T)` API, checks approximate count and p50/p90 quantiles, verifies merge on two `KLL<i64>` instances, and confirms MessagePack round-trip preserves weighted count. |
+| `kll_envelope_structure_and_round_trip` | The envelope frames a compact sketch under kind_id `0x06 0x00`, and the bytes are stable across a round trip. | For `k=200` seeded at `42` over 200,000 updates, verifies the bytes open with the ASAPv1 magic, `envelope::VERSION`, a `kind_id_len` of `2`, and `0x06 0x00`, that the decoded sketch re-serializes to the same bytes, and that quantiles at `{0, 0.01, 0.25, 0.5, 0.75, 0.99, 1}` match exactly. |
+| `kll_empty_round_trip` | A sketch that saw nothing round-trips. | Verifies `KLL::<f64>::init_kll_with_seed(200, 7)` decodes back with a `count` of `0` and identical re-serialized bytes. |
+| `kll_i64_round_trip` | The generic `KLL<T>` path reaches the wire under the same kind_id. | For `KLL<i64>` seeded at `5` over 50,000 updates, verifies the bytes carry `0x06 0x00`, re-serialize identically after a decode, and preserve `count`. |
+| `kll_item_type_cross_rejection` | The metadata `item_type` pins the element type. | Verifies an `f64` `KLL` envelope fails to decode as a `KLL<i64>`. |
+| `kll_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the four required `KllMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `KllMetadata`. |
+| `kll_rejects_inconsistent_levels` | A level layout the items do not fill is refused rather than panicking. | Verifies a crafted envelope whose `levels` end at `3` while `items` carries two entries fails to decode. |
+| `kll_rejects_out_of_range_k_m` | A crafted `k`/`m` is refused before `compute_max_capacity` sizes anything. | Verifies crafted envelopes at `(u32::MAX, u32::MAX)`, `(MAX_CACHEABLE_K + 1, 8)`, and `(200, 1)` each fail to decode rather than driving a giant allocation. |
+| `kll_seed_present_when_seeded_omitted_when_unseeded` | The seed key is present exactly when the sketch has one. | Verifies `init_kll_with_seed(200, 42)` emits metadata carrying `seed` `Some(42)`, while an `init_kll(200)` sketch omits the key entirely. |
+| `kll_unseeded_round_trip_byte_stable` | The absent-seed key decodes as well as it encodes. | For an unseeded `k=200` sketch over 2,000 updates, verifies the decoded sketch re-serializes to the same bytes and keeps `count`. |
+| `kll_seed_survives_round_trip_so_clear_stays_deterministic` | Carrying the seed keeps `clear` deterministic after a decode. | Decodes a `k=200` sketch seeded at `42` over 5,000 updates, calls `clear` on it and on a freshly seeded twin, feeds both 3,000 updates, and verifies their bytes are identical. |
+| `kll_rejects_weighted_count_overflow` | A level layout whose weighted count overflows is refused rather than handed back. | Verifies a crafted envelope parking 16 items at compactor level 60, so that `16 * 2^60` overflows `usize` in `count()`, fails to decode. |
+| `kll_dynamic_kind_id_rejected_by_compact` | The dynamic kind_id is refused by the compact decoder. | Verifies a crafted envelope carrying valid compact metadata and payload under `0x06 0x01` fails to decode as a `KLL<f64>`. |
 
 ### KLLDynamic
 
 Test file: [`src/sketches/kll_dynamic.rs`](../src/sketches/kll_dynamic.rs)
 
+Wire tests: [`src/sketches/kll_dynamic/wire.rs`](../src/sketches/kll_dynamic/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
-| `distributions_quantiles_stay_within_rank_error` | KLLDynamic quantiles stay within 2% rank tolerance across distributions and scales. | For `k=200`, checks quantiles `{0,0.1,0.25,0.5,0.75,0.9,1}` on Uniform (`0..100,000,000`) and Zipf (`1,000,000..10,000,000`, domain `8192`, exponent `1.1`) streams at sizes `[1_000, 5_000, 20_000, 100_000, 1_000_000, 5_000_000]`; each estimate must fall within truth interval defined by `q +/- 0.02`. |
 | `test_data_input_api` | `KLLDynamic<f64>` accepts numeric `DataInput` and rejects non-numeric input. | Inserts `I32`, `I64`, `F64`, `F32`, and `U32` values through `update_data_input`, checks median query lies between `20.0` and `40.2`, and verifies string input returns error `KLL sketch only accepts numeric inputs`. |
 | `test_forced_compact` | Small-capacity KLLDynamic triggers compaction and keeps median in valid compacted outcomes. | With `KLLDynamic::init(3,3)` and typed inserts `[10,20,30,40,50]`, asserts median query is one of `{30.0, 40.0}` under forced compaction. |
 | `test_no_compact` | Larger-capacity KLLDynamic avoids compaction for small stream and returns exact median. | With `KLLDynamic::init_kll(8)` and typed inserts `[10,20,30,40,50]`, asserts median query equals `30.0`. |
@@ -119,25 +140,46 @@ Test file: [`src/sketches/kll_dynamic.rs`](../src/sketches/kll_dynamic.rs)
 | `cdf_handles_empty_sketch` | Empty KLLDynamic CDF queries return zero-valued defaults. | For empty `KLLDynamic::<f64>::init_kll(64)`, asserts `cdf.quantile(123.0) == 0.0`, `cdf.query(0.5) == 0.0`, and `cdf.query_li(0.5) == 0.0`. |
 | `kll_dynamic_round_trip_rmp` | RMP round trip preserves KLLDynamic structure, packed data, and queried quantiles. | Serializes/deserializes `KLLDynamic::init_kll(256)` after 5,000 uniform updates (`0..1,000,000`, seed `0xDEAD_BEEF`), verifies non-empty bytes, core fields and packed arrays (`levels`, `items`) are identical, and CDF queries at `{0,0.1,0.25,0.5,0.75,0.9,1}` match within `f64::EPSILON`. |
 | `generic_kll_dynamic_i64_sanity` | Generic `KLLDynamic<T>` path works for non-`f64` numeric types. | Builds `KLLDynamic<i64>`, inserts `1..=20_000` through the typed `update(&T)` API, checks approximate count and p50/p90 quantiles, and confirms MessagePack round-trip preserves weighted count. |
+| `kll_dynamic_envelope_structure_and_round_trip` | The envelope frames a dynamic sketch under kind_id `0x06 0x01`, and the bytes are stable across a round trip. | For `k=200` over 200,000 updates, verifies the bytes open with the ASAPv1 magic, `envelope::VERSION`, a `kind_id_len` of `2`, and `0x06 0x01`, that the decoded sketch re-serializes to the same bytes, and that quantiles at `{0, 0.01, 0.25, 0.5, 0.75, 0.99, 1}` match exactly. |
+| `kll_dynamic_empty_round_trip` | A sketch that saw nothing round-trips. | Verifies `KLLDynamic::<f64>::init_kll(200)` decodes back and re-serializes to identical bytes. |
+| `kll_dynamic_i64_round_trip` | The generic `KLLDynamic<T>` path reaches the wire under the same kind_id. | For `KLLDynamic<i64>` over 50,000 updates, verifies the bytes carry `0x06 0x01` and re-serialize identically after a decode. |
+| `kll_dynamic_item_type_cross_rejection` | The metadata `item_type` pins the element type. | Verifies an `f64` `KLLDynamic` envelope fails to decode as a `KLLDynamic<i64>`. |
 
 ### DDSketch
 
 Test file: [`src/sketches/ddsketch.rs`](../src/sketches/ddsketch.rs)
 
+Wire tests: [`src/sketches/ddsketch/wire.rs`](../src/sketches/ddsketch/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `insert_and_query_basic` | Basic insert/query preserves count semantics and quantile monotonicity. | Inserts mixed values `[0.0, -5.0, 1.0, 2.0, 3.0, 10.0, 50.0, 100.0, 1000.0]`, verifies non-positive values are ignored (`count == 7`), and checks queried quantiles at `{0.0, 0.5, 0.9, 0.99, 1.0}` are monotone and bounded by sketch min/max. |
 | `empty_quantile_returns_none` | Empty sketch returns no quantiles and zero count. | For a new `DDSketch(alpha=0.01)`, asserts `get_value_at_quantile` returns `None` for `p in {0.0, 0.5, 1.0}` and `get_count() == 0`. |
-| `dds_uniform_distribution_quantiles` | Uniform-distribution quantiles stay within configured relative error. | With `alpha=0.01`, samples sizes `[1_000, 5_000, 20_000]` from uniform range `[1_000_000, 10_000_000]` (seeded), and requires relative error `<= 0.01` at quantiles `{0, 0.1, 0.25, 0.5, 0.75, 0.9, 1}` against sorted-truth quantiles. |
-| `dds_zipf_distribution_quantiles` | Zipf-distribution quantiles stay within configured relative error. | With `alpha=0.01`, samples sizes `[1_000, 5_000, 20_000]` from Zipf range `[1_000_000, 10_000_000]` (domain `8192`, exponent `1.1`, seeded), and requires relative error `<= 0.01` at quantiles `{0, 0.1, 0.25, 0.5, 0.75, 0.9, 1}`. |
-| `dds_normal_distribution_quantiles` | Normal-distribution quantiles stay within configured relative error. | With `alpha=0.01`, samples sizes `[1_000, 5_000, 20_000]` from normal distribution (`mean=1000.0`, `std=100.0`, positive finite values retained), and requires relative error `<= 0.01` at quantiles `{0, 0.1, 0.25, 0.5, 0.75, 0.9, 1}`. |
-| `dds_exponential_distribution_quantiles` | Exponential-distribution quantiles stay within near-1% relative error. | With `alpha=0.01`, `lambda=1e-3`, and sample sizes `[1_000, 5_000, 20_000]`, requires relative error `<= 0.011 + 1e-9` at quantiles `{0, 0.1, 0.25, 0.5, 0.75, 0.9, 1}`. |
 | `merge_two_sketches_combines_counts_and_bounds` | Merge combines counts and preserves quantile boundary invariants. | Merges sketches built from `[1,2,3,4]` and `[5,10,20]`, then verifies merged `count=7`, `min=1`, `max=20`, exact boundary quantiles (`q0=1`, `q1=20`), and median lies within `[1,20]`. |
-| `dds_serialization_round_trip` | Serialization round trip preserves count, bounds, and selected quantiles. | Serializes/deserializes a populated sketch (`alpha=0.01`), verifies non-empty bytes, equal `count/min/max`, and exact quantile matches at `{0.0, 0.1, 0.5, 0.9, 1.0}`. |
+| `dds_serialization_round_trip` | Serialization round trip preserves count, sum, bounds, and selected quantiles. | Serializes/deserializes a populated sketch (`alpha=0.01`), verifies non-empty bytes, equal `count/sum/min/max`, and exact quantile matches at `{0.0, 0.1, 0.5, 0.9, 1.0}`. |
+| `ddsketch_envelope_structure_and_round_trip` | The envelope frames a sketch under kind_id `0x05 0x00`, and the bytes are stable across a round trip. | For a sketch at `alpha = 0.01` over eight values, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x05 0x00`, that the metadata carries `metadata_version` `1` and that alpha, that the decoded store counts and offset match, that re-serializing reproduces the bytes, and that quantiles at `{0, 0.1, 0.5, 0.9, 1}` are unchanged. |
+| `ddsketch_scalars_survive_exactly` | `sum`, `min`, and `max` are carried, not recomputed from the buckets. | Verifies the decoded sketch reports the source's `sum` and `alpha`, a `min` of exactly `0.25`, and a `max` of exactly `1000.0`, rather than the alpha-bounded bucket representatives a recomputation would give. |
+| `ddsketch_count_is_recovered_from_the_buckets` | The payload carries no `count` field. | Verifies the payload reads back as a five-element array whose bucket counts sum to `get_count()`, that a six-element read fails, and that the decoded sketch reports the same count. |
+| `ddsketch_empty_round_trip` | A sketch that saw nothing round-trips. | Verifies a fresh `DDSketch(alpha=0.01)` decodes back with a `count` of `0`, `min` and `max` of `None`, an empty store, and identical re-serialized bytes. |
+| `ddsketch_merged_round_trip` | A store grown on both sides of a merge round-trips. | Merges 200 values against the same 200 scaled by `0.001`, then verifies the decoded sketch matches the source on `count`, `sum`, `min`, and `max` and re-serializes to the same bytes. |
+| `ddsketch_rejects_foreign_kind_id` | Another sketch's kind_id is refused even when the rest parses cleanly. | Verifies a `3x8` Count-Min envelope fails to decode as a `DDSketch`, and that well-formed DDSketch metadata and payload wrapped under kind_id `0x02 0x00` fail too. |
+| `dd_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the two `DdMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `DdMetadata`. |
+| `dd_metadata_rejects_a_missing_alpha_key` | `alpha` is required and can never be silently defaulted. | Encodes a named map holding only `metadata_version` and verifies it does not decode as `DdMetadata`. |
+| `ddsketch_rejects_alpha_outside_the_unit_interval` | An `alpha` outside `(0, 1)` makes every bucket index meaningless and is refused. | Verifies crafted envelopes at `alpha` of `0.0`, `1.0`, `-0.5`, `2.0`, `NaN`, and infinity each fail with an alpha or metadata-mismatch complaint, while the same payload at `0.01` decodes. |
+| `ddsketch_rejects_a_store_span_past_i32` | The span rule fires from the offset and the array length, before the store is rebuilt. | Verifies a crafted store of ten buckets at offset `i32::MAX - 2` fails with a "store span past i32" complaint, while the same payload three buckets long decodes. |
+| `ddsketch_rejects_a_nonzero_offset_on_an_empty_store` | An empty store has exactly one encoding. | Verifies a crafted empty store at offset `42` fails with an "empty store must be at offset 0" complaint. |
+| `ddsketch_rejects_a_total_count_overflow` | Bucket counts that overflow the recovered total are refused rather than wrapped. | Verifies a crafted payload of `[u64::MAX, 1]` fails with an "overflow the total sample count" complaint. |
+| `ddsketch_rejects_inconsistent_scalars` | The scalars the buckets do not determine are still bounded by them. | Verifies six crafted payloads each fail on a scalar rule: a populated store carrying the empty-store sentinels, `min` above `max`, a non-positive `min`, a `sum` below the smallest ingested value, an empty store carrying a non-zero `sum`, and all-zero buckets carrying populated-store scalars. |
+| `ddsketch_rejects_serializing_a_store_span_past_i32` | The encode side refuses a store its own decoder would reject. | Verifies a sketch whose store holds ten buckets at offset `i32::MAX - 2` fails to serialize. |
+| `ddsketch_rejects_serializing_an_overflowing_bucket_total` | The encode side enforces the total-count rule too. | Verifies a sketch whose store holds `[u64::MAX, 1]` fails to serialize. |
 
 ### CMSHeap
 
 Test file: [`src/sketches/countminsketch_topk.rs`](../src/sketches/countminsketch_topk.rs)
+
+Wire tests: [`src/sketches/countminsketch_topk/wire.rs`](../src/sketches/countminsketch_topk/wire.rs)
+
+Shared heap wire tests: [`src/sketches/countminsketch_topk/heap_wire.rs`](../src/sketches/countminsketch_topk/heap_wire.rs)
 
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
@@ -164,10 +206,33 @@ Test file: [`src/sketches/countminsketch_topk.rs`](../src/sketches/countminsketc
 | `zipf_stream_top_k_recall_regular_fast_budget` | Regular path heap achieves high top-k recall on Zipf stream. | On Zipf stream (`rows=3`, `cols=4096`, `top_k=16`, `domain=1024`, `exponent=1.1`, `N=20_000`), verifies heap size bound, entry-count consistency, and recall hits `>= 15` vs truth top-16. |
 | `zipf_stream_top_k_recall_fast_path_fast_budget` | Fast path heap achieves high top-k recall on Zipf stream. | Runs same Zipf setup in fast mode and verifies heap size bound, entry-count consistency, and recall hits `>= 15`. |
 | `zipf_stream_regular_fast_heap_overlap` | Regular and fast heaps substantially overlap on Zipf heavy hitters. | On shared Zipf stream (`top_k=16`), verifies key overlap ratio between regular and fast top-k heaps is at least `0.8`. |
+| `cms_heap_round_trip_serialization` | The envelope frames a sketch under kind_id `0x03 0x00`, and the bytes are stable across a round trip. | For a `3x8` regular-path `i64` sketch with a heap of `4` holding three weighted `u64` keys, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x03 0x00`, that the metadata carries `3x8`, `counter_type` `i64`, `mode` `regular`, `k` `4`, and `key_type` `u64`, that dimensions, counters, heap length and capacity, and per-key estimates and heap counts all match, and that re-serializing reproduces the bytes. |
+| `cms_heap_f64_counters_round_trip` | The `f64` base counter reaches the wire beside a string-keyed heap. | For a `2x4` `Vector2D<f64>` sketch holding one `Str` heap key, verifies the metadata names `counter_type` `f64` and `key_type` `string`, that the counters and the heap key survive the decode, and that the bytes re-serialize identically. |
+| `cms_heap_counter_type_is_pinned_by_the_target` | The base counter type separates two otherwise equal sketches. | For `2x4` sketches holding numerically equal `i64` and `f64` cells, verifies the bytes differ, that `i64` bytes fail to decode as `f64`, and that `f64` bytes fail to decode as `i64`. |
+| `cms_heap_mode_in_metadata_round_trips` | The metadata `mode` pins which column derivation built the sketch. | Round-trips a `4x16` fast-path sketch, verifies the metadata names `mode` `fast` and the counters are preserved, then that the same bytes fail to decode as a `RegularPath` sketch. |
+| `cms_heap_rejects_foreign_kind_ids` | The neighbouring sketches' kind_ids are refused. | Verifies `CSHeap`, `CountMin`, and `Count` envelopes at `3x8` each fail to decode as a `CMSHeap`. |
+| `cms_heap_rejects_zero_dimension_payload` | A zero dimension is a decode error, not a `Vector2D::from_fn` panic. | Verifies a crafted `4x0` envelope fails with a "must be non-zero" complaint. |
+| `cms_heap_rejects_dimension_length_mismatch` | The length check fires from the declared dimensions, before any allocation is sized from them. | Verifies a crafted envelope declaring `1024x1024` while carrying three counters fails with a "!= rows*cols" complaint. |
+| `cms_heap_rejects_serializing_an_unfilled_matrix` | The encode side refuses a matrix its own decoder would reject. | Verifies `Vector2D::<i64>::init(2, 4)`, which reserves eight cells without filling them, fails to serialize. |
+| `cms_heap_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the thirteen `TopKMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `TopKMetadata`. |
+| `cms_heap_metadata_rejects_a_missing_k_key` | `k` is required, so the heap capacity can never be silently defaulted. | Encodes the other twelve `TopKMetadata` fields as a named map with `k` omitted and verifies it does not decode as `TopKMetadata`. |
+| `cms_heap_rejects_a_foreign_counter_type_name` | A Count-Sketch-only counter type name is not a Count-Min one. | Wraps metadata naming `counter_type: "i32"` around a valid `2x4` payload and verifies an `i64` `CMSHeap` rejects it. |
+| `cms_heap_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For a `3x8` sketch with a heap of `4` over a hasher declaring its own `HashProfile`, verifies the counters and both heap entries round-trip, the bytes differ from the standard-profile sketch's over the same keys, and a standard-profile decode rejects them. |
+| `cms_heap_refuses_a_k_the_metadata_cannot_carry` | A `k` past the metadata's `u32` field fails the encode rather than truncating. | Verifies a `2x4` sketch built at a heap capacity of `1 << 40` fails to serialize with a message naming the "exceeds the u32 metadata field" rule. |
+| `heap_every_key_type_round_trips_and_keeps_its_variant` | The `key_type` names the exact `HeapItem` variant and is never widened. | Across all 13 wire key types - `i8`, `i16`, `i32`, `i64`, `isize`, `u8`, `u16`, `u32`, `u64`, `usize`, `f32`, `f64`, and `string` - verifies the metadata carries the expected name, the bytes re-serialize identically, and every decoded key is still found by its original `DataInput` at the weight it was given. |
+| `heap_refuses_mixed_and_128_bit_keys` | Keys the wire cannot carry refuse to serialize rather than being coerced. | Verifies a heap holding both an `I32` and an `I64` key fails with a "keys mix variants" complaint naming `key_type is i32`, that a lone `I128` or `U128` key fails with a "128-bit" complaint, and that a 128-bit key seated behind a `U64` one fails too. |
+| `heap_empty_emits_the_pinned_key_type_and_round_trips` | A heap monitoring nothing has one encoding. | For an empty `2x8` sketch with a heap of `8`, verifies the metadata carries the pinned `EMPTY_KEY_TYPE` and a `k` of `8`, and that the decode holds no entries at capacity `8` with identical re-serialized bytes. |
+| `heap_emitted_order_is_independent_of_seat_order` | The emitted order is descending count with ties broken by the key, not the sift path. | Seats four entries carrying two count ties in one order and in reverse, verifies both serialize to the same bytes, that the payload reads `heap_counts` `[9, 9, 5, 5]` and `keys` `[1, 4, 2, 3]`, and that a decoded heap re-serializes identically. |
+| `heap_rejects_a_key_type_the_payload_does_not_carry` | A payload relabelled with another `key_type` is refused. | Re-frames a string-keyed payload under a `u64` `key_type` and a `u64`-keyed payload under `string`, and verifies neither decodes. |
+| `heap_index_is_rebuilt_so_updates_still_move_entries` | `slots` and `positions` are rebuilt on decode, so later updates land the same way. | Round-trips a four-entry heap, applies the same rescore and new-key update to the source and to the decoded copy, and verifies both serialize to the same bytes and agree on every key's count. |
+| `heap_does_not_allocate_a_declared_k` | A declared `k` is metadata, never an allocation size. | Verifies an envelope declaring `k` `u32::MAX` with two entries decodes, reports that capacity, and holds two entries. |
+| `heap_rejects_crafted_entry_sets` | Entry sets the heap could not have reached are refused. | Verifies three crafted envelopes each fail with their own complaint: two entries over a `k` of `1`, the same key twice, and two keys against one count. |
 
 ### CSHeap
 
 Test file: [`src/sketches/countsketch_topk.rs`](../src/sketches/countsketch_topk.rs)
+
+Wire tests: [`src/sketches/countsketch_topk/wire.rs`](../src/sketches/countsketch_topk/wire.rs)
 
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
@@ -194,6 +259,41 @@ Test file: [`src/sketches/countsketch_topk.rs`](../src/sketches/countsketch_topk
 | `zipf_stream_top_k_recall_regular_fast_budget` | Regular path heap achieves high top-k recall on Zipf stream. | On Zipf stream (`rows=5`, `cols=4096`, `top_k=16`, `domain=1024`, `exponent=1.1`, `N=20_000`), verifies heap size bound, entry-count consistency, and recall hits `>= 15` vs truth top-16. |
 | `zipf_stream_top_k_recall_fast_path_fast_budget` | Fast path heap achieves high top-k recall on Zipf stream. | Runs same Zipf setup in fast mode and verifies heap size bound, entry-count consistency, and recall hits `>= 15`. |
 | `zipf_stream_regular_fast_heap_overlap` | Regular and fast heaps substantially overlap on Zipf heavy hitters. | On shared Zipf stream (`top_k=16`), verifies key overlap ratio between regular and fast top-k heaps is at least `0.8`. |
+| `cs_heap_round_trip_serialization` | The envelope frames a sketch under kind_id `0x0a 0x00`, and the bytes are stable across a round trip. | For a `3x8` regular-path `i64` sketch with a heap of `4` holding three weighted `u64` keys, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x0a 0x00`, that the metadata carries `3x8`, `counter_type` `i64`, `mode` `regular`, `k` `4`, and `key_type` `u64`, that dimensions, counters, heap length and capacity, and per-key estimates and heap counts all match, and that re-serializing reproduces the bytes. |
+| `cs_heap_negative_counters_round_trip` | Signed cells reach the wire and come back unchanged. | Round-trips a `2x4` matrix of alternating positive and negative counters beside a `Str` heap key, and verifies the decoded slice equals the source, still holds a negative cell, keeps the heap key, and re-serializes identically. |
+| `cs_heap_i32_round_trips_and_is_pinned_by_counter_type` | The `i32` wire config round-trips and its width is identity, not a detail. | Round-trips a `2x4` `Vector2D<i32>` sketch, verifies the metadata names `counter_type` `i32`, then that its bytes differ from the numerically equal `i64` sketch's, that `i32` bytes fail to decode as `i64`, and that `i64` bytes fail to decode as `i32`. |
+| `cs_heap_mode_in_metadata_round_trips` | The metadata `mode` pins which column derivation built the sketch. | Round-trips a `4x16` fast-path sketch, verifies the metadata names `mode` `fast` and the counters are preserved, then that the same bytes fail to decode as a `RegularPath` sketch. |
+| `cs_heap_rejects_foreign_kind_ids` | The neighbouring sketches' kind_ids are refused. | Verifies `CMSHeap`, `CountMin`, and `Count` envelopes at `3x8` each fail to decode as a `CSHeap`. |
+| `cs_heap_rejects_zero_dimension_payload` | A zero dimension is a decode error, not a `Vector2D::from_fn` panic. | Verifies a crafted `4x0` envelope fails with a "must be non-zero" complaint. |
+| `cs_heap_rejects_dimension_length_mismatch` | The length check fires from the declared dimensions, before any allocation is sized from them. | Verifies a crafted envelope declaring `1024x1024` while carrying three counters fails with a "!= rows*cols" complaint. |
+| `cs_heap_rejects_serializing_an_unfilled_matrix` | The encode side refuses a matrix its own decoder would reject. | Verifies `Vector2D::<i64>::init(2, 4)`, which reserves eight cells without filling them, fails to serialize. |
+| `cs_heap_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the thirteen `TopKMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `TopKMetadata`. |
+| `cs_heap_metadata_rejects_a_missing_key_type_key` | `key_type` is required, so the heap's key variant can never be silently defaulted. | Encodes the other twelve `TopKMetadata` fields as a named map with `key_type` omitted and verifies it does not decode as `TopKMetadata`. |
+| `cs_heap_rejects_a_foreign_counter_type_name` | A Count-Min-only counter type name is not a Count Sketch one. | Wraps metadata naming `counter_type: "f64"` around a valid `2x4` payload and verifies both the `i64` and the `i32` sketch reject it. |
+| `cs_heap_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For a `3x8` sketch with a heap of `4` over a hasher declaring its own `HashProfile`, verifies the counters and both heap entries round-trip, the bytes differ from the standard-profile sketch's over the same keys, and a standard-profile decode rejects them. |
+| `cs_heap_refuses_a_k_the_metadata_cannot_carry` | A `k` past the metadata's `u32` field fails the encode rather than truncating. | Verifies a `2x4` sketch built at a heap capacity of `1 << 40` fails to serialize with a message naming the "exceeds the u32 metadata field" rule. |
+
+### CountL2HH
+
+Test file: [`src/sketches/countsketch_topk.rs`](../src/sketches/countsketch_topk.rs)
+
+Wire tests: [`src/sketches/countsketch_topk/l2hh_wire.rs`](../src/sketches/countsketch_topk/l2hh_wire.rs)
+
+| test_name | test_description | what_is_tested |
+| --- | --- | --- |
+| `countl2hh_estimates_and_l2_are_consistent` | CountL2HH updates keep estimate and L2 consistent. | For `CountL2HH(3x32)`, applies `+5` then `-2` to one key, verifies estimates `5.0` then `3.0`, and asserts non-trivial L2 (`>= 3.0`). |
+| `countl2hh_merge_combines_frequency_vectors` | CountL2HH merge combines per-key frequencies. | Merges two `CountL2HH(3x32)` sketches with same key counts `4` and `9`, then verifies merged estimate `== 13.0`. |
+| `countl2hh_round_trip_serialization` | CountL2HH serialization round trip preserves estimate and L2. | Serializes/deserializes `CountL2HH::with_dimensions_and_seed(3,32,7)` after updates, verifying rows/cols and that both estimate and L2 remain unchanged (within `f64::EPSILON`). |
+| `count_l2hh_round_trip_serialization` | The envelope frames a sketch under kind_id `0x19 0x00`, and the state survives a round trip. | For a `3x32` sketch seeded at `7` over three signed weighted inserts, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x19 0x00`, that the metadata carries `seed_index` `7` and `3x32`, and that the decode matches on dimensions, seed index, the counter array, the `l2` accumulators, and `get_l2`. |
+| `count_l2hh_decoded_re_serializes_identically` | A decoded sketch re-serializes byte for byte. | Verifies the populated `3x32` sketch's decode re-encodes to the bytes it came from. |
+| `count_l2hh_negative_counters_round_trip` | Signed cells reach the wire and come back unchanged. | Round-trips a `2x8` sketch fed two negative weights and verifies the decoded slice equals the source, still holds a negative cell, and re-serializes identically. |
+| `count_l2hh_seed_index_travels_with_the_sketch` | The seed index is state, not a profile constant. | Verifies `2x8` sketches seeded at `0` and at `9` do not share bytes, and that the decoded seed-`9` sketch reports a `seed_idx` of `9`. |
+| `count_l2hh_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For a `3x32` sketch over a hasher declaring its own `HashProfile`, verifies the counter array round-trips, the bytes differ from the standard-profile sketch's over the same insert, and a standard-profile decode rejects them. |
+| `count_l2hh_rejects_foreign_kind_ids` | The neighbouring universal-sketch kind_ids are refused. | Verifies `Count`, `UnivMon`, `UnivMonPyramid`, and `UnivMonQ` envelopes each fail to decode as a `CountL2HH`. |
+| `count_l2hh_rejects_crafted_geometry` | Every geometry rule fires before an allocation is sized from it. | Verifies crafted envelopes carrying a zero `cols`, a `4096x4096` declaration against three counters, a five-entry `l2` array against two rows, and a negative `l2` accumulator each fail to decode. |
+| `count_l2hh_rejects_serializing_an_unfilled_matrix` | The encode side refuses a matrix its own decoder would reject. | Verifies a `2x4` sketch whose counts are replaced by `Vector2D::init(2, 4)`, which reserves eight cells without filling them, fails to serialize. |
+| `l2hh_metadata_rejects_unknown_and_missing_keys` | An unexpected metadata key and a missing required one both fail closed. | Encodes the nine `L2hhMetadata` fields plus a `bogus_field`, and the same fields with `cols` omitted, and verifies neither decodes as `L2hhMetadata`. |
+| `count_l2hh_empty_has_one_encoding` | A sketch holding nothing has exactly one encoding. | Verifies a fresh `3x32` sketch and one cleared after an insert serialize to identical bytes. |
 
 ### SpaceSaving
 
@@ -251,6 +351,7 @@ Conformance: [`tests/conformance_kit.rs`](../tests/conformance_kit.rs) runs `spa
 | `space_saving_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the summary rather than a hardcoded profile. | For a four-counter summary over a hasher declaring its own `HashProfile`, verifies the bytes round-trip with `estimate` intact and re-serialize identically, differ from the standard-profile summary's bytes over the same keys, and are rejected by a standard-profile decode. |
 | `space_saving_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the eight `SpaceSavingMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `SpaceSavingMetadata`. |
 | `space_saving_rejects_a_crafted_envelope` | Every structural rule is pinned by the complaint it fails with. | Verifies nine crafted envelopes are each refused for their own reason: a zero capacity, more entries than the capacity, `keys` longer than `counts`, `counts` longer than `errors`, a counter at zero, an error of `4` against a count of `3`, the same key twice, an unknown `key_type` of `u256`, and a foreign kind_id. |
+| `space_saving_refuses_a_capacity_the_metadata_cannot_carry` | A capacity past the metadata's `u32` field fails the encode rather than truncating. | Rebuilds a one-counter summary declaring a capacity of `1 << 40`, verifies it reports that capacity, and that serializing fails with a message naming the "exceeds the u32 metadata field" rule. |
 | `space_saving_does_not_allocate_a_declared_capacity` | A declared capacity is metadata, never an allocation size. | Verifies an envelope declaring `u32::MAX` counters with two entries decodes, reports that capacity, holds two counters with key 7 reading `9`, a `min_count` of `0`, and a two-entry `top_k`. |
 
 ### Bloom
@@ -307,6 +408,8 @@ Conformance: [`tests/conformance_kit.rs`](../tests/conformance_kit.rs) runs the 
 
 Test file: [`src/sketches/elastic.rs`](../src/sketches/elastic.rs)
 
+Wire tests: [`src/sketches/elastic/wire.rs`](../src/sketches/elastic/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `init_with_dimensions_sizes_both_parts` | Both parts take the requested dimensions. | `init_with_dimensions(12, 2, 256)` is verified to yield 12 heavy buckets and a 2x256 light layer. |
@@ -356,10 +459,26 @@ Test file: [`src/sketches/elastic.rs`](../src/sketches/elastic.rs)
 | `heavy_changes_reports_only_moves_past_the_threshold` | Heavy change detection filters by size of move. | Over rising (10->55), falling (60->8), and steady (40->42) flows, verifies only the first two are reported at `threshold = 20`. |
 | `heavy_changes_covers_a_flow_present_in_only_one_window` | A flow in one window only is a change. | Verifies a flow of 40 that vanishes reports `(40, 0)` and one of 45 that appears reports `(0, 45)`. |
 | `heavy_changes_reports_each_flow_once` | Each flow appears once in the change list. | A flow resident in both windows, each expanded so it also has a stale copy, reaches the id list four times and is reported once. |
+| `elastic_round_trip_serialization` | The envelope frames a sketch under kind_id `0x0b 0x00`, and the state survives a round trip. | For an 8-bucket heavy table over a `2x256` light layer fed 12 hits of one flow and one of another, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x0b 0x00`, and that the decode keeps `bktlen`, the light dimensions, every heavy bucket, every light counter, and a `query` of `12`. |
+| `elastic_rejects_foreign_kind_id` | The inlined Count-Min's own envelope is not an Elastic one. | Verifies a stand-alone `2x256` `CountMin<Vector2D<i32>, RegularPath>` envelope fails to decode as an `Elastic`. |
+| `elastic_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the twelve `ElasticMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `ElasticMetadata`. |
+| `elastic_metadata_rejects_a_missing_light_cols_key` | `light_cols` is required and can never be silently defaulted. | Encodes the other eleven `ElasticMetadata` fields as a named map with `light_cols` omitted and verifies it does not decode as `ElasticMetadata`. |
+| `elastic_rejects_zero_dimension_payload` | A zero dimension in either part is a decode error, not a panic. | Verifies crafted envelopes declaring `0` heavy buckets, `0` light rows, and `0` light columns each fail rather than panicking in the `cols.ilog2()` mask derivation. |
+| `elastic_rejects_dimension_length_mismatch` | Both length checks run before the heavy table and the light matrix are built. | Verifies a crafted envelope declaring `1024` buckets over `1024x1024` while carrying two buckets and three light counters fails, and that a payload whose heavy arrays agree with each other but whose `light_counts` holds eight entries against a declared `2x256` fails too. |
+| `elastic_rejects_a_flow_and_vote_that_disagree_on_occupancy` | A free bucket is `nil` with no vote, and a payload where the two disagree is refused. | Verifies a crafted payload naming a flow whose `vote_pos` is `0`, and one carrying a vote under a `nil` flow, both fail to decode. |
+| `elastic_rejects_serializing_an_inconsistent_sketch` | The encode side refuses states its own decoder would reject. | Verifies an 8-bucket sketch whose `bktlen` is set to `16` fails to serialize, and that one whose free bucket names a flow fails too. |
+| `elastic_free_buckets_are_nil_and_never_collide_with_an_empty_flow_id` | A free bucket is `nil`, not an empty string. | For an all-free 4-bucket table, verifies the payload holds one `0xc0` per bucket and no `0xa0` and that the decode matches bucket for bucket; then that a table holding an inserted empty flow id emits an `0xa0`, decodes identically, and answers that flow's `query` with `1`. |
+| `elastic_mixed_occupancy_round_trips` | A table mixing free, occupied and evicted buckets round-trips bucket for bucket. | For a 16-bucket table over `3x512` fed a resident, a colliding flow past the `LAMBDA` threshold, and six more flows, verifies the fixture holds both vacant and flagged buckets and that the decode matches on every bucket, every light counter, and both flows' `query` results. |
+| `elastic_negative_votes_and_light_counters_round_trip` | Votes and light counters are signed on the wire. | Sets a bucket's `vote_neg` to `-300` and `vote_pos` to `-7` and inserts a light weight of `-9` into a 4-bucket `2x8` sketch, then verifies the decode matches on every bucket and every light counter. |
+| `elastic_stale_copies_round_trips_in_both_states` | `stale_copies` is carried, since the buckets do not determine it. | Verifies an 8-bucket sketch decodes with the flag `false`, then that after `expand_heavy()` it decodes with the flag `true`, a `bktlen` of `16`, matching buckets, `heavy_hitters` agreeing with the source, and exactly twice as many occupied buckets as reported flows. |
+| `elastic_decoded_sketch_reserializes_byte_identically` | The emitted order is bucket index order for the heavy table and row-major for the light layer. | For a 16-bucket `3x512` sketch fed 40 flows and then expanded, verifies the decoded sketch re-serializes to the bytes it came from. |
+| `elastic_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For an 8-bucket `2x256` sketch over a hasher declaring its own `HashProfile`, verifies the buckets and light counters round-trip, the bytes differ from the standard-profile sketch's over the same flows, and a standard-profile decode rejects them. |
 
 ### Coco
 
 Test file: [`src/sketches/coco.rs`](../src/sketches/coco.rs)
+
+Wire tests: [`src/sketches/coco/wire.rs`](../src/sketches/coco/wire.rs)
 
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
@@ -375,20 +494,47 @@ Test file: [`src/sketches/coco.rs`](../src/sketches/coco.rs)
 | `a_key_occupies_at_most_one_bucket_per_row` | A key never gains a second home in the table. | After 64 inserts of one key into a `32x4` table, verifies exactly one bucket holds it and `estimate_key` returns `64`. |
 | `estimate_key_never_exceeds_the_inserted_mass` | Point queries stay inside the table mass. | Over 500 weighted inserts across 40 keys in an `8x2` table, verifies the table mass equals the inserted mass and no per-key estimate exceeds it. |
 | `merge_combines_tables_without_losing_counts` | Merge combines tables without losing counts. | Merge behavior preserves expected aggregate semantics and internal invariants. |
+| `coco_round_trip_serialization` | The envelope frames a sketch under kind_id `0x0c 0x00`, and the state survives a round trip. | For an `init_with_size(8, 4)` table holding two weighted keys, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x0c 0x00`, and that the decode keeps `w` `8`, `d` `4`, every bucket's key and value, and an `estimate_key` of `521`. |
+| `coco_rejects_foreign_kind_id` | Another sketch carrying `rows`/`cols` metadata is refused on its kind_id. | Verifies a `4x8` Count-Min envelope fails to decode as a `Coco`. |
+| `coco_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the eight `CocoMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `CocoMetadata`. |
+| `coco_metadata_rejects_a_missing_cols_key` | `cols` is required and can never be silently defaulted. | Encodes the other seven `CocoMetadata` fields as a named map with `cols` omitted and verifies it does not decode as `CocoMetadata`. |
+| `coco_rejects_zero_dimension_payload` | A zero dimension is a decode error, not a `Vector2D` panic. | Verifies a crafted `4x0` envelope with an empty payload fails rather than panicking in the `cols.ilog2()` mask derivation. |
+| `coco_rejects_dimension_length_mismatch` | The length check fires from the declared dimensions, before any allocation is sized from them. | Verifies a crafted envelope declaring `1024x1024` while carrying three buckets fails. |
+| `coco_rejects_mass_under_an_unoccupied_bucket` | An unoccupied bucket holds no mass. | Verifies a crafted `1x2` payload pairing a `nil` key with a value of `9` fails to decode. |
+| `coco_rejects_serializing_a_geometry_mismatch` | The encode side refuses geometries its own decoder would reject. | Verifies a sketch whose `w` is set to `16` against an 8-wide table fails to serialize, and that an `init_with_size(8, 0)` sketch fails too. |
+| `coco_empty_buckets_are_nil_and_never_collide_with_an_empty_key` | An unoccupied bucket is `nil`, not an empty string. | For an all-empty `init_with_size(4, 2)` table, verifies the payload holds eight `0xc0` and no `0xa0`, the decode matches cell for cell, and `recorded_flows` is empty; then that a table holding an inserted empty key emits an `0xa0`, decodes identically, lists one flow, and answers that key's `estimate_key` with `5`. |
+| `coco_mixed_occupancy_round_trips` | A table mixing occupied and free buckets round-trips bucket for bucket. | For an `init_with_size(16, 3)` table fed ten weighted keys, verifies the fixture leaves both bucket states present and that the decode matches on every cell and on `estimate_key` for all ten keys. |
+| `coco_decoded_sketch_reserializes_byte_identically` | The emitted order is the table's own index order, so a decode re-encodes exactly. | For an `init_with_size(16, 3)` table fed twelve weighted keys, verifies the decoded sketch re-serializes to the bytes it came from. |
+| `coco_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For an `init_with_size(8, 4)` table over a hasher declaring its own `HashProfile`, verifies every cell round-trips, the bytes differ from the standard-profile sketch's over the same keys, and a standard-profile decode rejects them. |
 
 ### KMV
 
 Test file: [`src/sketches/kmv.rs`](../src/sketches/kmv.rs)
 
+Wire tests: [`src/sketches/kmv/wire.rs`](../src/sketches/kmv/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
-| `assert_accuracy` | Assert accuracy. | Accuracy/error behavior stays within expected bounds on representative workloads. |
-| `assert_merge_accuracy` | Assert merge accuracy. | Merge behavior preserves expected aggregate semantics and internal invariants. |
 | `assert_serialization_round_trip` | Assert serialization round trip. | Serialization/deserialization preserves component state and behavior after round trip. |
+| `kmv_round_trip_serialization` | The envelope frames a sketch under kind_id `0x0e 0x00`, and the bytes are stable across a round trip. | For `k = 64` filled by 5,000 distinct keys, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x0e 0x00`, that the metadata carries `k` `64` and the canonical seed index, that the 64 emitted hashes are strictly ascending, and that the decode matches on `k`, capacity, retained hashes, heap root, and `estimate`, re-serializing identically. |
+| `kmv_emitted_order_is_independent_of_insertion_order` | The emitted order follows the hash value, not the arrival order. | Fills two `k = 32` sketches with the same 2,000 keys forward and backward, verifies their heap arrays differ, and that both serialize to the same bytes, which a decode re-encodes exactly. |
+| `kmv_empty_round_trip` | A sketch that retains nothing has exactly one encoding. | Verifies a fresh `k = 16` sketch emits `k` `16` beside an empty `hashes` array and decodes back to length `0` at capacity `16` with an `estimate` of `0.0` and identical re-serialized bytes. |
+| `kmv_carries_hashes_at_full_u64_width` | The retained digests travel at 64 bits. | Inserts `0`, `1`, `u64::MAX / 2`, and `u64::MAX` by hash into a `k = 4` sketch and verifies the payload and the decoded sketch both carry those four values, re-serializing identically. |
+| `kmv_rejects_foreign_kind_id` | Another sketch's kind_id is refused. | Verifies a `3x8` Count-Min envelope fails to decode as a `KMV` with a "kind_id mismatch" complaint. |
+| `kmv_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the eight `KmvMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `KmvMetadata`. |
+| `kmv_metadata_rejects_a_missing_k_key` | `k` is required and can never be silently defaulted. | Encodes the other seven `KmvMetadata` fields as a named map with `k` omitted and verifies it does not decode as `KmvMetadata`. |
+| `kmv_rejects_a_crafted_envelope` | Every structural rule is pinned by the complaint it fails with. | Verifies four crafted envelopes are each refused for their own reason: a `k` of `0`, three hashes over a `k` of `2`, an unsorted hash array, and one holding a duplicate. |
+| `kmv_rejects_a_payload_declaring_more_hashes_than_it_carries` | An over-declared array header is refused on the read. | Verifies a payload whose `array32` header declares `2^30` elements while carrying two of them fails rather than being allocated. |
+| `kmv_does_not_allocate_a_declared_k` | A declared `k` is metadata, never an allocation size. | Verifies an envelope declaring `k` `u32::MAX` with two hashes decodes, reports that bound and an `estimate` of `2.0`, and that a further hash is appended rather than evicting one. |
+| `kmv_refuses_a_k_the_metadata_cannot_carry` | A `k` past the metadata's `u32` field fails the encode rather than truncating. | Verifies a sketch built at `k = 1 << 40` fails to serialize with a message naming the "exceeds the u32 metadata field" rule. |
+| `kmv_refuses_to_serialize_a_state_decode_would_reject` | The encode side refuses the states decode refuses. | Verifies a `k = 0` sketch fails to serialize, and that one retaining two hashes at `k = 1` fails with a "2 hashes over a k of 1" complaint. |
+| `kmv_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For a `k = 16` sketch over 500 keys through a hasher declaring its own `HashProfile`, verifies the retained hashes round-trip and re-serialize identically, that the two profiles retain the same hashes yet emit different bytes, and that a standard-profile decode rejects them. |
 
 ### UniformSampling
 
 Test file: [`src/sketches/uniform.rs`](../src/sketches/uniform.rs)
+
+Wire tests: [`src/sketches/uniform/wire.rs`](../src/sketches/uniform/wire.rs)
 
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
@@ -397,12 +543,29 @@ Test file: [`src/sketches/uniform.rs`](../src/sketches/uniform.rs)
 | `merge_combines_samples_using_rate_based_target` | Merge combines samples using rate based target. | Merge behavior preserves expected aggregate semantics and internal invariants. |
 | `merge_rejects_different_rates` | Merge rejects different rates. | Merge behavior preserves expected aggregate semantics and internal invariants. |
 | `sample_access_is_stable` | Sample access is stable. | Core behavior for insert/query/update and deterministic semantics is validated. |
+| `uniform_sampling_round_trip_serialization` | The envelope frames a sampler under kind_id `0x0d 0x00`, and the state survives a round trip. | For a sampler at rate `0.25` seeded at `0xBEEF_FACE` over 40 updates, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x0d 0x00`, and that the decode matches on `sample_rate`, `total_seen`, `len`, and the retained samples. |
+| `uniform_sampling_re_encodes_byte_identically` | The priorities are payload state, not derived. | For a sampler at rate `0.5` seeded at `0xFACE_FACE` over 33 updates, verifies the decoded sampler re-serializes to the bytes it came from. |
+| `uniform_sampling_rng_state_resumes_the_same_sequence` | The payload carries the RNG position, so a decode resumes the same draws. | Feeds the same 40 further updates to a rate-`0.3` sampler and to its decoded copy, and verifies they agree on the samples, on `total_seen`, and on their re-serialized bytes. |
+| `uniform_sampling_empty_round_trip_has_exactly_one_encoding` | An empty sampler has one encoding for a given rate and RNG position. | Verifies a rate-`0.1` sampler seeded at `0xABC1` decodes back empty with `total_seen` `0` and its rate intact, and that its bytes equal both a fresh twin's and the decoded sampler's re-serialization. |
+| `uniform_sampling_rejects_foreign_kind_id` | Another sketch's kind_id is refused. | Verifies a `3x8` Count-Min envelope fails to decode as a `UniformSampling`. |
+| `us_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the three `UsMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `UsMetadata`. |
+| `us_metadata_rejects_a_missing_item_type_key` | `item_type` is required and can never be silently defaulted. | Encodes a named map holding only `metadata_version` and `sample_rate` and verifies it does not decode as `UsMetadata`. |
+| `us_metadata_rejects_a_foreign_item_type_name` | Samples are `f64`, and no other `item_type` name decodes. | Wraps an `i64`-labelled metadata around a one-sample payload and verifies it does not decode. |
+| `uniform_sampling_rejects_an_out_of_range_sample_rate` | A rate outside `(0, 1]` is refused before it reaches `target_size`. | Verifies crafted envelopes at rates `0.0`, `-0.5`, `1.5`, `NaN`, and infinity each fail rather than panic. |
+| `uniform_sampling_huge_declared_stream_costs_two_samples` | The declared stream length never sizes an allocation. | Verifies a payload declaring `total_seen` `u64::MAX` beside two samples decodes to a sampler holding exactly those two. |
+| `uniform_sampling_rejects_more_samples_than_the_rate_allows` | Retaining more than the rate allows is not a state the algorithm reaches. | Verifies a payload of three samples at `total_seen` `2` and rate `0.5` fails to decode. |
+| `uniform_sampling_rejects_parallel_array_length_mismatch` | The two payload arrays are parallel. | Verifies a payload of three priorities against two values fails to decode. |
+| `uniform_sampling_rejects_unordered_priorities` | Entries are held in ascending priority, with ties broken by the value. | Verifies a payload of priorities `[9, 2, 5]` fails to decode, and that one with equal priorities whose values run `[8.0, 1.0]` fails too. |
+| `uniform_sampling_rejects_crafted_bytes_without_panicking` | Truncated, foreign and garbage bytes are errors, never panics. | Verifies six truncations of a valid envelope, 64 bytes of `0xff`, and a valid envelope carrying a garbage payload all fail to decode. |
+| `uniform_sampling_rejects_serializing_an_over_full_sampler` | The encode side refuses a sampler its own decoder would reject. | Verifies a sampler holding two samples whose `total_seen` is set to `1` fails to serialize. |
 
 ## Sketch Frameworks
 
 ### Hydra
 
 Test file: [`src/sketch_framework/hydra.rs`](../src/sketch_framework/hydra.rs)
+
+Wire tests: [`src/sketch_framework/hydra/wire.rs`](../src/sketch_framework/hydra/wire.rs)
 
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
@@ -423,6 +586,22 @@ Test file: [`src/sketch_framework/hydra.rs`](../src/sketch_framework/hydra.rs)
 | `test_merge_counters` | Test merge counters. | Merges two CM counters and verifies frequency sum (`2.0`) for shared key, then confirms merging with mismatched counter type (`HLL`) returns error. |
 | `test_count_frequency_query` | Test count frequency query. | Inserts one `Count` key four times and verifies `Frequency` query succeeds with exact result `4.0`. |
 | `test_count_invalid_query_types` | Test count invalid query types. | Verifies unsupported `Count` queries fail, including exact `Quantile` error message and error on `Cardinality`. |
+| `hydra_count_min_round_trip_serialization` | A Count-Min grid round-trips under kind_id `0x07 0x01`. | For a `3x8` grid of `2x16` fast-path Count-Min counters over a two-column schema fed 30 records, verifies the envelope names that kind_id, that the grid and counter dimensions and the schema survive, that three frequency probes answer identically, and that the decode re-serializes to the same bytes. |
+| `hydra_count_sketch_round_trip_serialization` | A Count Sketch grid round-trips under kind_id `0x07 0x02`. | Runs the same round trip over `2x16` fast-path Count Sketch counters and the same three frequency probes. |
+| `hydra_hyperloglog_round_trip_serialization` | An HLL grid round-trips under kind_id `0x07 0x03`. | Runs the same round trip over `HyperLogLog<ErtlMLE>` counters fed 300 records, probing two cardinality queries. |
+| `hydra_kll_round_trip_serialization` | A KLL grid round-trips under kind_id `0x07 0x00`. | Runs the same round trip over default `KLL` counters fed 300 records, probing two quantiles and a CDF. |
+| `hydra_univmon_round_trip_serialization` | A UnivMon grid round-trips under kind_id `0x07 0x04`. | Runs the same round trip over `UnivMon::init_univmon(4, 2, 16, 3)` counters fed 120 records, probing L1, L2, entropy, and cardinality. |
+| `hydra_count_sketch_negative_cells_round_trip` | Signed cells reach the wire and come back unchanged. | Verifies the Count Sketch grid holds a negative counter and that every cell of every counter matches after a decode. |
+| `hydra_schema_round_trips_exactly` | The key columns round-trip exactly, escaping included. | For a grid whose two labels carry a semicolon, a colon, and a backslash and whose subkeys carry a semicolon, verifies the round trip preserves both frequency probes' answers and that the decoded schema equals the labels. |
+| `hydra_variants_reject_each_others_envelopes` | Each variant's decoder owns exactly one kind_id. | Runs all five per-variant decoders against all five variants' envelopes and verifies each succeeds only on its own, and that a plain `2x16` Count-Min envelope is refused by every decoder and by `deserialize_from_bytes`. |
+| `hydra_rejects_a_mixed_variant_grid` | A grid mixing counter variants has no encoding. | Replaces one cell of a Count-Min grid with an HLL counter and verifies serialization fails with a complaint naming `cell (1, 1)` and both counter types. |
+| `hydra_rejects_serializing_an_inconsistent_grid` | The encode side refuses states its own decoder would reject. | Verifies four Count-Min grids each fail to serialize: one whose `row_num` is `4` against its storage, one whose grid is an unfilled `Vector2D::init(3, 8)`, one holding a `2x8` cell against a `2x16` prototype, and one whose `type_to_clone` holds data. |
+| `hydra_univmon_rejects_cells_mixing_key_variants` | A UnivMon grid whose cells hold different `HeapItem` variants has no single `counter_key_type`. | Seats a string-keyed UnivMon in a `u64`-keyed grid and verifies serialization fails with a "mix key variants" complaint. |
+| `hydra_rejects_crafted_geometry` | Every declared count is measured against the payload before anything is sized from it. | Verifies seven crafted Count-Min metadata shapes each fail with their own complaint - `1024x1024`, `u32::MAX` by `u32::MAX`, a zero grid row or column, a zero counter row or column, and a `4x16` counter against the payload - and that an empty schema fails too. |
+| `hydra_rejects_crafted_geometry_for_the_variable_counters` | The variable-length counters are cut by the same rule. | Verifies a `4096x4096` KLL grid declaration fails, and that a `4096x4096` UnivMon declaration and shapes carrying a zero `sketch_col`, `layer_size`, or `heap_size` each fail too. |
+| `hydra_metadata_rejects_unknown_and_missing_keys` | An unexpected metadata key and a missing required one both fail closed. | Encodes the fourteen `HydraMatrixMetadata` fields plus a `bogus_field`, and the same fields with `schema` omitted, and verifies neither decodes as `HydraMatrixMetadata`. |
+| `hydra_cell_envelopes_mirror_the_counters_own_bytes` | A cell's inlined state is exactly that counter's own payload. | Verifies the HLL, KLL, and UnivMon cell envelopes built from a cell's state equal the bytes those counters serialize to on their own. |
+| `hydra_pins_its_hash_profile` | Hydra hashes its subkeys through the crate default, so it has one truthful profile. | Verifies a Count-Min grid emits `DefaultXxHasher`'s profile id and seed list, and that the same payload re-framed under a custom profile is different bytes that fail to decode. |
 
 ### HashSketchEnsemble
 
@@ -447,6 +626,8 @@ Test file: [`src/sketch_framework/hashlayer.rs`](../src/sketch_framework/hashlay
 
 Test file: [`src/sketch_framework/univmon.rs`](../src/sketch_framework/univmon.rs)
 
+Wire tests: [`src/sketch_framework/univmon/wire.rs`](../src/sketch_framework/univmon/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `univmon_round_trip_serialization` | Univmon round trip serialization. | After weighted inserts, verifies non-empty serialization and round-trip preservation of configuration fields, `bucket_size`, `L1/L2/entropy` (`<1e-6` drift), and cardinality (`< EPSILON` drift). |
@@ -457,11 +638,21 @@ Test file: [`src/sketch_framework/univmon.rs`](../src/sketch_framework/univmon.r
 | `univmon_bucket_size_tracked_correctly` | Univmon bucket size tracked correctly. | Inserts counts `100`, `200`, `150` for three flows and verifies `bucket_size` equals total `450`. |
 | `univmon_basic_operation` | Univmon basic operation. | On fixed mixed workload, verifies exact aggregate metrics `cardinality=10.0` and `L1=131.0`. |
 | `test_statistical_accuracy` | Test statistical accuracy. | On heavy/medium/noise synthetic distribution, verifies relative error for both `L2` and `entropy` is below `0.15`. |
-| `univmon_random_data_matches_ground_truth_within_five_percent` | Univmon random data matches ground truth within five percent. | Over `10_000` random weighted updates, requires relative error `<= 0.05` for `cardinality`, `L1`, `L2`, and `entropy` against exact truth map. |
+| `univmon_random_data_matches_ground_truth_within_configured_tolerance` | Random weighted updates keep every metric inside its own tolerance. | Over `10_000` seeded random weighted updates across 5,000 keys into `init_univmon(256, 6, 8192, 16)`, requires relative error against the exact truth map at or under `0.07` for cardinality and at or under `0.05` for `L1`, `L2`, and entropy. |
+| `univmon_layers_with_different_heap_loads_round_trip` | Each layer's heap contents and emitted order survive the round trip. | For an `init_univmon(8, 2, 16, 4)` pyramid fed 40 weighted keys, verifies the layers carry different heap loads, that every layer's length, capacity of `8`, and per-key counts match after a decode, and that the bytes re-serialize identically. |
+| `univmon_carries_update_mode_and_candidate_flags` | `update_mode` and `candidate_complete` are state, not derived. | For a terminal-only `init_univmon(2, 2, 8, 3)` pyramid fed 20 keys through `fast_insert`, verifies the payload carries `update_mode` `2`, that the decode preserves the candidate flags, cardinality, and entropy and re-serializes identically, and that forcing every flag true changes what the pyramid reports. |
+| `univmon_empty_has_one_encoding` | An empty pyramid has exactly one encoding. | Verifies a fresh `init_univmon(4, 2, 16, 3)` pyramid and one freed after an insert serialize to identical bytes carrying the pinned `EMPTY_KEY_TYPE`, and that the decode holds empty heaps and re-serializes identically. |
+| `univmon_pins_its_hash_profile` | UnivMon hashes through the crate default, so it has one truthful profile. | Verifies a populated pyramid emits `DefaultXxHasher`'s profile id and seed list, and that the same payload re-framed under a custom profile is different bytes that fail to decode. |
+| `univmon_rejects_foreign_kind_ids` | The neighbouring universal-sketch kind_ids are refused. | Verifies `Count`, `CountL2HH`, `UnivMonPyramid`, and `UnivMonQ` envelopes each fail to decode as a `UnivMon`. |
+| `univmon_rejects_crafted_shapes` | Every shape rule fires before an allocation is sized from it. | Verifies six crafted metadata shapes fail - a `layer_size` of `u32::MAX` or `0`, a zero `sketch_col` or `heap_size`, a `4096x4096` sketch, and a `heap_size` of `1` - and that a short `heap_counts`, a short `candidate_complete`, and an `update_mode` of `7` each fail too. |
+| `univmon_rejects_serializing_an_inconsistent_pyramid` | The encode side refuses states its own decoder would reject. | Verifies a layer resized to `2x32` and a layer hashing at another layer's seed index each fail to serialize while the matching `2x16` layer at its own index serializes, and that a pyramid whose heap mixes key variants fails with a "keys mix variants" complaint while a 128-bit key fails outright. |
+| `univmon_metadata_rejects_unknown_and_missing_keys` | An unexpected metadata key and a missing required one both fail closed. | Encodes the eleven `UnivMonMetadata` fields plus a `bogus_field`, and the same fields with `key_type` omitted, and verifies neither decodes as `UnivMonMetadata`. |
 
 ### UnivMon Optimized
 
 Test file: [`src/sketch_framework/univmon_optimized.rs`](../src/sketch_framework/univmon_optimized.rs)
+
+Wire tests: [`src/sketch_framework/univmon_optimized/wire.rs`](../src/sketch_framework/univmon_optimized/wire.rs)
 
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
@@ -475,6 +666,35 @@ Test file: [`src/sketch_framework/univmon_optimized.rs`](../src/sketch_framework
 | `pyramid_accuracy_zipf` | Pyramid accuracy Zipf. | On heavy/medium/light Zipf-like workload, requires relative error `<15%` for `L1`, `L2`, cardinality, and entropy. |
 | `pyramid_fast_insert_accuracy` | Pyramid fast insert accuracy. | Using `fast_insert` only, requires relative error `<15%` for `L1`, `L2`, cardinality, and entropy versus exact frequency map. |
 | `pyramid_memory_savings_vs_uniform` | Pyramid memory savings vs uniform. | Verifies pyramid column budget is smaller than uniform baseline and computed memory savings exceed `30%`. |
+| `pyramid_round_trip_serialization` | The envelope frames a pyramid under kind_id `0x11 0x00`, and the bytes are stable across a round trip. | For `UnivMonPyramid::new(4, 2, 3, 16, 2, 8, 4)` fed four weighted string keys, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x11 0x00`, that the metadata carries that layout and `key_type` `string`, and that the decode matches on `bucket_size`, L1, L2, cardinality, entropy, and the candidate flags, re-serializing identically. |
+| `pyramid_two_tier_geometry_survives` | The two tiers are derived from the layer's position. | Verifies every decoded layer keeps its tier's dimensions - `3x16` for the two elephant layers and `2x8` for the mouse layers - its own seed index, and its counter array. |
+| `pyramid_layers_with_different_heap_loads_round_trip` | Each layer's heap contents survive the round trip. | For `UnivMonPyramid::new(8, 2, 3, 32, 2, 16, 4)` fed 40 weighted keys, verifies the layers carry different heap loads, that every layer's length and per-key counts match after a decode, and that the bytes re-serialize identically. |
+| `pyramid_without_mouse_layers_round_trips` | The one-tier case still round-trips. | For a pyramid whose four layers are all elephants, verifies the decoded layers all read `2x16` and the bytes re-serialize identically. |
+| `pyramid_empty_has_one_encoding` | An empty pyramid has exactly one encoding. | Verifies a fresh pyramid and one freed after an insert serialize to identical bytes carrying a `key_type` of `u64`, and that the decode re-serializes identically. |
+| `pyramid_carries_update_mode_and_candidate_flags` | `update_mode` and `candidate_complete` are state, not derived. | For a terminal-only `UnivMonPyramid::new(2, 1, 2, 8, 2, 8, 3)` fed 20 keys through `fast_insert`, verifies the payload carries `update_mode` `2` and that the decode preserves the candidate flags and cardinality and re-serializes identically. |
+| `pyramid_pins_its_hash_profile` | The pyramid hashes through the crate default, so it has one truthful profile. | Verifies a populated pyramid emits `DefaultXxHasher`'s profile id and seed list, and that the same payload re-framed under a custom profile is different bytes that fail to decode. |
+| `pyramid_rejects_foreign_kind_ids` | The neighbouring universal-sketch kind_ids are refused. | Verifies `Count`, `CountL2HH`, `UnivMon`, and `UnivMonQ` envelopes each fail to decode as a `UnivMonPyramid`. |
+| `pyramid_rejects_crafted_shapes` | Every layout rule fires before an allocation is sized from it. | Verifies six crafted metadata layouts fail - a `layer_size` of `u32::MAX` or `0`, a `heap_size` of `0` or `1`, a zero `elephant_col`, and a `4096x4096` mouse tier - and that a short `heap_lens` and an `update_mode` of `9` each fail too. |
+| `pyramid_rejects_serializing_an_inconsistent_layout` | The encode side refuses states its own decoder would reject. | Verifies a mouse layer holding the elephant tier's `3x16` dimensions fails to serialize, and that a layer hashing at another layer's seed index fails too. |
+| `pyramid_metadata_rejects_unknown_and_missing_keys` | An unexpected metadata key and a missing required one both fail closed. | Encodes the fourteen `PyramidMetadata` fields plus a `bogus_field`, and the same fields with `mouse_col` omitted, and verifies neither decodes as `PyramidMetadata`. |
+
+### UnivMon-Q
+
+Test file: [`src/sketch_framework/univmon_q.rs`](../src/sketch_framework/univmon_q.rs)
+
+Wire tests: [`src/sketch_framework/univmon_q/wire.rs`](../src/sketch_framework/univmon_q/wire.rs)
+
+| test_name | test_description | what_is_tested |
+| --- | --- | --- |
+| `univmon_q_round_trip_serialization` | The envelope frames a sketch under kind_id `0x1a 0x00`, and the bytes are stable across a round trip. | For a 4-level, 64-wide, depth-3 sketch seeded at `5` with source id `7` over 200 updates, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x1a 0x00`, that the metadata carries that shape, `counter_type` `i64`, and `seed_index` `5`, and that the decode matches on config, source id, `count`, `min`, `max`, `cdf`, and `estimate_f2`, re-serializing identically. |
+| `univmon_q_ordering_state_continues_after_a_round_trip` | The ordering state survives, so a decoded sketch draws the same occurrence priorities. | Feeds the same 400 further updates to a sketch built over 300 updates and to its decoded copy, and verifies they agree on `next_sequence`, on the sorted ordered heap, on `cdf`, and on their serialized bytes. |
+| `univmon_q_empty_has_one_encoding` | An empty sketch has exactly one encoding, and `min` and `max` travel as msgpack nil. | Verifies two fresh sketches at the same config and source id serialize identically with a payload `count` of `0` and no extrema, that a cleared sketch is deliberately different bytes since it keeps its occurrence sequence, and that the decode is empty and re-serializes identically. |
+| `univmon_q_counter_type_is_pinned` | The counter width is pinned by `counter_type`. | Verifies a 32-bit-counter sketch emits `counter_type` `i32` and decodes with its `estimate_f2` intact, that its bytes differ from the 64-bit sketch's over the same 50 updates, and that relabelling the metadata `f64` makes the decode fail. |
+| `univmon_q_custom_hasher_profile_round_trips_and_is_self_describing` | The metadata describes the hasher that built the sketch rather than a hardcoded profile. | For a sketch over a hasher declaring its own `HashProfile`, verifies `estimate_f2` round-trips, the bytes differ from the standard-profile sketch's over the same 100 updates, and a standard-profile decode rejects them. |
+| `univmon_q_rejects_foreign_kind_ids` | The neighbouring universal-sketch kind_ids are refused. | Verifies `Count`, `CountL2HH`, `UnivMon`, and `UnivMonPyramid` envelopes each fail to decode as a `UnivMonQ`. |
+| `univmon_q_rejects_crafted_shapes` | Every shape rule fires before an allocation is sized from it. | Verifies seven crafted configs fail - `levels` of `63` or `1`, a `width` of `u32::MAX`, a `depth` of `4`, zero `candidates` or `ordered_samples`, and another `hash_seed` - and that a short `candidate_scores`, a short `ever_evicted`, a missing `min`, swapped extrema, a short `occurrence_keys`, and reversed `candidate_keys` each fail too. |
+| `univmon_q_rejects_serializing_an_inconsistent_state` | The encode side refuses states its own decoder would reject. | Verifies a level whose `PackedCountSketch` is not the config's size, a `count`/`min`/`max` triple the algorithm cannot reach, and a candidate table over its declared capacity each fail to serialize. |
+| `univmon_q_metadata_rejects_unknown_and_missing_keys` | An unexpected metadata key and a missing required one both fail closed. | Encodes the fourteen `UnivMonQMetadata` fields plus a `bogus_field`, and the same fields with `counter_type` omitted, and verifies neither decodes as `UnivMonQMetadata`. |
 
 ### NitroBatch
 
@@ -489,6 +709,8 @@ Test file: [`src/sketch_framework/nitro.rs`](../src/sketch_framework/nitro.rs)
 
 Test file: [`src/sketch_framework/eh.rs`](../src/sketch_framework/eh.rs)
 
+Wire tests: [`src/sketch_framework/eh/wire.rs`](../src/sketch_framework/eh/wire.rs)
+
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `constructor_infers_merge_norm` | Constructor infers merge norm. | Verifies constructor infers `SketchNorm::L1` for CM payload and `SketchNorm::L2` for `COUNTL2HH` payload. |
@@ -496,10 +718,27 @@ Test file: [`src/sketch_framework/eh.rs`](../src/sketch_framework/eh.rs)
 | `l2_merge_invariant_sum_l22` | L2 merge invariant sum l22. | With `k=1` and weighted updates, verifies L2 merge rule keeps bucket count bounded (`bucket_count <= 2`). |
 | `merge_recomputes_l2_mass` | Merge recomputes L2 mass. | After L2 merges, verifies bounded bucket count (`<=2`) and non-negative recomputed `l2_mass` for every payload bucket. |
 | `test_basic_insertion_and_query` | Test basic insertion and query. | After one update at `t=100`, verifies single bucket presence, exact min/max timestamps (`100`), and successful interval merge query for `[100,100]`. |
+| `eh_round_trip_serialization` | The envelope frames a histogram under kind_id `0x13 0x00`, and the state survives a round trip. | For `k = 2` over a 1,000-tick window of Count-Min buckets fed six timestamped updates, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x13 0x00`, and that the decode matches on `window`, `k`, `merge_norm`, every bucket's size, time range, and bit-exact `l2_mass`, and the bucket count. |
+| `eh_every_variant_round_trips_as_a_bucket` | Every variant this build carries round-trips as a bucket and as the prototype. | For each populated variant, builds a `k = 3` histogram over four timestamped updates and verifies the decoded prototype keeps its `sketch_type`, the bucket ranges match, and the bytes are stable across a re-serialization. |
+| `eh_empty_has_one_encoding_and_round_trips` | A histogram with no buckets has exactly one encoding. | Verifies two `k = 2` histograms over the same Count-Min prototype serialize identically and that the decode holds a bucket count of `0` and re-serializes to the same bytes. |
+| `eh_carries_a_non_empty_prototype` | A prototype carrying state keeps it, so later buckets start from it. | For a prototype fed seven inserts of one key, verifies the decoded prototype answers that key as the source does and at or above `7.0`. |
+| `eh_decoded_re_serializes_byte_identically_and_queries_agree` | A decoded histogram re-encodes exactly and answers the same interval query. | Verifies the populated histogram's decode re-serializes to the bytes it came from and that `query_interval_merge(0, 50)` answers the same key identically on both. |
+| `eh_rejects_foreign_kind_ids` | An `EHSketchList` envelope and a Count-Min envelope are not histogram envelopes. | Verifies both fail to decode as an `ExponentialHistogram`. |
+| `eh_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes the three `EhMetadata` fields plus a `bogus_field` as a named map and verifies it does not decode as `EhMetadata`. |
+| `eh_metadata_rejects_a_missing_key` | `k` is required and can never be silently defaulted. | Encodes a named map holding only `metadata_version` and `window` and verifies it does not decode as `EhMetadata`. |
+| `eh_rejects_a_zero_k` | `k` is at least `1` on both sides. | Verifies a histogram whose `k` is set to `0` fails to serialize, and that a valid payload re-framed under metadata declaring `k` `0` fails to decode. |
+| `eh_rejects_parallel_arrays_of_unequal_length` | A declared array far longer than the buckets carried is refused before anything is sized from it. | Verifies a payload of one bucket against a `sizes` array of a million entries fails to decode. |
+| `eh_rejects_impossible_bucket_state` | A zero size and an inverted time range are states the algorithm never reaches. | Verifies a crafted bucket of size `0` and one spanning `[9, 4]` each fail to decode, and that a histogram whose first bucket's size is set to `0` fails to serialize. |
+| `eh_rejects_derived_fields_that_disagree` | A cached field that disagrees with the state it derives from has no encoding. | Verifies a histogram whose first bucket's `l2_mass` is set to `42.0` fails to serialize, and that one whose `merge_norm` is switched to `L2` over Count-Min buckets fails too. |
+| `eh_rejects_an_experimental_kind_id_in_a_bucket` | An experimental variant's kind_id in a bucket is refused without the feature. | Verifies crafted buckets relabelled with the `Coco`, `Elastic`, and `UniformSampling` kind_ids each fail to decode, with a message naming the variant and "experimental" in builds without the feature. |
+| `eh_rejects_a_custom_hash_profile_bucket` | A bucket naming a custom hash profile is refused, since the variant's decoder pins the profile of the type it rebuilds. | Verifies a bucket whose descriptor comes from a custom-profile Count-Min fails to decode. |
+| `eh_rejects_an_unknown_kind_id_in_a_bucket` | An unknown kind_id in a bucket is refused. | Verifies a bucket relabelled `0xff 0xff` fails with a "not a wire variant" complaint. |
 
 ### EHSketchList
 
 Test file: [`src/sketch_framework/eh_sketch_list.rs`](../src/sketch_framework/eh_sketch_list.rs)
+
+Wire tests: [`src/sketch_framework/eh_sketch_list/wire.rs`](../src/sketch_framework/eh_sketch_list/wire.rs)
 
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
@@ -507,6 +746,19 @@ Test file: [`src/sketch_framework/eh_sketch_list.rs`](../src/sketch_framework/eh
 | `count_sketch_insert_and_query_round_trip` | Count insert and query round trip. | Confirms the `Count` variant updates/query path by inserting one key and verifying returned estimate is at least `1.0`. |
 | `ddsketch_insert_and_quantile_query_round_trip` | DDSketch insert and quantile query round trip. | Inserts `10,20,30` into DDSketch variant and verifies queried median (`q=0.5`) lies within `[10.0, 30.0]`. |
 | `supports_norm_whitelist_is_enforced` | Supports norm whitelist is enforced. | Validates norm capability matrix: `CM/CS/DDS` support `L1` only, while `COUNTL2HH/UNIVMON` support `L2` only. |
+| `eh_sketch_list_round_trip_serialization` | The envelope frames a union under kind_id `0x14 0x00`, and the state survives a round trip. | For a `3x8` fast-path Count-Min variant holding one key, verifies the bytes open with the ASAPv1 magic, a `kind_id_len` of `2`, and `0x14 0x00`, and that the decode keeps a `sketch_type` of `CountMin` and answers that key as the source does. |
+| `eh_sketch_list_every_variant_round_trips` | Every variant this build carries round-trips and keeps its type. | For each populated variant, verifies the decode reports the same `sketch_type` and re-serializes to the bytes it came from. |
+| `eh_sketch_list_kind_ids_are_build_independent` | The ten nested kind_ids and their registry names are the same in every build. | Verifies `variant_name` maps each of the ten ids to its name and `0xff 0xff` to `None`, and that every populated variant emits the id the table gives it. |
+| `eh_sketch_list_rejects_an_experimental_kind_id` | An experimental variant's kind_id is refused without the feature. | Verifies crafted triples carrying the `Coco`, `Elastic`, and `UniformSampling` kind_ids each fail to decode, with a message naming the variant and "experimental" in builds without the feature. |
+| `eh_sketch_list_rejects_an_unknown_kind_id` | An unknown kind_id is refused. | Verifies a Count-Min triple relabelled `0xff 0xff` fails with a "not a wire variant" complaint. |
+| `eh_sketch_list_rejects_sibling_algorithm_kind_ids` | The nested ids are pinned to one algorithm each. | Verifies an HLL triple relabelled `0x01 0x01` or `0x01 0x03` fails to decode, and that a KLL triple relabelled `0x06 0x01` fails too. |
+| `eh_sketch_list_rejects_a_mismatched_kind_id_and_descriptor` | A kind_id that does not match the blocks it carries is refused by the variant's own decoder. | Verifies an HLL triple relabelled with the Count-Min kind_id fails to decode. |
+| `eh_sketch_list_rejects_foreign_kind_ids` | A Count-Min envelope and an `ExponentialHistogram` envelope are not union envelopes. | Verifies both fail to decode as an `EHSketchList`. |
+| `eh_sketch_list_metadata_rejects_unknown_keys` | An unexpected metadata key fails closed. | Encodes `metadata_version` plus a `bogus_field` as a named map and verifies it does not decode as `EhSketchListMetadata`. |
+| `eh_sketch_list_metadata_rejects_a_missing_key` | `metadata_version` is required. | Encodes an empty named map and verifies it does not decode as `EhSketchListMetadata`. |
+| `eh_sketch_list_rejects_crafted_blocks` | Crafted blocks fail closed with an error, never a panic. | Verifies a Count-Min triple whose descriptor is cut in half, and one whose state is three `0xc1` bytes, each fail to decode. |
+| `eh_sketch_list_rejects_a_custom_hash_profile_descriptor` | A descriptor naming a custom hash profile is refused, since the variant's decoder pins the profile of the type it rebuilds. | Verifies a triple built from a custom-profile Count-Min fails to decode. |
+| `eh_sketch_list_query_agrees_after_decode` | A decoded union answers a query the way the original did. | For every populated variant, verifies the source and the decode return the same answer for that variant's sample input. |
 
 ### EHUnivOptimized
 
@@ -546,7 +798,6 @@ Test file: [`src/common/hash.rs`](../src/common/hash.rs)
 | `hash128_seeded_preserves_cardinality` | Hash128 seeded preserves cardinality. | With `SEED_IDX=0` and `SAMPLE_SIZE=5000`, verifies uniform and Zipf sample unique-input counts exactly match unique-hash counts (no observed collisions). |
 | `hash128_seeded_is_deterministic_for_repeated_inputs` | Hash128 seeded is deterministic for repeated inputs. | For fixed key `"deterministic-key"` and seed `3`, verifies 100 repeated `hash128_seeded` calls always equal the first hash value. |
 | `digest_hasher_spreads_digests_that_share_their_low_bits` | `DigestHasher` mixes rather than passing a digest through. | Hashes `0..1024` shifted left by 16, so every digest shares its ten low bits, and verifies more than 550 of the 1,024 low-bit buckets are occupied rather than the single bucket a pass-through hash would fill; the unshifted range is held to the same bound. |
-| `digest_hasher_is_deterministic` | `DigestHasher` returns the same value for the same digest. | For `0`, `1`, `u64::MAX`, and `0xdead_beef`, verifies repeated calls agree, and that `0` and `1` hash differently. |
 
 ### Common Heap Utilities
 


### PR DESCRIPTION
Folds the eleven merged wire-payload PRs' §3.x spec drafts into
`docs/asapv1_wire_format.md`, and brings the shared docs in line with what
shipped. Documentation only: no `.rs` file is touched.

## Section numbering

§3.1–§3.6 keep their numbers, since the doc and source doc-comments cross-
reference them. The new sections append in kind_id order:

| § | Kind | kind_id |
| --- | --- | --- |
| 3.7 | CMSHeap (and the shared top-k heap encoding) | `0x03 0x00` |
| 3.8 | DDSketch | `0x05 0x00` |
| 3.9 | Hydra, five counter variants | `0x07 0x00`–`0x07 0x04` |
| 3.10 | CSHeap | `0x0a 0x00` |
| 3.11 | Elastic | `0x0b 0x00` |
| 3.12 | Coco | `0x0c 0x00` |
| 3.13 | UniformSampling | `0x0d 0x00` |
| 3.14 | KMV | `0x0e 0x00` |
| 3.15 | UnivMon | `0x10 0x00` |
| 3.16 | UnivMon Optimized | `0x11 0x00` |
| 3.17 | ExponentialHistogram | `0x13 0x00` |
| 3.18 | EHSketchList | `0x14 0x00` |
| 3.19 | CountL2HH | `0x19 0x00` |
| 3.20 | UnivMon-Q | `0x1a 0x00` |
| 3.21 | payloads not yet designed | — |

The shared top-k heap encoding lives inside §3.7, the lowest kind_id that uses
it; §3.10 and §3.15 reference it there. Every `§3.` reference in `docs/` and
`src/` was re-checked — see "Follow-ups" for the three in `.rs` files that need
a code-owner's touch.

## Where a draft disagreed with the shipped code

The code won in each case.

- **PR #115, CMSHeap counter types.** The draft said the wire covers `"i64"` and
  `"f64"`. `CmsWireCounter` is implemented for `i32`, `i64` and `f64`
  (`src/sketches/countminsketch/wire.rs:37-45`), and `CMSHeap`'s impl is bounded
  on that trait, so `"i32"` is a CMSHeap `counter_type`. §3.7 says so, and the
  same stale claim is corrected in `docs/api/api_cms_heap.md`.
- **PR #115, §3.5 cross-reference.** The draft's `key_type` table duplicated
  §3.5's thirteen names. §3.7 references §3.5 rather than restating them.
- **PR #118, heap-order cross-reference.** The UnivMon draft cites "§3.5" for
  the `heap_wire` comparator; that comparator is §3.7's. Corrected.
- **PR #111, decode-rule order.** The draft lists the metadata pin before the
  `sample_rate` range check; the code checks the range first, and lists the
  ordering check after the length and retention-bound checks. §3.13 follows the
  code.
- **PR #120, Hydra rule 4.** The draft says every counter dimension is checked
  non-zero. `decode_kll` has no explicit `counter_k` / `counter_m` check — KLL's
  own decoder enforces those. §3.9 rule 3 scopes the check to the variants that
  make it and rule 6 covers the delegated ones.
- **PR #120, `schema` validation order.** The draft implies `schema` is
  re-validated before the grid is built; it is the last struct-literal field, so
  it runs after. §3.9 lists it as rule 7, after the sizing rules.
- **PR #119, EH encode side.** The draft claims the parallel-length rule is
  enforced on encode. It is not, and needs no check: the four arrays are built
  from one walk of the bucket vector. §3.17 says that.
- **PR #114, KMV encode side.** The draft says the full strict-ascent rule is
  enforced on encode; the encoder sorts and then rejects only a duplicate.
- **PR #119 superseded by #121**, as briefed: §3.18 carries the nested variant's
  `kind_id` bytes, not a name string.

## The stale round

- **Orphaned Section 1 prose** applied verbatim.
- **Registry** rebuilt from the code: every row's algorithm variant, section and
  status. `(Unstable)` dropped from Coco and Elastic only.
- **Top-of-document Status** lists every implemented kind.
- **Mermaid diagram**: kept as four `PAYLOAD` branches, relabelled
  `example-kind-…`, with a sentence above it saying they are four examples and
  that Section 3 and the registry are the complete list. A twenty-branch diagram
  would not be readable, and an unlabelled four-branch one was the actual
  problem.
- **Count-Min `i32`**: the §3.6 and §3.5 "widens" claims and §4's `counts`
  element rule are corrected, along with §3.4's "i64/f64 counters" aside.
- **`hydra_seed_index` / `univmon_bottom_layer_seed_index`** removed from the §2
  tables and the reference-profile block. `HashProfile` declares only
  `CANONICAL_SEED_INDEX` and `MATRIX_SEED_INDEX`; neither key appears in any
  `.rs` file, and every metadata struct is `deny_unknown_fields`, so a map
  carrying one would be rejected. §2 now states the rule that replaces them. The
  alternative is a `HashProfile` constant per index, which is a code change and
  out of scope here.
- **§3.7's "likely payload" table** keeps only the eight genuinely undesigned
  kinds, as §3.21. The Hydra row is gone.
- **Decisions (resolved)** gains twelve entries: `Q-NEST`, `Q-NEST-HET`,
  `Q-NEST-GATE`, `Q-HYDRA-IDS`, `Q-NOHASH`, `Q-SEEDIDX`, `Q-ORDER`, `Q-CAP`,
  `Q-KEYTYPE`, `Q-DERIVED`, `Q-NIL`, `Q-RNG`, `Q-UNIVMON-SCOPE`.

## docs/tests.md

`dds_serialization_round_trip` was the smaller half of the story: the row was
accurate but omitted the `sum()` assertion the test makes, so the doc side was
fixed. PR #116's deletions were already reconciled; the 17 stale rows found are
older rot (the dropped full-precision HLL accuracy tests, the removed DDSketch
distribution tests, two KMV helpers that were never tests, and a UnivMon test
that was renamed — that one is replaced rather than deleted).

218 rows were added for the wire-module tests, with `Wire tests:` links on 19
sections and new **CountL2HH** and **UnivMon-Q** sections. All 602 rows in the
file name a real `#[test]` fn. One pre-existing arithmetic error is fixed:
`Vector2D::init(2, 4)` reserves eight cells, not four.

## Other shared docs

- **`docs/message_pack_format.md`** — the converted list covers all 22 wire
  modules under both `src/sketches/` and `src/sketch_framework/`, names the two
  shared modules (`heap_wire.rs`, `l2hh_wire.rs`), records the non-hashing and
  nesting shapes, corrects the Count-Min `i32` claim, and scopes the parity
  claim to the six kinds that have a fixture. It also **ended with stray
  `</content></invoke>` tags committed on `main`** — removed.
- **`docs/library_map.md`** — knows about every `wire.rs`, adds `univmon_q.rs`
  and the uncatalogued modules, and drops `orchestrator/`, which does not exist.
- **`docs/features.md`** — Elastic, Coco, UniformSampling, CMSHeap/CSHeap and
  EHSketchList have built-in helpers; UnivMonQ's emit the envelope, not native
  MessagePack; ExponentialHistogram and UnivMon Optimized gain rows.
- **`asapv1_golden/README.md`** — states the coverage gap up front. **The
  fixtures are HLL / Count-Min / Count Sketch / KLL only — there are no Bloom or
  Space-Saving vectors**, so the gap is one wider than assumed. A stale `§5`
  cross-reference is corrected to Section 4.
- **`CHANGELOG.md`** — one Added entry for the fourteen payloads and one
  BREAKING Changed entry: bytes in the earlier serde-derived form do not decode,
  and the goldens do not yet guard the new kinds, so `portable` stays.

## Follow-ups for a code owner (not changed here)

- `src/sketches/uniform/wire.rs:63` says "ASAPv1 §3.8". Under this numbering
  §3.8 is DDSketch; UniformSampling is §3.13.
- `src/sketch_framework/univmon_q/wire.rs:139` and
  `src/sketches/countsketch_topk/l2hh_wire.rs:82` carry a literal `§3.x`
  placeholder; they are §3.20 and §3.19.
- `src/sketches/ddsketch/wire.rs:9,63` and `src/sketches/kmv/wire.rs:74` cite a
  bare `§3`; they are §3.8 and §3.14.

Nothing in `docs/apis.md`, `docs/api/api_coco.md` or `docs/api/api_elastic.md`
was touched. `docs/apis.md` still lists Coco and Elastic as `Unstable`, which
the parallel promotion PR is expected to change; the registry's `Unstable` note
is worded so both states read correctly.

## Verify

CI skips `docs/**` and `**/*.md`, so no Rust job runs. Checked locally:

- `git status --porcelain` — only the eight files above.
- `cargo fmt --all -- --check` — pass (tree unchanged).
- Every markdown table in every changed file has a consistent column count.
- Every internal anchor link in every changed file resolves.
- No `§3.` reference in `docs/` is stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
