### PR TITLE
test(e2e): hold every sketch to its own error bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@ signals a backwards-compatible change.
   overflow-checked before anything is sized from it, and a container whose
   order does not survive a rebuild has its emitted order pinned, so a decoded
   sketch re-serializes byte-identically.
+- **Seeded constructors for the sketches whose randomness was wall-clock or
+  OS-drawn.** `KLLDynamic::init_with_seed` / `init_kll_with_seed`,
+  `NitroBatch::with_target_and_seed` / `init_nitro_with_seed`,
+  `KllSketch::with_seed` (and the free `new_sketchlib_kll_with_seed`) and
+  `HydraKllSketch::with_seed`, each mirroring the unseeded constructor beside
+  it. A KLL's compaction coin and a Nitro batch's geometric skip draw are the
+  only randomness those types hold, so fixing them makes the sketch a
+  deterministic function of its input — which is what reproducible replay,
+  cross-process parity and any assertion of an accuracy bound require.
+  `KLLDynamic` stores its seed so `clear()` re-seeds from it, as `KLL` already
+  did; the seed is not part of the wire format, since it describes how a sketch
+  was built rather than what it holds, so encoded bytes are unchanged.
+  `HydraKllSketch::with_seed` shares one seed across every cell.
 
 ### Changed
 
@@ -142,6 +155,16 @@ signals a backwards-compatible change.
   (Cargo convention: `y` is the major component pre-1.0).
 
 ### Fixed
+
+- **`ExponentialHistogram` no longer discards its payload when the bucket
+  sketch is an `Elastic`.** `EHSketchList::merge` had no `ELASTIC` arm, so the
+  catch-all returned `Cannot merge sketches of different types` for two Elastic
+  payloads — and `EHBucket::to_merge` drops that `Result`, so the histogram
+  went on summing bucket sizes while keeping only the counters of whichever
+  bucket it merged into. Every interval query then answered from a single
+  bucket: on a 10k-update Zipf stream each of the true top flows read 0 against
+  counts in the thousands. The arm is now present and delegates to
+  `Elastic::merge` like every other variant. No wire or API change.
 
 - **`HeapItem` now has an owned byte-array key, so `DataInput::Bytes` no longer
   goes through `String`.** `input_to_owned` decoded every byte array as UTF-8

--- a/docs/api/api_kll.md
+++ b/docs/api/api_kll.md
@@ -17,7 +17,16 @@ Approximate quantile estimation with rank-error guarantees.
 fn default() -> Self
 fn init_kll(k: i32) -> Self
 fn init(k: usize, m: usize) -> Self
+fn init_kll_with_seed(k: i32, seed: u64) -> Self
+fn init_with_seed(k: usize, m: usize, seed: u64) -> Self
 ```
+
+The unseeded constructors draw the compaction coin from the wall clock, so two
+runs over the same input produce different sketches. The `*_with_seed` forms
+fix the coin and store the seed, so `clear()` re-seeds from it too — use them
+for reproducible replay, cross-process parity, and any test asserting an
+accuracy bound. `KLLDynamic` exposes the same pair
+(`init_with_seed` / `init_kll_with_seed`).
 
 ## Insert/Update
 

--- a/docs/api/api_nitrobatch.md
+++ b/docs/api/api_nitrobatch.md
@@ -16,7 +16,16 @@ Batch-mode geometric sampling wrapper that updates a sketch target.
 ```rust
 fn init_nitro(rate: f64) -> Self
 fn with_target(rate: f64, sk: S) -> Self
+fn init_nitro_with_seed(rate: f64, seed: u64) -> Self
+fn with_target_and_seed(rate: f64, sk: S, seed: u64) -> Self
 ```
+
+Sampling is where all of Nitro's randomness lives: which updates reach the
+target sketch is drawn from the geometric skip distribution. `init_nitro` and
+`with_target` seed that RNG from the OS, so the admitted subset — and therefore
+every estimate — differs between runs. The `*_with_seed` forms make it a
+deterministic function of the input, which is what lets an accuracy bound be
+asserted reproducibly.
 
 ## Insert/Update
 

--- a/docs/e2e_coverage_matrix.md
+++ b/docs/e2e_coverage_matrix.md
@@ -1,0 +1,298 @@
+# E2E Coverage Matrix
+
+Which public instance is covered by which E2E test, against what ground truth,
+under which error metric, and whether the tolerance is a **theorem** or a
+**documented empirical band**.
+
+The distinction this document exists to make explicit:
+
+> having a test ≠ having an accuracy test ≠ correctly verifying a theoretical
+> guarantee.
+
+A row whose `error_metric` is `structural` asserts an exact property
+(serialization round trips, one-sided guarantees, merge equality, window
+bookkeeping) and needs no bound. A row marked `empirical` asserts measured
+behaviour and says so in its test name (`*_stays_within_the_documented_empirical_band`);
+it is never presented as theory. Everything else is a theorem, cited in the
+spec that computes it.
+
+## How to read the columns
+
+| Column | Meaning |
+| --- | --- |
+| `public_instance` | The concrete type a caller can construct |
+| `e2e_test` | Test function, in `tests/` |
+| `ground_truth` | Exact reference. Never another approximation |
+| `error_metric` | What is bounded — and it differs per family |
+| `bound_formula` | The formula evaluated at the instance's own parameters |
+| `confidence` | Per-check failure probability the bound is quoted at |
+| `deterministic_seed` | Stream seed / sketch seed. Both fixed, always |
+| `status` | `theorem`, `empirical`, `structural`, or `gap` |
+
+Acceptance rules live in [`tests/common/specs.rs`](../tests/common/specs.rs).
+Every probabilistic bound is judged by a binomial tail at a fixed test level
+(`TEST_LEVEL = 1e-6`), decided before the run: a battery of `n` checks with
+per-check failure probability `p` may show at most `c` violations, where `c` is
+the smallest count with `P[Bin(n, p) > c] <= 1e-6`. Tolerances are never
+adjusted to whatever the current run produced.
+
+## Error metrics, one per family
+
+The single most common way to have a test that verifies nothing is to check a
+sketch against another family's bound. These are the metrics in use:
+
+| Family | Metric | Formula | Source |
+| --- | --- | --- | --- |
+| Count-Min | one-sided **additive** | `est >= f` always; `P[est - f > e(N-f)/w] <= e^-d` | Cormode & Muthukrishnan 2005, Thm 1 |
+| Count Sketch | two-sided **L2**, rank-independent | `P[\|est-f\| > sqrt(kappa/w)*\|\|f_-i\|\|_2] <= P[Bin(d, 1/kappa) >= ceil(d/2)]`, `kappa=3` | Charikar, Chen & Farach-Colton 2002 |
+| F2 from a Count Sketch matrix | **relative**, AMS row-sum | `\|F2_hat/F2 - 1\| <= sqrt(2*kappa/w)`, same median amplification | Alon, Matias & Szegedy 1996 |
+| KLL | **rank** | `rank_incl(v) >= q - eps`, `rank_excl(v) <= q + eps`, `eps(k) = 2.446/k^0.9433` | Karnin, Lang & Liberty 2016; constant from the Apache DataSketches contract at 99% confidence |
+| DDSketch | **relative value** | `\|est - true\|/\|true\| <= alpha + ULP slack` vs the exact nearest-rank order statistic | Masson, Rim & Lee 2019 |
+| HLL Classic / ErtlMLE | **cardinality RSE** | `\|est/n - 1\| <= z * 1.04/sqrt(m)`, `m = 2^p` | Flajolet et al. 2007; Ertl 2017 attains the same CRLB |
+| HLL HIP | **cardinality RSE**, tighter | `\|est/n - 1\| <= z * sqrt(ln2/m)` | Cohen 2015; Ting 2014 |
+| KMV | **cardinality RSE** | exact for `n <= k`; `\|est/n - 1\| <= z/sqrt(k-1)` above | Bar-Yossef et al. 2002 |
+| Bloom | **no false negatives** + predicted FPP | exact membership; measured FPP vs the filter's own sizing | `tests/e2e_membership.rs` |
+| Nitro | **binomial sampling** | `\|est - f\| <= z*sqrt(f(1-p)/p)` | NitroSketch, SIGCOMM 2019 |
+| OctoSketch promotion | **deterministic residual** | `ref - k*tau <= octo <= ref` per counter | OctoSketch, NSDI 2024, Thm 1 |
+
+Three pairings that are specifically wrong and are now prevented by having
+separate spec types: Count Sketch under Count-Min's `eps*N`; KLL under a
+relative *value* tolerance; DDSketch inside a *rank* battery.
+
+## Matrix-backed frequency families
+
+Ten storage backends × two hashing paths. Each instance is judged at the
+dimensions **it** reports, so the fixed 5×2048 (`Quick*`) and 3×4096
+(`Default*`) layouts are not evaluated at a borrowed `w`.
+
+| public_instance | e2e_test | ground_truth | error_metric | bound_formula | confidence | deterministic_seed | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `CountMin<Vector2D<i32\|i64\|i128\|f64>, RegularPath>` | `countmin_regular_path_instances_satisfy_the_count_min_bound` | `FreqTruth` | additive one-sided | `e(N-f)/w` | `e^-d` | stream `0x10BEC700` | theorem |
+| `CountMin<…, FastPath>` (same 4) | `countmin_fast_path_instances_satisfy_the_count_min_bound` | `FreqTruth` | additive one-sided | `e(N-f)/w` | `e^-d` | stream `0x10BEC700` | theorem |
+| `CountMin<FixedMatrix\|DefaultMatrixI32\|QuickMatrixI64\|QuickMatrixI128\|DefaultMatrixI64\|DefaultMatrixI128, Regular\|Fast>` (12) | same two tests | `FreqTruth` | additive one-sided | `e(N-f)/w` | `e^-d` | stream `0x10BEC700` | theorem |
+| all 20 `CountMin` instances | `countmin_both_paths_are_exact_on_a_collision_free_workload` | exact counts | structural | `est == f` | — | 8 fixed keys | structural |
+| `CountMin<Vector2D<i64>, FastPath>` (production-sized) | `countmin_zipf_satisfies_the_count_min_additive_bound_and_shard_merge` | `FreqTruth` | additive one-sided + merge equality | `e(N-f)/w` | `e^-d` | stream `1001` | theorem |
+| `CountMin<Vector2D<i32>, Regular\|Fast>` over `U64`/`F64` inputs | `countmin_satisfies_the_count_min_theorem_on_both_paths` | `FreqTruth` | additive one-sided | `e(N-f)/w` | `e^-d` | 3 stream seeds from `1005` | theorem |
+| `Count<Vector2D<i32\|i64\|i128>, Regular\|Fast>` + 6 fixed storages (18) | `countsketch_{regular,fast}_path_instances_satisfy_the_l2_bound` | `FreqTruth` | L2, rank-independent | `sqrt(3/w)*\|\|f_-i\|\|_2` | `P[Bin(d,1/3) >= ceil(d/2)]` | stream `0x10BEC700` | theorem |
+| all 18 `Count` instances | `countsketch_both_paths_are_exact_on_a_collision_free_workload` | exact counts | structural | `est == f` | — | 8 fixed keys | structural |
+| `Count<Vector2D<i64>, RegularPath>` (production-sized) | `countsketch_turnstile_cancels_and_satisfies_the_l2_median_bound` | `FreqTruth` | L2 + exact cancellation | `sqrt(3/w)*\|\|f_-i\|\|_2` | as above | stream `1003` | theorem |
+| `Count<Vector2D<i32>, Regular\|Fast>`, pooled trials | `countsketch_satisfies_the_l2_median_bound_on_both_paths` | `FreqTruth` | L2 | `sqrt(3/w)*\|\|f_-i\|\|_2` | as above | 3 stream seeds from `1005` | theorem |
+| `Count<Vector2D<i64>, RegularPath>` | `countsketch_error_stays_rank_independent_within_the_documented_empirical_band` | `FreqTruth` deciles | mean \|error\| per frequency decile | spread ≤ 3× (measured 1.29×) | — | stream `1007` | empirical |
+| `CMSHeap<{Vector2D<i32>,Vector2D<i64>,FixedMatrix,DefaultMatrixI32,QuickMatrixI64,DefaultMatrixI64}, Regular\|Fast>` (12) | `cmsheap_{regular,fast}_path_instances_satisfy_the_count_min_bound` | `FreqTruth` | additive one-sided + heap consistency + recall | `e(N-f)/w` | `e^-d` | stream `0x10BEC700` | theorem |
+| `CSHeap<same 6 storages, Regular\|Fast>` (12) | `csheap_{regular,fast}_path_instances_satisfy_the_l2_bound` | `FreqTruth` | L2 + heap consistency + recall | `sqrt(3/w)*\|\|f_-i\|\|_2` | as above | stream `0x10BEC700` | theorem |
+| `CMSHeap`/`CSHeap` `<QuickMatrixI128\|DefaultMatrixI128, Regular\|Fast>` (4 each) | — | — | — | — | — | — | **gap — not insertable** (see below) |
+| `CMSHeap<Vector2D<i64>, RegularPath>` / `CSHeap<Vector2D<i64>, RegularPath>` | `heaps_satisfy_their_own_bounds_and_stay_heap_consistent` | `FreqTruth` | per-family bound + heap/sketch equality + top-k recall | as above | as above | stream `1004` | theorem |
+| `i32` / `i64` / `i128` counter widths | `countmin_counter_widths_carry_the_mass_their_type_allows`, `countsketch_counter_widths_carry_signed_mass_in_both_directions` | exact | structural | no wrap at each width's ceiling | — | fixed keys | structural |
+| `CountL2HH<DefaultXxHasher>` | `countl2hh_weighted_turnstile_satisfies_the_l2_median_bound` | `FreqTruth` | L2 + AMS F2 | `sqrt(3/w)*\|\|f_-i\|\|_2`; `sqrt(6/w)` for F2 | as above | stream `1005`, hash seed idx `11` | theorem |
+| `FoldCMS` / `FoldCS` after a 16-way merge | `folded_sketches_keep_their_own_bounds_through_a_sixteen_way_merge` | `FreqTruth` | per-family bound at the **folded** width | `e(N-f)/w'`, `sqrt(3/w')*\|\|f_-i\|\|_2`, `w' = w >> fold_level` | `e^-d` / median tail | stream `1009` | theorem |
+| portable `CountMinSketch` / `CountSketch` | `portable_cms_and_cs_string_keys_satisfy_their_own_bounds` | `FreqTruth` over string keys | per-family bound | as above | as above | stream `1006` | theorem |
+
+### Known gap: 128-bit heap variants
+
+`CMSHeap<QuickMatrixI128>`, `CMSHeap<DefaultMatrixI128>` and their `CSHeap`
+twins have `Default` impls (so they construct and compile) but their insert
+paths are bounded on `S::Counter: Into<i64>`, which `i128` does not satisfy.
+They are **constructible but not insertable**, so there is no behaviour to
+test. Four instances per family. Fixing this is a library change (widening the
+heap's count type or bounding on `TryInto<i64>`), not a test change.
+
+## Quantiles
+
+| public_instance | e2e_test | ground_truth | error_metric | bound_formula | confidence | deterministic_seed | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `KLL<f64>`, `KLLDynamic<f64>` × k∈{64,200,800} × 6 distributions × 4 feed modes | `kll_family_satisfies_the_datasketches_normalized_rank_error_contract` | `NumericTruth` rank intervals | rank | `eps(k) = 2.446/k^0.9433` | 0.01 per query | sketch `0x5EED0001..4`, stream `0xA5A50000+` | theorem |
+| `KLL<f64>` k∈{64,256,1024} | `kll_rank_error_shrinks_with_k_as_the_contract_predicts` | `NumericTruth` | rank scaling | worst error ≤ `eps(k)`; ≥4× improvement over 16× k | — | sketch `0x5EED0001..4`, stream `0xC0FFEE01` | theorem |
+| `KLL<T>`, `KLLDynamic<T>` for all 14 `NumericalValue` types | `every_numeric_type_satisfies_the_kll_rank_error_contract` | `NumericTruth` over the `to_f64` projection | rank | `eps(200)` | 0.01 | sketch `0x4E170001..3`, stream `0x57EA0001` | theorem |
+| the 8 signed/float types | `signed_numeric_types_order_negative_values_correctly_in_kll` | `NumericTruth` | rank + range containment | `eps(200)`; answers inside `[min, max]` | 0.01 | same | theorem |
+| `KLL<u128>` above `2^70` | `the_f64_projection_is_exact_below_two_to_the_53` | `NumericTruth` | rank + projection exactness | `eps(200)`; `(v as f64) as u128 == v` for `v <= 2^53` | 0.01 | `0x57EA0001` | theorem |
+| `TumblingWindow<KLL>` (`query_all`, `query_recent`, active) | `tumbling_kll_windows_are_exact_and_answers_satisfy_the_rank_contract` | exact window slice | rank + exact window count | `eps(200)` | 0.01 | sketch `0x77170001`, stream `3009` | theorem |
+| portable `HydraKllSketch` per key | `portable_hydra_kll_per_key_medians_satisfy_the_rank_contract` | per-key `NumericTruth` | rank | `eps(200)` | 0.01 | streams `3010`/`3011` | theorem |
+| portable `KllSketch` (+ merge, msgpack round trip) | `portable_kll_sketch_satisfies_the_rank_error_contract_through_merge_and_wire` | `NumericTruth` | rank + wire equality | `eps(200)` | 0.01 | sketch `0x5EED0400` | theorem |
+| `DDSketch` and portable `DdSketch`, alpha ∈ {0.001, 0.01, 0.05, 0.1} × 6 shapes × 3 sizes | `ddsketch_core_and_portable_satisfy_the_relative_value_error_contract` | exact nearest-rank order statistics | relative value | `alpha + 8*eps_f64*(1+\|ln v\|)` | deterministic — **zero** violations tolerated | streams from `3005000` | theorem |
+| both, all alphas | `ddsketch_endpoints_return_the_exact_min_and_max` | exact min/max | structural | `q=0 -> min`, `q=1 -> max` exactly | — | stream `4242` | structural |
+| both, bucket edges `gamma^k` for k ∈ {−40,−7,0,1,13,60,200} | `ddsketch_satisfies_the_relative_error_contract_at_bucket_boundaries` | the probe value itself | relative value | `alpha + ULP` at the edge, ±1 ULP either side, and the interior | zero tolerated | fixed probes | theorem |
+| both, 4-way merge + delta replay | `ddsketch_merge_and_delta_replay_preserve_the_relative_error_contract` | exact order statistics | relative value | `alpha + ULP` | zero tolerated | stream `7654321+alpha` | theorem |
+| `DDSketch::add<T>` for all 14 `NumericalValue` types × 3 alphas | `every_numeric_type_satisfies_the_ddsketch_relative_value_error_contract` | exact order statistics of the projection | relative value | `alpha + ULP` | zero tolerated | stream `0x57EA0001` | theorem |
+| `DDSketch` over `u128` above `2^70` | `the_f64_projection_is_exact_below_two_to_the_53` | exact order statistics | relative value + projection limit | `alpha + ULP` | zero tolerated | `0x57EA0001` | theorem |
+| both | `ddsketch_rejects_untrackable_values_and_mapping_mismatches`, `portable_ddsketch_rejects_hostile_delta_spans` | — | structural | drop non-indexable inputs; reject far-span deltas without allocating | — | fixed | structural |
+
+## Cardinality
+
+| public_instance | e2e_test | ground_truth | error_metric | bound_formula | confidence | deterministic_seed | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `HyperLogLogP12/P14/P16<Classic>` | `hll_classic_p{12,14,16}_satisfies_its_register_error_model` | exact identity count | cardinality RSE | `z * 1.04/sqrt(2^p)`, `z=4` | 6.3e-5 | identities `0..n` | theorem |
+| `HyperLogLogP12/P14/P16<ErtlMLE>` | `hll_ertl_mle_p{12,14,16}_satisfies_the_cramer_rao_error_model` | exact | cardinality RSE | same constant (CRLB) | 6.3e-5 | identities `0..n` | theorem |
+| `HyperLogLogHIPP12/P14/P16` | `hll_hip_p{12,14,16}_satisfies_the_hip_error_model` | exact | cardinality RSE | `z * sqrt(ln2/2^p)` | 6.3e-5 | identities `0..n` | theorem |
+| all 9 above | same tests | exact | structural | duplicate replay must not move the estimate at all | — | — | structural |
+| the 6 mergeable ones | same tests | exact | cardinality RSE | disjoint even/odd shard merge in the same band | 6.3e-5 | — | theorem |
+| portable `HllSketch` × {Regular, Datafusion, Hip} × p{12,14,16} (9) | `portable_hll_variants_and_precisions_satisfy_the_register_error_model` | `HashSet` | cardinality RSE | `z * 1.04/sqrt(2^p)` — the variant is a **wire tag**, not an estimator | 6.3e-5 | streams `2001+p` | theorem |
+| `HyperLogLogP12/P14/P16<Classic>` | `hll_accuracy_improves_with_precision_as_the_error_model_predicts` | exact | measured RSE over 6 blocks | ≤ 2× predicted; ≥ 2× improvement p12→p16 | — | identities `0..6e6` | theorem |
+| `HyperLogLogP12/P14/P16<Classic>` at `n = 2.5m` | `hll_classic_switchover_band_stays_within_the_documented_empirical_band` | exact | measured RSE | 1.5×–10× the asymptotic RSE (measured 2.1×/3.5×/6.3×) | — | identities `0..` | **empirical** — see finding below |
+| `KMV`, exact and estimated regimes | `kmv_satisfies_its_relative_standard_error_across_both_regimes` | exact | cardinality RSE | exact for `n<=k`; `z/sqrt(k-1)`, `z=4` → 6.25% at k=4096 | 6.3e-5 | identities `0..n` | theorem |
+| `KMV` over a duplicate-bearing stream | `kmv_over_a_duplicate_bearing_stream_satisfies_its_error_model` | `HashSet` | cardinality RSE | as above | 6.3e-5 | stream `5001` | theorem |
+| `SetAggregator` | `set_aggregator_union_is_exact` | `HashSet` | structural | exact union | — | stream `2002` | structural |
+
+## Windowed frameworks
+
+| public_instance | e2e_test | ground_truth | error_metric | bound_formula | confidence | deterministic_seed | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `EHSketchList::CM` in an `ExponentialHistogram` | `eh_count_min_variant_satisfies_the_count_min_bound_over_the_retained_window` | exact truth over the merged bucket span | additive one-sided | `e(N-f)/w` | `e^-d` | stream `0x0E110001` | theorem |
+| `EHSketchList::CS` | `eh_count_sketch_variant_satisfies_the_l2_bound_over_the_retained_window` | same | L2 | `sqrt(3/w)*\|\|f_-i\|\|_2` | median tail | `0x0E110001` | theorem |
+| `EHSketchList::COUNTL2HH` | `eh_countl2hh_variant_satisfies_the_l2_bound_over_the_retained_window` | same | L2 | as above | median tail | `0x0E110001` | theorem |
+| `EHSketchList::COCO`, `::ELASTIC` | `eh_heavy_hitter_variants_stay_one_sided_over_the_retained_window` | same | one-sided on heavy keys | `est >= f` for the true top 32 | — | `0x0E110001` | structural |
+| `EHSketchList::HLL` | `eh_hll_variant_satisfies_the_register_error_model_over_the_retained_window` | `HashSet` over the span | cardinality RSE | `4 * 1.04/sqrt(2^14)` | 6.3e-5 | `0x0E110001` | theorem |
+| `EHSketchList::KLL` | `eh_kll_variant_satisfies_the_rank_error_contract_over_the_retained_window` | `NumericTruth` over the span | rank | `eps(200)` | 0.01 | sketch `0x5EED0200` | theorem |
+| `EHSketchList::DDS` | `eh_ddsketch_variant_satisfies_the_relative_value_error_contract_over_the_window` | exact order statistics | relative value | `alpha + ULP` | zero tolerated | `0x0E110001` | theorem |
+| `EHSketchList::UNIVMON` | `eh_univmon_variant_reports_the_exact_l1_over_the_retained_window` | exact | L1 exact; L2 empirical | `calc_l1 == N`; L2 within ±15% (measured 3%) | — | `0x0E110001` | structural + empirical |
+| `EHSketchList::UNIFORM` (experimental) | `eh_uniform_sampling_variant_reports_exact_retention_bookkeeping` | exact | structural | `total_seen` exact; samples ⊆ window | — | sampler `0x5A9101` | structural |
+| all 10 variants | `every_eh_variant_can_merge_into_its_own_kind`, `every_eh_variant_selects_the_documented_merge_norm` | — | structural | merge arm present; L2 norm for COUNTL2HH/UNIVMON, L1 otherwise | — | — | structural |
+| `ExponentialHistogram` expiry | `eh_expires_buckets_past_the_window_and_reports_its_retained_span` | exact retained events | structural | no bucket entirely before the cutoff | — | — | structural |
+| `TumblingWindow<KLL>` | `tumbling_kll_windows_are_exact_and_answers_satisfy_the_rank_contract` | exact slices | rank + exact window count | `eps(200)` | 0.01 | sketch `0x77170001` | theorem |
+| `TumblingWindow<FoldCMS>` | `tumbling_foldcms_weighted_windows_exact_counts` | exact | structural | exact weighted counts, flush, rotation | — | — | structural |
+| `TumblingWindow<FoldCS>` | `tumbling_fold_cs_windows_are_exact_and_answers_satisfy_the_l2_bound` | exact slices | L2 at the folded width | `sqrt(3/w')*\|\|f_-i\|\|_2` | median tail | stream `0x0E110001` | theorem |
+| `TumblingWindow<UnivMonQ>` | `tumbling_univmon_q_windows_carry_exact_aggregates_through_rotation` | exact slices | structural | count/min/max exact per window; pool reuse clears | — | stream `0x0E110001` | structural |
+| `EHUnivOptimized` map tier | `eh_univ_optimized_map_tier_exact_windows`, `…_matches_exact_per_key_counts_on_a_skewed_stream` | exact | structural | exact per-key counts | — | stream `9001` | structural |
+| `EHUnivOptimized` sketch tier | `eh_univ_optimized_promotes_into_the_sketch_tier_and_answers_from_it` | exact over the promoted span | L1 exact; L2/entropy empirical | `calc_l1 == N`; L2 ±10%, entropy −10/+40% | — | stream `4242` | structural + empirical |
+| `EHUnivOptimized` mixed interval, expiry, pool reuse | `…_answers_a_mixed_map_and_sketch_interval`, `…_expires_buckets_past_the_window`, `…_reuses_pooled_sketches_without_leaking_state` | exact | structural | exact L1 over the retained span | — | — | structural |
+| `EHUnivOptimized` sketch-tier cardinality | `eh_univ_optimized_sketch_tier_cardinality_is_documented_as_unrecoverable` | exact | — | reported < 10% of true | — | stream `4242` | **empirical** — see finding below |
+
+## Composition
+
+| public_instance | e2e_test | ground_truth | error_metric | bound_formula | confidence | deterministic_seed | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `EnsembleSketch::{CountMinFast, CountFast}` | `ensemble_members_match_standalone_sketches_fed_the_same_stream` | standalone sketch on the same stream | structural | exact equality, key for key | — | stream `0xC0905101` | structural |
+| `EnsembleSketch::{HllErtl, HllClassic, HllHip}` | same | `FreqTruth` distinct + standalone | cardinality RSE | each member's own model; ensemble and standalone agree within their combined band (they use different hashes by design) | 6.3e-5 | `0xC0905101` | theorem |
+| all 5 member variants | `ensemble_members_satisfy_their_own_error_bounds` | `FreqTruth` / `HashSet` | per-family | Count-Min additive, Count L2, HLL register, HIP HIP | as each | `0xC0905101` | theorem |
+| multi-matrix ensembles, layout compatibility | `ensemble_composes_by_hash_layout_and_rejects_incompatible_members` | `FreqTruth` | per-family + structural | each member judged at **its own** width; mismatched rows or packing modes rejected | as each | `0xC0905101` | theorem + structural |
+| `NitroBatch<CountMin<Vector2D<i32>, FastPath>>`, `NitroBatch<Count<…>>`, rates 1.0/0.5/0.1/0.01 | `nitro_estimates_stay_inside_the_binomial_sampling_band_on_every_target` | exact count | binomial sampling | `z*sqrt(f(1-p)/p)`, `z=4` | 6.3e-5 | sampling seeds `0x01170001..4` | theorem |
+| `NitroBatch<Vector2D<u32>>` (all 4 rates) | `nitro_over_a_bare_vector2d_target_admits_mass_inside_the_sampling_band` | exact count | binomial sampling on admitted mass | as above | 6.3e-5 | same | theorem |
+| `NitroBatch` rate = 1.0 | `nitro_at_full_sampling_is_exact` | exact | structural | exact | — | `0x01170001` | structural |
+| `NitroBatch` seeding | `nitro_sampling_is_reproducible_from_its_seed` | — | structural | same seed → same result; different seeds → different | — | 4 seeds | structural |
+| `NitroBatch::merge`, saturation | `nitro_merge_sums_admitted_mass_at_the_combined_band`, `nitro_saturates_oversized_weights_instead_of_wrapping` | exact | binomial + structural | as above; clamp at `i32::MAX`/`u32::MAX` | 6.3e-5 | — | theorem + structural |
+| `UnivMonQ` default / `counter_bits=64` / `width_halving_period=2` / explicit `hash_seed` | `univmonq_configuration_variants_all_build_and_keep_exact_aggregates` | `NumericTruth` | structural | count/min/max exact; config round-trips | — | stream `0xC0905101` | structural |
+| `UnivMonQ` `ordered_samples = 0` | `univmonq_with_ordered_samples_disabled_answers_everything_except_ordered_queries` | `NumericTruth` | structural | ordered queries `None`; endpoints still exact | — | `0xC0905101` | structural |
+| `UnivMonQConfig::with_window_bound` | `univmonq_with_window_bound_chooses_a_hierarchy_that_satisfies_its_own_inequality` | Bernstein bound recomputed in-test | structural | chosen `levels` is the smallest with `mean + sqrt(2·mean·ln(1/δ)) + (2/3)ln(1/δ) < candidates` | δ = 1e-3 | — | theorem |
+| `UnivMonQ::with_hasher_and_source_id`, 4-shard merge | `univmonq_multi_shard_merge_with_distinct_source_ids_covers_the_union` | `NumericTruth` | structural | merged count/min/max exact | — | `0xC0905101` | structural |
+| `UnivMonQ::estimate_frequency` / `estimate_f2` | `univmonq_frequency_and_f2_satisfy_the_count_sketch_bounds` | `FreqTruth` | L2 + AMS F2 | `sqrt(3/w)*\|\|f_-i\|\|_2`, `sqrt(6/w)` | median tail | stream `3008` | theorem |
+| `UnivMonQ::{rank, cdf, quantile}` in the diffuse regime | `univmonq_ordered_queries_satisfy_the_residual_occurrence_bound_when_diffuse` | `NumericTruth` | rank, from the occurrence sample | `eps_R = sqrt(ln(2/δ)/(2 m_R))` | δ = 0.01 | stream `0x0DDE0001` | theorem (partial — see below) |
+| `UnivMonQ::{estimate_distinct, estimate_entropy, heavy_hitters}` | `univmonq_distinct_entropy_and_recall_stay_within_the_documented_empirical_band` | `FreqTruth` | relative | ±10% distinct, ±10% entropy, ≥8/10 recall | — | stream `3008` | **empirical** |
+| portable `CountMinSketchWithHeap` | `portable_count_min_with_heap_satisfies_the_count_min_bound_through_merge_and_wire` | `FreqTruth` | additive one-sided + heap + wire equality | `e(N-f)/w` | `e^-d` | stream `0xC0905101` | theorem |
+| portable `CountSketchWithHeap` | `portable_count_sketch_with_heap_satisfies_the_l2_bound_through_merge_and_wire` | `FreqTruth` | L2 + heap + wire | `sqrt(3/w)*\|\|f_-i\|\|_2` | median tail | `0xC0905101` | theorem |
+
+### UnivMon-Q ordered queries: what is and is not verified
+
+The documented contract is
+`sup_x |F_hat(x) − F(x)| <= 2 E_H + P_hat_R * eps_R`. `E_H` is the frequency
+error over the sketch's **internally recovered** heavy set, and neither that
+set nor `m_R` is reachable through the public API, so the complete theorem
+**cannot be verified from outside the crate** and the test does not claim to.
+
+What it verifies instead is the strongest contract public state supports: the
+adaptive gate is `F2_hat / N^2 >= 1 / ordered_samples`, and both sides are
+public. On a stream where the gate provably does not fire, the heavy set is
+empty, so `E_H = 0`, `P_hat_R = 1`, and the whole bound collapses to the
+distribution-free occurrence bound `eps_R`, with `m_R` observable as the number
+of CDF breakpoints. The test asserts the gate premise first and fails loudly if
+it is not met.
+
+## OctoSketch
+
+| public_instance | e2e_test | ground_truth | error_metric | bound_formula | confidence | deterministic_seed | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `CmTopKOctoPlan/Worker/Aggregator`, HashByKey + RoundRobin | `cm_top_k_point_estimates_trail_the_single_thread_reference_by_at_most_k_tau` | single-thread `CMSHeap` **and** `FreqTruth` | promotion residual + additive | `ref − k·tau <= octo <= ref`; `f − k·tau <= est <= f + e(N−f)/w` | deterministic; `e^-d` | stream `0x0C701101` | theorem |
+| `CountTopKOctoPlan/Worker/Aggregator`, both partitions | `count_top_k_point_estimates_satisfy_the_l2_bound_within_the_promotion_residual` | single-thread `CSHeap` **and** `FreqTruth` | promotion residual + L2 | `\|octo − ref\| <= k·tau`; `\|est − f\| <= sqrt(3/w)\|\|f_-i\|\|_2 + k·tau` | deterministic; median tail | `0x0C701101` | theorem |
+| both top-k plans, both partitions | `top_k_plans_recover_the_heavy_hitters_their_promotion_floor_guarantees` | `FreqTruth` top-k | recall / precision / heap consistency | recall = 100% above the `k·tau` promotion floor; nothing in the heap below the k-th count − `k·tau` | deterministic | `0x0C701101` | theorem |
+| `CmTopKOctoWorker` below threshold | `a_key_below_the_promotion_threshold_never_reaches_the_top_k_aggregator` | exact | structural | no promotion under `tau`; first promotion hands over exactly `tau` | — | fixed key | structural |
+| `CmOctoPlan`, `CountOctoPlan` | pre-existing `theorem_1_bounds_the_count_min_error`, `theorem_3_bounds_the_count_sketch_error` | `FreqTruth` | additive / L2 with the `k'·tau` residual | paper's Thms 1 and 3 | `delta = 2^-d` | fixed | theorem, **both partitions** |
+| `HllOctoPlan`, `DdOctoPlan`, `CocoOctoPlan`, `ElasticOctoPlan`, `UnivMonOctoPlan` | pre-existing `tests/e2e_octo.rs` (mass conservation, flush completeness, sketch-merge baselines) | exact mass / `FreqTruth` | per-family | see that suite | — | fixed | theorem, **HashByKey only** |
+
+The `HashByKey` premise is named in the assertions where it matters: under it a
+flow's whole count lands on one worker so it promotes `floor(f/tau)` times,
+while `RoundRobin` splits the same flow `k` ways. Recall is therefore measured
+per partition rather than averaged.
+
+Partition coverage is uneven and this pass did not change that: `CmOctoPlan`,
+`CountOctoPlan` and the two top-k plans run under both `HashByKey` and
+`RoundRobin`; the HLL, DDSketch, Coco, Elastic and UnivMon plans are driven
+under `HashByKey` only outside the `octo-runtime` feature. Their invariants
+(mass conservation, flush completeness) are partition-independent, but their
+accuracy comparisons are not.
+
+## Heavy hitters and membership (pre-existing, unchanged)
+
+| public_instance | e2e_test | ground_truth | error_metric | status |
+| --- | --- | --- | --- | --- |
+| `SpaceSaving` | `tests/e2e_heavy_hitters.rs` (Space-Saving group, 20 tests) | `FreqTruth` | error sandwich, `min_count` ceiling | theorem |
+| `Coco`, `Elastic` | `tests/e2e_heavy_hitters.rs` (`keyed_bucket` module, 9 tests) | `FreqTruth` | over-attribution / one-sided under eviction | theorem |
+| `Bloom<RegularPath>`, `Bloom<FastPath>` | `tests/e2e_membership.rs` (30 tests) | exact sets | no false negatives; measured FPP vs the filter's own sizing | theorem |
+| `Hydra` with CM / CS / HLL / KLL / UnivMon counters | `tests/e2e_frameworks.rs` (29 tests) | exact lattice truth | additive grid bound, exact marginals, exact shard merge | theorem |
+
+## Production findings from this pass
+
+1. **`EHSketchList::merge` had no `ELASTIC` arm** — fixed. `EHBucket::to_merge`
+   discards the `Result`, so an `ExponentialHistogram` over the Elastic payload
+   silently dropped every bucket merge while still counting bucket sizes. Every
+   heavy key read 0. Pinned by
+   `eh_heavy_hitter_variants_stay_one_sided_over_the_retained_window` and
+   `every_eh_variant_can_merge_into_its_own_kind`.
+2. **HLL Classic's accuracy cliff at the linear-counting switchover** — not
+   fixed, documented. At `n ≈ 2.5m` the 2007 estimator's two branches do not
+   meet smoothly and the RSE reaches 6.3× the asymptotic `1.04/sqrt(m)` at p16.
+   The old checkpoint grid stepped over the band for every precision. Pinned by
+   `hll_classic_switchover_band_stays_within_the_documented_empirical_band`,
+   which fails if the cliff is ever removed so the test gets updated rather than
+   left stale. A real fix is HLL++ bias correction, which changes shipped
+   estimates and the golden bytes.
+3. **`EHUnivOptimized`'s sketch-tier cardinality is structurally
+   unrecoverable** — not fixed, documented. Promotion fires only once a bucket
+   holds `layer_size * rows * cols / 2` distinct keys, while UnivMon needs about
+   `log2(distinct)` layers to recover `F0`; raising `layer_size` raises the
+   promotion threshold in lockstep, so the two requirements cannot both be met
+   by tuning. Measured: 0–11 reported for windows holding 16k–40k distinct.
+   Pinned by `eh_univ_optimized_sketch_tier_cardinality_is_documented_as_unrecoverable`.
+4. **`CMSHeap`/`CSHeap` `i128` instances are constructible but not insertable** —
+   not fixed, documented above.
+
+## Seeded constructors added for deterministic testing
+
+Four public constructors were added so accuracy tests can reproduce a failure.
+Each mirrors an existing one and changes nothing about the unseeded path.
+
+| Added | Mirrors | Why |
+| --- | --- | --- |
+| `KLLDynamic::init_with_seed`, `KLLDynamic::init_kll_with_seed` | `KLL::init_with_seed` / `init_kll_with_seed` | `KLLDynamic` had no seeded constructor at all, so every accuracy assertion over it was re-rolled per run. The seed is stored so `clear()` re-seeds from it, and is `#[serde(skip)]` — it describes how the sketch was built, not what it holds, so the wire format is unchanged |
+| `NitroBatch::with_target_and_seed`, `NitroBatch::init_nitro_with_seed` | `NitroBatch::with_target` / `init_nitro` | sampling is where all of Nitro's randomness lives; without a seed the admitted subset differs every run |
+| `KllSketch::with_seed`, `new_sketchlib_kll_with_seed` | `KLL::init_kll_with_seed` | the portable facade had only the wall-clock path |
+| `HydraKllSketch::with_seed` | as above | every cell shares one prototype, so one seed makes the whole grid reproducible |
+
+Documented in `docs/api/api_kll.md` and `docs/api/api_nitrobatch.md`.
+
+## Test-side defects corrected
+
+| What | Where it was | Why it was wrong |
+| --- | --- | --- |
+| Count Sketch checked against Count-Min's `eps*N` with `delta = e^-rows` | `countsketch_error_bound_covers_most_keys_on_both_paths` | Count Sketch's error is `L2/sqrt(w)`, two-sided and rank-independent; `eps*N` is enormously looser on a skewed stream, so passing it said almost nothing |
+| `1.5 * bound` with no explanation | Count Sketch median and portable CS tests | an undeclared 50% widening of a bound is not that bound |
+| `alpha * 1.05` for DDSketch | `ddsketch_alpha_across_distributions_core_and_portable` | accepts results 5% past the advertised guarantee — the one thing the guarantee forbids. Measured worst case is exactly `alpha`, so the slop was unnecessary as well as wrong |
+| KLL checked with a hard-coded 0.02/0.03 rank tolerance | quantile suites | untied to `k`: passes identically at k=64 and k=800, so it cannot see `k` failing to reach the compactors |
+| `KLL::init_kll` (wall-clock seeded) in accuracy tests | `kll_quantile_rank_bands_and_shard_merge` and others | a failure would not reproduce |
+| `KLLDynamic::init_kll` only | all KLLDynamic tests | no seeded constructor existed; one was added |
+| KMV "4 standard errors" asserting 4% at k=4096 | `kmv_*` | `4/sqrt(4095) = 6.25%`, so the comment and the number disagreed. The band is now computed from `z` and `k` |
+| HLL at a flat 2%/3% for every precision and estimator | `hll_variants_checkpoints_and_shard_merge` | 4.9σ at p16 and 1.2σ at p12 — simultaneously too loose and too tight, and it held HIP to Classic's constant |
+| `NitroBatch::with_target` (OS-seeded) with ±5%/±10% bands | `nitro_unbiased_across_rates_cm_and_cs_targets` | re-rolled every run and unrelated to the estimator's variance; a seeded constructor was added |
+| Regular/fast path *equality* asserted on 4 hand-picked keys | `countmin_regular_fast_paths_agree_on_stream` | the two paths use different hash functions and legitimately disagree on about a third of keys; the equality held by coincidence at those dimensions |
+| `CountL2HH::get_l2_sqr` treated as exact | `countl2hh_weighted_f2_with_decrements` | it is the AMS row-median estimator over the sketch's own counters, with a real bound |
+| Ensemble HLL asserted equal to a standalone HLL | new test, corrected before landing | the ensemble feeds HLL the shared *matrix* hash, not the canonical seed — equally accurate, not equal |
+| Ensemble "same dimensions" assumed | new test, corrected before landing | compatibility is by hash *layout* (`rows`, packing mode); different widths compose fine and each folds with its own `cols` |
+
+## Still uncovered
+
+| Instance | Reason |
+| --- | --- |
+| `CMSHeap`/`CSHeap` over `QuickMatrixI128`, `DefaultMatrixI128` (8 instances) | not insertable — `S::Counter: Into<i64>` excludes `i128`. Library change required |
+| `NitroBatch<Vector2D<u32>>` per-key estimates | no public estimator: `NitroEstimate` is implemented only for the `Vector2D<i32>`-backed sketches, and `CountMin::estimate` cannot instantiate over `u32`. Admitted-mass coverage stands in; re-deriving the fast-path hash in a test is exactly how the Nitro estimator once shipped broken |
+| `UnivMonQ`'s full ordered-query theorem | `E_H` and `m_R` are not public. The diffuse-regime half is verified; see above |
+| User-supplied `SketchHasher` / `MatrixStorage` implementations | out of scope by request: only in-repo concrete and default types are enumerated |
+| `octo-runtime` thread-scheduling paths | covered by the pre-existing `mod runtime` tests under `--features octo-runtime`; this pass added no new instances there |
+| `RoundRobin` accuracy comparisons for the HLL, DDSketch, Coco, Elastic and UnivMon Octo plans | pre-existing gap, unchanged by this pass; their partition-independent invariants are covered |
+| `EHSketchList::UNIFORM` inside the accuracy batteries | reservoir sampling has no per-key or per-quantile guarantee to assert; its retention bookkeeping is covered exactly |

--- a/docs/e2e_testing_harness.md
+++ b/docs/e2e_testing_harness.md
@@ -1,15 +1,28 @@
 # The E2E Testing Harness and Conformance Kit
 
 This document explains how the end-to-end testing harness is designed and how
-to use it when adding or changing a sketch. The short version: **every sketch
-must pass the same conformance batteries, driven by seeded synthetic data and
-compared against exactly-known ground truth.** Ad-hoc assertions alone are no
-longer an acceptable bar for a new sketch.
+to use it when adding or changing a sketch. The short version, in two parts:
+
+1. **Every public instance is driven by seeded synthetic data and compared
+   against exactly-known ground truth.** Which instances those are, and which
+   test covers each, is enumerated in
+   [`docs/e2e_coverage_matrix.md`](./e2e_coverage_matrix.md) — that document,
+   not this one, is the authority on what is and is not covered.
+2. **Every approximate answer is judged against its own family's bound.** The
+   conformance batteries are a shared floor for capabilities a sketch has in
+   common with others; they are not where a family's guarantee is asserted.
+   That lives in the per-metric specs in
+   [`tests/common/specs.rs`](../tests/common/specs.rs).
+
+Ad-hoc assertions alone are not an acceptable bar for a new sketch, and neither
+is a battery pass on its own.
 
 Related reading:
 
+- [`docs/e2e_coverage_matrix.md`](./e2e_coverage_matrix.md) — instance → test → bound
 - [`tests/README.md`](../tests/README.md) — quick onboarding recipe
-- [`tests/common/conformance.rs`](../tests/common/conformance.rs) — the kit itself
+- [`tests/common/specs.rs`](../tests/common/specs.rs) — the error-model specs
+- [`tests/common/conformance.rs`](../tests/common/conformance.rs) — the capability kit
 - [`tests/conformance_kit.rs`](../tests/conformance_kit.rs) — reference adapters
 
 ## Why it exists
@@ -22,10 +35,18 @@ Three properties make this harness effective where ordinary unit tests are not:
    values are never derived from another approximation.
 2. **Everything is deterministic.** All randomness flows through seeded RNGs.
    A failure today reproduces tomorrow, on any machine.
-3. **Tolerances are justified.** Where theory exists we assert against it
-   (α for DDSketch, rank error bands for KLL, one-sided ε·N bounds for
-   Count-Min). Where it does not, tolerances are documented empirical values
-   consistent across suites.
+3. **Tolerances are computed, not written down.** Where theory exists the
+   bound is evaluated from the sketch's own configuration and the exact truth —
+   never a hand-picked percentage. Where it does not, the tolerance is a
+   documented empirical band, the test is *named* as one, and the measurement
+   it came from is recorded next to it.
+
+Point 3 is the one that is easy to get wrong in a way that looks fine. Having a
+test is not the same as having an accuracy test, and an accuracy test is not
+the same as correctly verifying a theoretical guarantee. A Count Sketch checked
+against Count-Min's `ε·N` passes comfortably and verifies almost nothing,
+because on a skewed stream that bound is enormously looser than the one Count
+Sketch actually promises.
 
 The harness earned its keep immediately: its first run surfaced four real
 defects — a Nitro estimator that returned zero because inserts and queries
@@ -34,26 +55,38 @@ skip-draw rounding bug that halved the effective sampling rate, and a portable
 DDSketch representative that violated the advertised α bound at bucket edges.
 None of these were caught by the existing unit tests.
 
+Tightening the bounds to the ones each family actually promises surfaced more:
+a missing `ELASTIC` arm in `EHSketchList::merge` that silently discarded every
+bucket merge in an exponential histogram, HLL Classic's accuracy cliff at the
+linear-counting switchover, and a structural coupling in `EHUnivOptimized` that
+makes its sketch-tier cardinality unrecoverable. See the findings section of
+the coverage matrix.
+
 ## Architecture
 
 ```sh
 tests/
 ├── common/
-│   ├── mod.rs           # generators + truth trackers + assertion helpers
-│   └── conformance.rs   # capability traits + reusable batteries  ← the kit
-├── conformance_kit.rs   # reference adapters (copy these)
-├── e2e_frequency.rs     # deep per-family suites…
+│   ├── mod.rs               # generators + truth trackers + assertion helpers
+│   ├── specs.rs             # per-metric error models + acceptance rules  ← the bounds
+│   └── conformance.rs       # capability traits + reusable batteries      ← the kit
+├── conformance_kit.rs       # reference adapters (copy these)
+├── e2e_frequency.rs         # deep per-family suites…
 ├── e2e_cardinality.rs
 ├── e2e_quantiles.rs
-├── e2e_frameworks.rs
-├── e2e_octo.rs          # …the OctoSketch promotion protocol
-├── e2e_heavy_hitters.rs # …Space-Saving, CocoSketch and Elastic
-├── e2e_membership.rs    # …the Bloom filter's membership guarantees
-├── e2e_experimental.rs  # …the remaining feature-gated sketches
-└── bug_verification.rs  # regression tests for fixed defects
+├── e2e_matrix_instances.rs  # every (storage, path) instance of the matrix families
+├── e2e_numeric_types.rs     # every NumericalValue type through KLL / DDSketch
+├── e2e_windows.rs           # every EHSketchList variant + TumblingWindow payloads
+├── e2e_composition.rs       # HashSketchEnsemble, NitroBatch, UnivMonQ config, portable facade
+├── e2e_frameworks.rs        # Hydra and UnivMon composition
+├── e2e_octo.rs              # …the OctoSketch promotion protocol
+├── e2e_heavy_hitters.rs     # …Space-Saving, CocoSketch and Elastic
+├── e2e_membership.rs        # …the Bloom filter's membership guarantees
+├── e2e_experimental.rs      # …the remaining feature-gated sketches
+└── bug_verification.rs      # regression tests for fixed defects
 ```
 
-There are three layers:
+There are four layers:
 
 **Layer 1 — primitives (`common/mod.rs`).**
 Seeded generators produce streams with known shape: `zipf_u64` (heavy heads),
@@ -64,7 +97,33 @@ exact F0/F1/F2/L2/entropy/top-k) or `NumericTruth` (sorted values exposing
 nearest-rank quantiles, CDF, and rank-tolerance value bands). Assertion
 helpers turn comparisons into readable failures that print expected vs actual.
 
-**Layer 2 — the conformance kit (`common/conformance.rs`).**
+**Layer 2 — the error-model specs (`common/specs.rs`).**
+One spec per *metric*, not per sketch, because the metric is what differs:
+
+| Spec | Bounds | Formula |
+| --- | --- | --- |
+| `CountMinSpec` | one-sided additive excess | `e·(N − f) / w`, failure `e^-d` |
+| `CountSketchSpec` | two-sided L2, rank-independent | `sqrt(κ/w)·‖f₋ᵢ‖₂`, κ = 3, failure `P[Bin(d, 1/3) ≥ ⌈d/2⌉]` |
+| `SecondMomentSpec` | F2 from a Count Sketch matrix | `sqrt(2κ/w)`, same median amplification |
+| `RankErrorSpec` | KLL rank error | `ε(k) = 2.446 / k^0.9433`, 99% confidence |
+| `RelativeQuantileSpec` | DDSketch relative value error | `α + ULP slack` vs the exact order statistic |
+| `CardinalityConfidenceSpec` | HLL / KMV | `z · σ_rel`, σ from the estimator's own model |
+| `SamplingConfidenceSpec` | Nitro | `z · sqrt(f(1−p)/p)` |
+
+Each spec exposes the bound formula, the per-check failure probability the
+theorem allows, and an acceptance rule. `Tally` accumulates violations across
+checks and trials, and `assert_within` applies a binomial tail at a fixed test
+level (`TEST_LEVEL = 1e-6`) decided before the run — so the number of tolerated
+violations cannot be adjusted after seeing the result. `assert_none` is for
+structural guarantees, which tolerate nothing.
+
+Keeping these apart is deliberate. There is no shared
+`QuantileSpec { rank_tol }` that KLL and DDSketch both use, because they do not
+promise the same thing: a correct KLL can return a value 100× off on a
+heavy-tailed stream and still be within its rank guarantee, and a correct
+DDSketch has no rank guarantee at all.
+
+**Layer 3 — the conformance kit (`common/conformance.rs`).**
 A sketch describes *what it guarantees* by implementing small capability
 traits; batteries translate those guarantees into checks. Traits:
 
@@ -89,11 +148,13 @@ into a `BatteryReport`, and report all failures at once via `.assert_ok()`:
 | `cardinality_battery` | unique-stream accuracy at a checkpoint; re-ingesting seen keys must not move the estimate |
 | `quantile_battery` | estimates land inside rank-tolerance value bands across the standard q grid |
 
-Specs carry the tolerances: `FrequencySpec { one_sided, rel_tol, abs_tol }`,
-`MembershipSpec { max_fpp }`, `CardinalitySpec { rel_tol }`,
-`QuantileSpec { rank_tol, qs }`.
+The kit's own specs (`FrequencySpec`, `MembershipSpec`, `CardinalitySpec`,
+`QuantileSpec`) carry loose smoke-test tolerances. They exist so a new sketch
+can be wired up in one adapter and immediately checked for gross breakage —
+they are a floor, not the guarantee. A sketch's actual bound is asserted in its
+suite with the matching spec from Layer 2.
 
-**Layer 3 — suites.**
+**Layer 4 — suites.**
 `conformance_kit.rs` wires established sketches through the kit as reference
 adapters. The `e2e_*.rs` suites add depth the kit deliberately does not
 attempt: serialization round trips, window semantics, framework composition
@@ -198,18 +259,51 @@ portable type, heavy-hitter recall targets, and so on.
 
 ## Tolerance policy
 
-- Prefer theoretical bounds and cite them in a comment next to the spec.
-- Empirical tolerances must be no looser than comparable sketches in the same
-  suite. If your sketch needs ±30% where KLL uses ±3%, either fix the sketch
-  or document why the guarantee is genuinely weaker before widening.
-- Fixed seeds are part of the contract. If a test is flaky, do not loosen the
-  seed's randomness exposure — tighten the implementation or state the
-  statistical intent explicitly and pick a defensible band.
+**Compute the bound; do not write it down.** Evaluate it from the sketch's own
+configuration and the exact truth, through the matching spec. A tolerance that
+does not move when `k`, `w` or the precision moves is not that family's bound:
+a hard-coded 0.02 rank tolerance passes identically at `k = 64` and `k = 800`,
+so it cannot notice `k` failing to reach the compactors at all.
+
+**Name empirical bands as empirical.** Theory-backed tests are named
+`*_satisfies_<theorem_or_bound>`; measured ones are named
+`*_stays_within_the_documented_empirical_band`, and the doc comment records the
+configuration, the stream seed, and the number actually measured. An empirical
+band is never described as a theoretical bound.
+
+**Never widen a bound to make a failure go away.** If the correct bound exposes
+an implementation defect, keep the reproducing test and fix the implementation —
+or, when the behaviour is a documented limitation rather than a bug, pin it
+with *both* an upper and a lower guard so that fixing it later fails the test
+and forces the documentation to be updated instead of going stale. Two tests
+in this suite do exactly that: `hll_classic_switchover_band_stays_within_the_documented_empirical_band`
+and `eh_univ_optimized_sketch_tier_cardinality_is_documented_as_unrecoverable`.
+
+**Do not use a fudge factor.** `1.5 * bound` and `alpha * 1.05` are not bounds;
+the second one accepts results that break the advertised guarantee by 5%. If a
+looser constant is genuinely needed, change the constant *inside* the derivation
+(e.g. Chebyshev's κ) and state the failure probability it now implies.
+
+**Fixed seeds are part of the contract.** Stream seeds and sketch seeds are
+separate things and both are pinned. A sketch whose only constructor seeds from
+the wall clock cannot be used in an accuracy test — add a seeded constructor.
+Every failure message prints the seeds, the configuration, and the measured
+error against its bound.
 
 ## Rules and anti-patterns
 
-- No unseeded randomness anywhere in tests. Coco-style nondeterministic
-  implementations are tested statistically over bounded ranges instead.
+- No unseeded randomness anywhere in tests — no `rand::rng()`, no wall-clock
+  seeding, no implicit RNG inside a constructor. `KLL::init_kll_with_seed`,
+  `KLLDynamic::init_kll_with_seed`, `KllSketch::with_seed`,
+  `NitroBatch::with_target_and_seed` and `UniformSampling::with_seed` exist for
+  this. Coco-style nondeterministic implementations are tested statistically
+  over bounded ranges instead.
+- A probabilistic guarantee is about randomness the test cannot resample: the
+  library fixes its hash seed table, so counting how many keys clear a bound
+  under *one* hash is not a measurement of the theorem's failure probability.
+  Where independent trials are needed, resample the *key population* and say so;
+  where the API genuinely cannot expose the dimension, say that instead of
+  claiming the theorem was verified.
 - Never derive expected values from another approximation. Truth comes from
   `FreqTruth`/`NumericTruth`, full stop.
 - Do not bypass public APIs in tests to "fix" them. The Nitro estimator
@@ -225,8 +319,10 @@ portable type, heavy-hitter recall targets, and so on.
 ## Running
 
 ```bash
-cargo test --all-features --locked          # full matrix incl. experimental
+cargo test --all-features --locked           # full matrix incl. experimental
 cargo test --test conformance_kit            # kit + reference adapters only
+cargo test --test e2e_matrix_instances       # every storage x path instance
+cargo test --test e2e_numeric_types          # every NumericalValue type
 cargo run --release --example accuracy_probe --features experimental
                                              # heavy release-only probes
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,8 @@ This page is the docs home for `asap_sketchlib`.
 - [Advanced Use Cases](./advanced_use_cases.md)
 - [HHHeap Acceleration](./hhheap_acceleration.md) - what the top-k heap costs per update, how its digest-keyed position index is maintained through the sift, and the throughput it measures at
 - [Test Coverage Map](./tests.md)
+- [E2E Testing Harness](./e2e_testing_harness.md) - how the end-to-end suites are built and what a new sketch must satisfy
+- [E2E Coverage Matrix](./e2e_coverage_matrix.md) - which public instance is covered by which test, under which error bound, and whether that bound is a theorem or a documented empirical band
 - [Feature Status](./features.md)
 
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -720,7 +720,7 @@ Test file: [`src/sketch_framework/nitro.rs`](../src/sketch_framework/nitro.rs)
 | test_name | test_description | what_is_tested |
 | --- | --- | --- |
 | `nitro_batch_countmin_error_bound_zipf` | Nitro batch countmin error bound Zipf. | On Zipf stream (`rows=3`, `cols=4096`, `N=200_000`), verifies CountMin estimates satisfy in-bound key count `> (1-delta)*distinct` using `epsilon=e/cols`, `delta=e^-rows`, and bound `epsilon*N`. |
-| `nitro_batch_count_error_bound_zipf` | Nitro batch count error bound Zipf. | Applies the same probabilistic in-bound criterion to `Count` median estimates with `epsilon=e/cols`, `delta=e^-rows`, and bound `epsilon*N`. |
+| `nitro_batch_count_error_bound_zipf` | Nitro batch Count Sketch L2 error bound on a Zipf stream. | On the same stream, checks `Count` median estimates against **Count Sketch's own** bound `sqrt(kappa/cols) * \|\|f_-i\|\|_2` (kappa = 3, residual L2 recomputed per key from the exact frequency vector), requiring the in-bound share to exceed `1 - P[Bin(rows, 1/3) >= ceil(rows/2)]`. Count-Min's `epsilon*N` does not apply to this sketch and is far looser on a skewed stream. Sampling RNG is seeded. |
 
 ### ExponentialHistogram
 

--- a/src/message_pack_format/portable/hydra_kll.rs
+++ b/src/message_pack_format/portable/hydra_kll.rs
@@ -24,6 +24,18 @@ impl HydraKllSketch {
         Self { sketch, rows, cols }
     }
 
+    /// [`HydraKllSketch::new`] with an explicit compaction-coin seed shared by
+    /// every cell.
+    ///
+    /// `new` seeds from the wall clock, so two runs over the same input give
+    /// different per-key quantiles. Pass a seed when the result has to be
+    /// reproducible — replaying a stream, comparing two processes, or
+    /// asserting an accuracy bound in a test.
+    pub fn with_seed(rows: usize, cols: usize, k: u16, seed: u64) -> Self {
+        let sketch = vec![vec![KllSketch::with_seed(k, seed); cols]; rows];
+        Self { sketch, rows, cols }
+    }
+
     /// Number of hash rows in the sketch matrix.
     pub fn rows(&self) -> usize {
         self.rows

--- a/src/message_pack_format/portable/kll.rs
+++ b/src/message_pack_format/portable/kll.rs
@@ -21,6 +21,12 @@ pub fn new_sketchlib_kll(k: u16) -> SketchlibKll {
     KLL::init_kll(k as i32)
 }
 
+/// [`new_sketchlib_kll`] with an explicit compaction-coin seed, so the sketch
+/// replays identically across runs.
+pub fn new_sketchlib_kll_with_seed(k: u16, seed: u64) -> SketchlibKll {
+    KLL::init_kll_with_seed(k as i32, seed)
+}
+
 /// Updates a sketchlib KLL with one numeric observation.
 pub fn sketchlib_kll_update(inner: &mut SketchlibKll, value: f64) {
     inner.update(&value);
@@ -58,6 +64,19 @@ impl KllSketch {
         Self {
             k,
             backend: new_sketchlib_kll(k),
+        }
+    }
+
+    /// [`KllSketch::new`] with an explicit compaction-coin seed.
+    ///
+    /// `new` seeds the coin from the wall clock, so two runs over the same
+    /// input produce different sketches. Pass a seed when the result has to be
+    /// reproducible — replaying a stream, comparing two processes, or
+    /// asserting an accuracy bound in a test.
+    pub fn with_seed(k: u16, seed: u64) -> Self {
+        Self {
+            k,
+            backend: new_sketchlib_kll_with_seed(k, seed),
         }
     }
 

--- a/src/sketch_framework/eh_sketch_list.rs
+++ b/src/sketch_framework/eh_sketch_list.rs
@@ -142,6 +142,10 @@ impl EHSketchList {
             (EHSketchList::DDS(s), EHSketchList::DDS(o)) => s
                 .merge(o)
                 .map_err(|_| "Cannot merge DDSketches with different index mappings"),
+            (EHSketchList::ELASTIC(s), EHSketchList::ELASTIC(o)) => {
+                s.merge(o);
+                Ok(())
+            }
             (EHSketchList::HLL(s), EHSketchList::HLL(o)) => {
                 s.merge(o);
                 Ok(())

--- a/src/sketch_framework/nitro.rs
+++ b/src/sketch_framework/nitro.rs
@@ -161,28 +161,17 @@ impl Default for NitroBatch<Vector2D<u32>> {
 impl NitroBatch<Vector2D<u32>> {
     /// Creates a Nitro sketch with the given sampling rate.
     pub fn init_nitro(rate: f64) -> Self {
-        assert!(
-            !rate.is_nan() && rate > 0.0 && rate <= 1.0,
-            "sample_rate must be within (0.0, 1.0]"
-        );
-        let inv_ln = if (rate - 1.0).abs() <= f64::EPSILON {
-            0.0 // Not used for full sampling
-        } else {
-            1.0 / (1.0 - rate).ln()
-        };
-        let mut nitro = Self {
-            sampling_rate: rate,
-            to_skip: 0,
-            inv_ln_one_minus_p: inv_ln,
-            generator: new_small_rng(),
-            delta: 0,
-            idx: 0,
-            mask: 0x10000,
-            sk: Vector2D::init(5, 2048),
-        };
-        nitro.sk.fill(0);
-        nitro.delta = nitro.scaled_increment(1);
-        nitro
+        let mut sk = Vector2D::init(5, 2048);
+        sk.fill(0);
+        Self::with_target(rate, sk)
+    }
+
+    /// [`NitroBatch::init_nitro`] with an explicit sampling-RNG seed. See
+    /// [`NitroBatch::with_target_and_seed`].
+    pub fn init_nitro_with_seed(rate: f64, seed: u64) -> Self {
+        let mut sk = Vector2D::init(5, 2048);
+        sk.fill(0);
+        Self::with_target_and_seed(rate, sk, seed)
     }
 }
 
@@ -203,7 +192,27 @@ impl<S: NitroTarget> NitroBatch<S> {
     }
 
     /// Wraps an existing target sketch with Nitro sampling.
+    ///
+    /// The sampling RNG is seeded from the OS, so two runs over the same input
+    /// admit different subsets. Use [`NitroBatch::with_target_and_seed`] when
+    /// the result has to be reproducible.
     pub fn with_target(rate: f64, sk: S) -> Self {
+        Self::build(rate, sk, new_small_rng())
+    }
+
+    /// Wraps an existing target sketch with Nitro sampling driven by an
+    /// explicitly seeded RNG.
+    ///
+    /// Sampling is where all of Nitro's randomness lives: which updates reach
+    /// the target sketch is drawn from the geometric skip distribution. With a
+    /// fixed seed the admitted subset — and therefore every estimate — is a
+    /// deterministic function of the input, which is what lets an accuracy
+    /// bound be asserted reproducibly instead of re-rolled on every run.
+    pub fn with_target_and_seed(rate: f64, sk: S, seed: u64) -> Self {
+        Self::build(rate, sk, SmallRng::seed_from_u64(seed))
+    }
+
+    fn build(rate: f64, sk: S, generator: SmallRng) -> Self {
         assert!(
             !rate.is_nan() && rate > 0.0 && rate <= 1.0,
             "sample_rate must be within (0.0, 1.0]"
@@ -217,7 +226,7 @@ impl<S: NitroTarget> NitroBatch<S> {
             sampling_rate: rate,
             to_skip: 0,
             inv_ln_one_minus_p: inv_ln,
-            generator: new_small_rng(),
+            generator,
             delta: 0,
             idx: 0,
             mask: 0x10000,
@@ -349,6 +358,10 @@ mod tests {
     use crate::test_utils::sample_zipf_u64;
     use std::collections::HashMap;
 
+    /// Fixed sampling-RNG seed. `with_target` seeds from the OS, so an
+    /// accuracy assertion built on it would be re-rolled every run.
+    const NITRO_TEST_SEED: u64 = 0x0117_5EED;
+
     #[test]
     fn nitro_batch_countmin_error_bound_zipf() {
         let rows = 3;
@@ -369,7 +382,7 @@ mod tests {
             .collect();
 
         let cm = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(rows, cols);
-        let mut batch = NitroBatch::with_target(1.0, cm);
+        let mut batch = NitroBatch::with_target_and_seed(1.0, cm, NITRO_TEST_SEED);
         batch.insert(&data);
 
         let epsilon = std::f64::consts::E / cols as f64;
@@ -409,23 +422,41 @@ mod tests {
             .collect();
 
         let cs = Count::<Vector2D<i32>, FastPath>::with_dimensions(rows, cols);
-        let mut batch = NitroBatch::with_target(1.0, cs);
+        let mut batch = NitroBatch::with_target_and_seed(1.0, cs, NITRO_TEST_SEED);
         batch.insert(&data);
 
-        let epsilon = std::f64::consts::E / cols as f64;
-        let delta = 1.0 / std::f64::consts::E.powi(rows as i32);
-        let error_bound = epsilon * samples as f64;
-        let correct_lower_bound = truth.len() as f64 * (1.0 - delta);
+        // Count Sketch's bound, not Count-Min's. The error is driven by the L2
+        // norm of the residual frequency vector and is rank-independent:
+        //
+        //   Var[row estimator] <= ||f_-i||_2^2 / w
+        //   Chebyshev at t = sqrt(kappa/w) * ||f_-i||_2 -> per-row failure 1/kappa
+        //   the reported value is the median of d rows, so the query fails
+        //   only when at least ceil(d/2) rows do.
+        //
+        // Reusing Count-Min's eps*N here would be checking a bound this sketch
+        // never claimed — and on a Zipf stream that bound is far looser, so it
+        // would pass almost regardless of what the sketch did.
+        const KAPPA: f64 = 3.0;
+        let f2: f64 = truth.values().map(|c| (*c as f64) * (*c as f64)).sum();
+        // P[Bin(3, 1/3) >= 2] = 7/27.
+        let median_failure = 7.0 / 27.0;
+        let correct_lower_bound = truth.len() as f64 * (1.0 - median_failure);
         let mut within_count = 0;
-        for key in truth.keys() {
+        for (key, exact) in &truth {
+            let f = *exact as f64;
+            let residual_l2 = (f2 - f * f).max(0.0).sqrt();
+            let error_bound = (KAPPA / cols as f64).sqrt() * residual_l2;
             let est = batch.estimate_median(&DataInput::I64(*key));
-            if (est - (*truth.get(key).unwrap() as f64)).abs() < error_bound {
+            if (est - f).abs() <= error_bound {
                 within_count += 1;
             }
         }
         assert!(
             within_count as f64 > correct_lower_bound,
-            "in-bound items number {within_count} not greater than expected amount {correct_lower_bound}"
+            "{within_count} of {} keys within sqrt(kappa/w)*||f_-i||_2; the median-of-{rows} \
+             bound allows a failure probability of {median_failure:.4}, so at least \
+             {correct_lower_bound:.1} must be in bound",
+            truth.len()
         );
     }
 }

--- a/src/sketches/kll_dynamic.rs
+++ b/src/sketches/kll_dynamic.rs
@@ -48,6 +48,13 @@ pub struct KLLDynamic<T: NumericalValue = f64> {
     m: usize, // Minimum buffer size (usually 8)
     num_levels: usize,
     co: Coin,
+    /// Explicit seed for the compaction coin, when present. Set by
+    /// [`KLLDynamic::init_with_seed`] / [`KLLDynamic::init_kll_with_seed`] so
+    /// a sketch replays identically across runs and `clear()` re-seeds from
+    /// the same value. Not part of the wire format: it describes how the
+    /// sketch was built, not what it currently holds.
+    #[serde(skip)]
+    seed: Option<u64>,
     /// Cached level capacities by height (from top to bottom)
     #[serde(skip)]
     capacity_cache: [u32; CAPACITY_CACHE_LEN],
@@ -68,6 +75,23 @@ impl<T: NumericalValue> Default for KLLDynamic<T> {
 impl<T: NumericalValue> KLLDynamic<T> {
     /// Creates a KLLDynamic sketch with the given `k` and `m` parameters.
     pub fn init(k: usize, m: usize) -> Self {
+        Self::init_internal(k, m, Coin::new(), None)
+    }
+
+    /// Creates a KLLDynamic sketch with an explicit RNG seed for the
+    /// compaction coin. Two sketches built with the same seed and fed the same
+    /// input produce identical state, which is what makes reproducible-replay
+    /// scenarios and deterministic accuracy tests possible. The seed is also
+    /// stored so `clear()` re-seeds deterministically.
+    ///
+    /// The unseeded [`KLLDynamic::init`] draws from the wall clock, so a
+    /// sketch built with it cannot be used to assert an accuracy bound
+    /// reproducibly. Mirrors [`crate::KLL::init_with_seed`].
+    pub fn init_with_seed(k: usize, m: usize, seed: u64) -> Self {
+        Self::init_internal(k, m, Coin::from_seed(seed), Some(seed))
+    }
+
+    fn init_internal(k: usize, m: usize, coin: Coin, seed: Option<u64>) -> Self {
         let mut norm_m = m.min(MAX_CACHEABLE_K);
         norm_m = norm_m.max(2);
         let mut norm_k = k.max(norm_m);
@@ -80,7 +104,8 @@ impl<T: NumericalValue> KLLDynamic<T> {
             k: norm_k,
             m: norm_m,
             num_levels: 1,
-            co: Coin::new(),
+            co: coin,
+            seed,
             capacity_cache: [0; CAPACITY_CACHE_LEN],
             top_height: 0,
             level0_capacity: 0,
@@ -92,6 +117,11 @@ impl<T: NumericalValue> KLLDynamic<T> {
     /// Creates a KLLDynamic sketch with default `m` and the provided `k`.
     pub fn init_kll(k: i32) -> Self {
         Self::init(k as usize, 8)
+    }
+
+    /// `init_kll` with an explicit RNG seed. See [`KLLDynamic::init_with_seed`].
+    pub fn init_kll_with_seed(k: i32, seed: u64) -> Self {
+        Self::init_with_seed(k as usize, 8, seed)
     }
 
     fn push_value(&mut self, value: T) {
@@ -247,7 +277,13 @@ impl<T: NumericalValue> KLLDynamic<T> {
         self.items.clear();
         self.levels = Vector1D::filled(2, 0);
         self.num_levels = 1;
-        self.co = Coin::new();
+        // Re-seed from the construction seed when there is one, so a cleared
+        // sketch replays exactly like a fresh one; fall back to the wall clock
+        // for the unseeded constructor.
+        self.co = match self.seed {
+            Some(s) => Coin::from_seed(s),
+            None => Coin::new(),
+        };
         self.rebuild_capacity_cache();
     }
 

--- a/src/sketches/kll_dynamic/wire.rs
+++ b/src/sketches/kll_dynamic/wire.rs
@@ -74,6 +74,9 @@ where
             m: meta.m as usize,
             num_levels,
             co: Coin::from_wire(coin.state, coin.bit_cache, coin.remaining_bits as u8),
+            // The wire carries the coin's live state, not the construction
+            // seed, so a decoded sketch has no seed to re-derive on `clear()`.
+            seed: None,
             capacity_cache: [0; CAPACITY_CACHE_LEN],
             top_height: 0,
             level0_capacity: 0,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,18 +1,33 @@
 # E2E Testing Harness & Conformance Kit
 
 Every sketch in `asap_sketchlib` is validated end-to-end against exact ground
-truth from seeded synthetic streams. New sketches **must** go through the
-same conformance batteries before landing — copy an adapter from
-`tests/conformance_kit.rs`, run the batteries, done.
+truth from seeded synthetic streams, and every approximate answer is judged
+against **its own family's** error bound.
+
+New sketches go through the conformance batteries — copy an adapter from
+`tests/conformance_kit.rs` — and then assert their actual guarantee with the
+matching spec from `tests/common/specs.rs`. The batteries are a floor, not the
+guarantee: passing them says a sketch is not grossly broken, not that it meets
+its theorem.
+
+[`docs/e2e_coverage_matrix.md`](../docs/e2e_coverage_matrix.md) is the
+authority on which public instance is covered by which test, under which bound,
+and whether that bound is a theorem or a documented empirical band.
 
 ## Layout
 
 | Path | Purpose |
 | --- | --- |
-| `common/mod.rs` | Seeded stream generators (`zipf_u64`, `uniform_u64`, `normal_f64`, `exponential_f64`, adversarial `log_uniform_f64`), exact truth trackers (`FreqTruth`, `NumericTruth`), assertion helpers |
-| `common/conformance.rs` | Capability traits + standard conformance batteries |
+| `common/mod.rs` | Seeded stream generators (`zipf_u64`, `uniform_u64`, `normal_f64`, `exponential_f64`, adversarial `log_uniform_f64`, `duplicate_heavy_f64`, `monotonic_f64`, `outside_in_ordering`), exact truth trackers (`FreqTruth`, `NumericTruth`), assertion helpers |
+| `common/specs.rs` | One error model per metric — `CountMinSpec`, `CountSketchSpec`, `SecondMomentSpec`, `RankErrorSpec`, `RelativeQuantileSpec`, `CardinalityConfidenceSpec`, `SamplingConfidenceSpec` — plus the binomial acceptance rules |
+| `common/conformance.rs` | Capability traits + standard conformance batteries (the floor) |
 | `conformance_kit.rs` | Reference adapters: established sketches running through the kit (copy these) |
-| `e2e_frequency.rs` / `e2e_cardinality.rs` / `e2e_quantiles.rs` / `e2e_frameworks.rs` | Deep per-family suites with hand-tuned tolerances |
+| `e2e_frequency.rs` / `e2e_cardinality.rs` / `e2e_quantiles.rs` | Deep per-family suites, each against its own theorem |
+| `e2e_matrix_instances.rs` | Every built-in `(storage, hashing path)` instance of CountMin / Count / CMSHeap / CSHeap, plus counter-width edges |
+| `e2e_numeric_types.rs` | Every `NumericalValue` type through `KLL<T>`, `KLLDynamic<T>` and `DDSketch::add<T>` |
+| `e2e_windows.rs` | Every `EHSketchList` variant in an `ExponentialHistogram`, and every `TumblingWindow` payload |
+| `e2e_composition.rs` | `HashSketchEnsemble`, `NitroBatch`, `UnivMonQ`'s config surface, and the portable sketch+heap facade |
+| `e2e_frameworks.rs` | Hydra's subpopulation lattice and UnivMon composition |
 | `e2e_heavy_hitters.rs` | Space-Saving's error sandwich, `min_count` ceiling and Stream-Summary lists under sustained eviction, plus CocoSketch and Elastic through the batteries and the heavy-hitter properties no battery models |
 | `e2e_membership.rs` | Bloom: no false negative, exact union, and the delivered false-positive rate against its own sizing |
 | `e2e_octo.rs` | OctoSketch delta-promotion invariants, the `octo-runtime` pipeline, and conformance to the paper's Theorems 1-4 and its sketch-merge baseline |
@@ -36,8 +51,7 @@ same conformance batteries before landing — copy an adapter from
 2. **Write one adapter struct** implementing the trait(s) by delegating to
    your public API. See any adapter in `tests/conformance_kit.rs`.
 
-3. **Run the battery** with production-shaped dimensions and tolerances from
-   your sketch's documentation:
+3. **Run the battery** with production-shaped dimensions, as a smoke test:
 
    ```rust
    conformance::quantile_battery(
@@ -49,17 +63,38 @@ same conformance batteries before landing — copy an adapter from
    .assert_ok();
    ```
 
-4. **Add deeper, sketch-specific checks** (merge semantics, windowing,
+4. **Assert your sketch's actual bound** with the matching spec from
+   `common/specs.rs`, evaluated at the parameters the instance reports:
+
+   ```rust
+   let spec = CountSketchSpec::new(sketch.rows(), sketch.cols());
+   spec.assert_contract("MyNewSketch", &truth, |k| sketch.estimate(k), &context);
+   ```
+
+   If no spec fits, add one — one spec per metric, with the formula, the
+   per-check failure probability, and the citation in its doc comment. Do not
+   reuse another family's.
+
+5. **Add deeper, sketch-specific checks** (merge semantics, windowing,
    serialization) as a test in the matching `e2e_*.rs` suite.
+
+6. **Add a row to `docs/e2e_coverage_matrix.md`.**
 
 ## Rules
 
-- All randomness flows through seeded generators; no `rand::rng()` in tests.
+- All randomness flows through seeded generators; no `rand::rng()` in tests,
+  and no sketch constructed by a wall-clock-seeded constructor. Stream seeds
+  and sketch seeds are separate and both are pinned.
 - Ground truth is tracked exactly while generating — never re-derived from
   another approximation.
-- Tolerances must be justified: theory bounds when they exist (α for DDS,
-  rank error for KLL, ε·N for CMS), otherwise documented empirical values
-  consistent with existing suites.
+- Tolerances are **computed from the instance's own parameters**, not written
+  down. A tolerance that does not move with `k`, `w` or the precision is not
+  that family's bound.
+- Theory-backed tests are named `*_satisfies_<theorem_or_bound>`; measured ones
+  are named `*_stays_within_the_documented_empirical_band` and record the
+  configuration, seed and measured value they came from.
+- Never widen a bound to make a failure pass. If the correct bound exposes a
+  defect, keep the reproducing test and fix the implementation.
 - Batteries accumulate failures into a `BatteryReport`; call `.assert_ok()`
   once at the end so a single run reports every violation, not just the first.
 
@@ -67,6 +102,8 @@ same conformance batteries before landing — copy an adapter from
 
 ```bash
 cargo test --test conformance_kit        # kit + reference adapters
+cargo test --test e2e_matrix_instances   # every storage x path instance
+cargo test --test e2e_numeric_types      # every NumericalValue type
 cargo test --all-features               # everything, incl. e2e_experimental
 cargo run --release --example accuracy_probe --features experimental
                                          # heavy release-only probes

--- a/tests/bug_verification.rs
+++ b/tests/bug_verification.rs
@@ -21,12 +21,16 @@ use asap_sketchlib::{
 // Synthetic stream: one key inserted 100_000 times at rate 1.0.
 // Truth: 100_000. Current behavior: 0.
 // ---------------------------------------------------------------------------
+/// Fixed sampling-RNG seed so these regressions reproduce exactly.
+const NITRO_SEED: u64 = 0x8E_9101;
+
 #[test]
 fn nitro_estimate_median_matches_insert_hash_domain() {
     let n = 100_000i64;
-    let mut nb = NitroBatch::with_target(
+    let mut nb = NitroBatch::with_target_and_seed(
         1.0,
         CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(5, 2048),
+        NITRO_SEED,
     );
     nb.insert(&vec![7i64; n as usize]);
 
@@ -52,9 +56,10 @@ fn nitro_estimate_is_not_divided_by_rows() {
     let n = 100_000i64;
     let rows = 5usize;
     for rate in [1.0f64, 0.5, 0.25] {
-        let mut nb = NitroBatch::with_target(
+        let mut nb = NitroBatch::with_target_and_seed(
             rate,
             CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(rows, 2048),
+            NITRO_SEED,
         );
         nb.insert(&vec![7i64; n as usize]);
         let est = nb.estimate_median(&DataInput::I64(7));

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -158,6 +158,16 @@ impl Default for CardinalitySpec {
 
 pub const DEFAULT_QUANTILE_QS: [f64; 5] = [0.1, 0.25, 0.5, 0.75, 0.9];
 
+/// Smoke-test spec for sketches that promise **rank** error (the KLL family,
+/// UnivMon-Q's ordered queries).
+///
+/// This is deliberately not a general quantile spec. A sketch that promises
+/// *relative value* error instead — DDSketch — has no rank guarantee at all
+/// and must go through [`relative_quantile_battery`]; running it here would be
+/// asserting a property it does not claim. The tie-breaking form of the rank
+/// contract, and the `eps(k)` that ties the band to the sketch's own `k`, live
+/// in `super::specs::RankErrorSpec`; `rank_tol` here is a loose floor for
+/// catching gross breakage in a new adapter.
 #[derive(Clone, Copy)]
 pub struct QuantileSpec {
     /// Rank-tolerance band width for quantile checks.
@@ -375,7 +385,10 @@ where
     report
 }
 
-/// Quantile battery: rank-band checks across the standard q grid.
+/// Rank-error battery: rank-band checks across the standard q grid.
+///
+/// For sketches whose guarantee is on the **rank** of the returned value. See
+/// [`relative_quantile_battery`] for the value-error families.
 pub fn quantile_battery<S, F>(
     sketch: &str,
     new_sketch: F,
@@ -403,6 +416,51 @@ where
             "rank band",
             est >= lo && est <= hi,
             format!("q={q} est {est:.3} outside [{lo:.3}, {hi:.3}]"),
+        );
+    }
+    report
+}
+
+/// Relative-value-error battery: for sketches that bound
+/// `|est - true| / |true|` against the exact order statistic, such as
+/// DDSketch.
+///
+/// Kept separate from [`quantile_battery`] because the two guarantees are not
+/// interchangeable: a rank band says nothing about DDSketch's promise, and a
+/// relative-value band says nothing about KLL's. The nearest-rank (ceil)
+/// convention matches `DDSketch::get_value_at_quantile`.
+pub fn relative_quantile_battery<S, F>(
+    sketch: &str,
+    new_sketch: F,
+    values: &[f64],
+    spec: super::specs::RelativeQuantileSpec,
+    qs: &[f64],
+) -> BatteryReport
+where
+    S: QuantileOps,
+    F: Fn() -> S,
+{
+    let mut report = BatteryReport {
+        sketch: sketch.to_string(),
+        battery: "relative-quantile",
+        failures: vec![],
+    };
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut sk = new_sketch();
+    for v in values {
+        sk.update(*v);
+    }
+    let n = sorted.len();
+    for &q in qs {
+        let idx = ((q.clamp(0.0, 1.0) * n as f64).ceil() as usize).clamp(1, n);
+        let truth = sorted[idx - 1];
+        let est = sk.quantile(q);
+        let outcome = spec.check(q, est, truth);
+        report.record(
+            "relative value error",
+            outcome.is_ok(),
+            outcome.err().unwrap_or_default(),
         );
     }
     report

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,6 +9,7 @@
 #![allow(dead_code)]
 
 pub mod conformance;
+pub mod specs;
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -83,6 +84,51 @@ pub fn log_uniform_f64(n: usize, gamma: f64, k_range: std::ops::Range<i32>, seed
             };
             gamma.powi(k) * (1.0 + frac * (gamma - 1.0))
         })
+        .collect()
+}
+
+/// `n` values drawn from a small domain so most values repeat many times.
+/// Rank-error checks must survive heavy ties, where one value legitimately
+/// spans a wide rank interval.
+pub fn duplicate_heavy_f64(n: usize, distinct: usize, seed: u64) -> Vec<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| (rng.random::<u64>() % distinct as u64) as f64)
+        .collect()
+}
+
+/// Strictly increasing values: the worst case for a compactor that assumes
+/// arrivals are unordered.
+pub fn monotonic_f64(n: usize, start: f64, step: f64) -> Vec<f64> {
+    (0..n).map(|i| start + step * i as f64).collect()
+}
+
+/// Adversarial ordering of a fixed multiset: the sorted values are emitted
+/// alternately from the two ends inward, so every compaction sees a stream
+/// whose local order is maximally unlike its global order.
+pub fn outside_in_ordering(mut values: Vec<f64>) -> Vec<f64> {
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let (mut lo, mut hi) = (0usize, values.len());
+    let mut out = Vec::with_capacity(values.len());
+    while lo < hi {
+        out.push(values[lo]);
+        lo += 1;
+        if lo < hi {
+            hi -= 1;
+            out.push(values[hi]);
+        }
+    }
+    out
+}
+
+/// `n` draws from Zipf(s) mapped onto a fixed value grid spanning
+/// `[lo, hi]`, so a heavy-tailed key distribution becomes a heavy-tailed
+/// *value* distribution usable by quantile sketches.
+pub fn zipf_f64(n: usize, domain: usize, exponent: f64, lo: f64, hi: f64, seed: u64) -> Vec<f64> {
+    let step = (hi - lo) / (domain - 1) as f64;
+    zipf_u64(n, domain, exponent, seed)
+        .into_iter()
+        .map(|i| lo + step * i as f64)
         .collect()
 }
 
@@ -194,6 +240,21 @@ impl NumericTruth {
     /// Empirical share of observations <= x.
     pub fn cdf(&self, x: f64) -> f64 {
         self.sorted.iter().filter(|v| **v <= x).count() as f64 / self.sorted.len() as f64
+    }
+
+    /// The ascending sorted observations.
+    pub fn sorted(&self) -> &[f64] {
+        &self.sorted
+    }
+
+    /// The closed interval of normalized ranks the value `x` occupies:
+    /// `(|{v < x}| / n, |{v <= x}| / n)`. Stating rank error on this interval
+    /// is what keeps the check correct when values repeat.
+    pub fn rank_interval(&self, x: f64) -> (f64, f64) {
+        let n = self.sorted.len() as f64;
+        let excl = self.sorted.partition_point(|v| *v < x) as f64 / n;
+        let incl = self.sorted.partition_point(|v| *v <= x) as f64 / n;
+        (excl, incl)
     }
 
     /// Allowed value band for a quantile query with rank tolerance `tol`.

--- a/tests/common/specs.rs
+++ b/tests/common/specs.rs
@@ -1,0 +1,840 @@
+//! Error-model specifications, one per *error metric*, plus the statistical
+//! machinery that turns a theorem into an acceptance rule.
+//!
+//! The specs in [`super::conformance`] carry loose smoke-test tolerances,
+//! which is the right thing for wiring up a new adapter but wrong as a
+//! statement of theory: KLL promises *rank* error while DDSketch promises
+//! *relative value* error, and Count-Min's one-sided additive `eps*N` is not
+//! Count Sketch's two-sided `L2/sqrt(w)`. Each spec here models exactly one
+//! guarantee and nothing else, so no two families can be judged by the same
+//! number by accident.
+//!
+//! Every spec exposes three things:
+//!
+//! 1. the **bound formula**, computed from the sketch's own configuration and
+//!    the exact ground truth — never a hand-picked percentage;
+//! 2. the **per-check failure probability** the theorem allows; and
+//! 3. an **acceptance rule** over many checks, derived from the binomial tail
+//!    at a fixed test level, so the number of tolerated violations is fixed
+//!    before the run rather than after seeing the result.
+//!
+//! Where a guarantee has no closed form, or the public API cannot expose the
+//! dimension a theorem quantifies over, the test says so and is named
+//! `*_stays_within_the_documented_empirical_band` rather than being dressed up
+//! as theory. See `docs/e2e_coverage_matrix.md` for which is which.
+
+#![allow(dead_code)]
+
+use super::FreqTruth;
+
+// ---------------------------------------------------------------------------
+// Binomial machinery
+// ---------------------------------------------------------------------------
+
+/// `ln(n choose k)` via log-gamma, stable for the counts used here.
+fn ln_choose(n: usize, k: usize) -> f64 {
+    if k > n {
+        return f64::NEG_INFINITY;
+    }
+    ln_factorial(n) - ln_factorial(k) - ln_factorial(n - k)
+}
+
+/// `ln(n!)` — exact summation below 256, Stirling/Lanczos above.
+fn ln_factorial(n: usize) -> f64 {
+    if n < 256 {
+        (1..=n).map(|i| (i as f64).ln()).sum()
+    } else {
+        let x = n as f64 + 1.0;
+        // Stirling series; accurate to well past the precision this needs.
+        (x - 0.5) * x.ln() - x
+            + 0.5 * (std::f64::consts::TAU).ln()
+            + 1.0 / (12.0 * x)
+            + -1.0 / (360.0 * x * x * x)
+    }
+}
+
+/// `P(Binomial(n, p) >= k)`.
+pub fn binomial_tail_ge(n: usize, k: usize, p: f64) -> f64 {
+    if k == 0 {
+        return 1.0;
+    }
+    if k > n {
+        return 0.0;
+    }
+    if p <= 0.0 {
+        return 0.0;
+    }
+    if p >= 1.0 {
+        return 1.0;
+    }
+    let (lp, l1p) = (p.ln(), (1.0 - p).ln());
+    let mut acc = 0.0;
+    for i in k..=n {
+        acc += (ln_choose(n, i) + i as f64 * lp + (n - i) as f64 * l1p).exp();
+    }
+    acc.min(1.0)
+}
+
+/// The largest violation count a run may show and still be consistent with a
+/// per-check failure probability of `p`, at test level `test_level`.
+///
+/// Returns the smallest `c` with `P(Binomial(trials, p) > c) <= test_level`.
+/// Fixing `test_level` up front is what stops a tolerance from being tuned to
+/// whatever the current run happens to produce.
+pub fn max_allowed_failures(trials: usize, p: f64, test_level: f64) -> usize {
+    if trials == 0 {
+        return 0;
+    }
+    for c in 0..=trials {
+        if binomial_tail_ge(trials, c + 1, p) <= test_level {
+            return c;
+        }
+    }
+    trials
+}
+
+/// Standard test level for every acceptance rule in this file.
+///
+/// Every stream, every sketch seed and every trial grid in these suites is
+/// fixed, so a run is a deterministic function of the code — re-running
+/// cannot produce a different verdict and there is no flake to buy insurance
+/// against. The level therefore only has to be small enough that a *correct*
+/// implementation clears it with room to spare, and large enough that the
+/// acceptance rule still bites: at 1e-6 a battery of a few hundred checks
+/// tolerates roughly two to five times the theorem's expected violation
+/// count, not twenty times.
+pub const TEST_LEVEL: f64 = 1e-6;
+
+// ---------------------------------------------------------------------------
+// Violation tallies
+// ---------------------------------------------------------------------------
+
+/// Accumulates violations across checks (and across trials) so a single
+/// acceptance rule is applied once, at the end, to the whole population.
+#[derive(Debug, Default)]
+pub struct Tally {
+    pub checks: usize,
+    pub violations: usize,
+    /// Up to `SAMPLE_LIMIT` rendered violations, for the failure message.
+    pub samples: Vec<String>,
+}
+
+const SAMPLE_LIMIT: usize = 12;
+
+impl Tally {
+    pub fn record(&mut self, ok: bool, detail: impl FnOnce() -> String) {
+        self.checks += 1;
+        if !ok {
+            self.violations += 1;
+            if self.samples.len() < SAMPLE_LIMIT {
+                self.samples.push(detail());
+            }
+        }
+    }
+
+    /// Applies the binomial acceptance rule for a per-check failure
+    /// probability of `p`, panicking with the full context on rejection.
+    pub fn assert_within(self, label: &str, p: f64, context: &str) {
+        let allowed = max_allowed_failures(self.checks, p, TEST_LEVEL);
+        assert!(
+            self.violations <= allowed,
+            "{label}: {} of {} checks violated the bound; the theorem's per-check \
+             failure probability p={p:.3e} allows at most {allowed} at test level \
+             {TEST_LEVEL:.0e}.\n  context: {context}\n  first violations:\n{}",
+            self.violations,
+            self.checks,
+            self.samples
+                .iter()
+                .map(|s| format!("    {s}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
+
+    /// Applies a rule that tolerates no violations at all — for structural
+    /// guarantees (Count-Min never underestimates, Bloom never has a false
+    /// negative) rather than probabilistic ones.
+    pub fn assert_none(self, label: &str, context: &str) {
+        assert!(
+            self.violations == 0,
+            "{label}: {} of {} checks violated a structural (non-probabilistic) \
+             guarantee.\n  context: {context}\n  first violations:\n{}",
+            self.violations,
+            self.checks,
+            self.samples
+                .iter()
+                .map(|s| format!("    {s}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Count-Min: one-sided additive error
+// ---------------------------------------------------------------------------
+
+/// Count-Min Sketch, Cormode & Muthukrishnan (2005), Theorem 1.
+///
+/// For a sketch of `d` rows and `w` columns, with `f` the exact frequency
+/// vector and `N = ||f||_1`:
+///
+/// - **structural:** `est(i) >= f(i)` for every key, always, no probability;
+/// - **probabilistic:** `P[ est(i) - f(i) > e * (N - f(i)) / w ] <= e^-d`.
+///
+/// The row estimator is `f(i) + X_r` with `X_r >= 0` and
+/// `E[X_r] = (N - f(i)) / w` (only the *other* keys can collide into `i`'s
+/// cell). Markov gives `P[X_r >= e * E[X_r]] <= 1/e` per row; the `d` rows use
+/// independent hashes and the minimum exceeds the bound only if every row
+/// does, hence `e^-d`.
+///
+/// `N - f(i)` rather than `N` is the tighter and correct tail mass: it is what
+/// the expectation actually is, and using `N` would silently hand a hot key a
+/// larger budget than the theorem grants it.
+#[derive(Clone, Copy, Debug)]
+pub struct CountMinSpec {
+    pub rows: usize,
+    pub cols: usize,
+}
+
+impl CountMinSpec {
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self { rows, cols }
+    }
+
+    /// `e * (N - f_i) / w` — the additive excess budget for one key.
+    pub fn excess_bound(&self, total_mass: f64, key_mass: f64) -> f64 {
+        std::f64::consts::E * (total_mass - key_mass) / self.cols as f64
+    }
+
+    /// `e^-d` — the probability a single key's minimum exceeds the budget.
+    pub fn per_key_failure(&self) -> f64 {
+        (-(self.rows as f64)).exp()
+    }
+
+    /// Runs the full Count-Min contract over every key in `truth`.
+    ///
+    /// The one-sided half is asserted with zero tolerated violations (it is
+    /// structural); the additive half uses the binomial acceptance rule at
+    /// `e^-d`.
+    pub fn assert_contract<F>(&self, label: &str, truth: &FreqTruth, estimate: F, context: &str)
+    where
+        F: Fn(i64) -> f64,
+    {
+        let total = truth.total() as f64;
+        let mut one_sided = Tally::default();
+        let mut additive = Tally::default();
+        for (key, count) in truth.pairs() {
+            let est = estimate(key);
+            let f = count as f64;
+            one_sided.record(est >= f, || {
+                format!("key {key}: est {est} < true {f} (Count-Min must never underestimate)")
+            });
+            let bound = self.excess_bound(total, f);
+            additive.record(est - f <= bound, || {
+                format!(
+                    "key {key}: excess {:.1} > e*(N-f)/w = {bound:.1} (true {f}, est {est})",
+                    est - f
+                )
+            });
+        }
+        let ctx = format!(
+            "{context}; rows={} cols={} N={total:.0} distinct={}",
+            self.rows,
+            self.cols,
+            truth.distinct()
+        );
+        one_sided.assert_none(&format!("{label} / one-sided"), &ctx);
+        additive.assert_within(
+            &format!("{label} / additive e*(N-f)/w"),
+            self.per_key_failure(),
+            &ctx,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Count Sketch: two-sided L2 error
+// ---------------------------------------------------------------------------
+
+/// Count Sketch, Charikar, Chen & Farach-Colton (2002).
+///
+/// This is **not** Count-Min's bound and must not reuse `eps * N`. Count
+/// Sketch's error is driven by the L2 norm of the *residual* frequency vector,
+/// is two-sided (signed), and is rank-independent — a cold key gets the same
+/// absolute error band as the hottest one.
+///
+/// Per row `r`, the estimator is `X_r = s_r(i) * C[r][h_r(i)]`, which is
+/// unbiased with
+///
+/// ```text
+///   E[X_r] = f(i)
+///   Var[X_r] <= || f_{-i} ||_2^2 / w
+/// ```
+///
+/// where `f_{-i}` is `f` with coordinate `i` removed and `w` is the row width.
+/// Chebyshev at `t = sqrt(kappa / w) * || f_{-i} ||_2` gives a per-row failure
+/// probability of at most `1 / kappa`. The reported estimate is the median of
+/// the `d` rows, so it exceeds `t` only when at least `ceil(d/2)` independent
+/// rows do:
+///
+/// ```text
+///   P[ |est(i) - f(i)| > sqrt(kappa / w) * ||f_{-i}||_2 ]
+///        <= P[ Binomial(d, 1/kappa) >= ceil(d/2) ]
+/// ```
+///
+/// `kappa = 3` is the usual choice (per-row failure 1/3, so the median is a
+/// genuine amplification); it is a declared constant of the spec, not a fudge
+/// factor multiplied onto a bound after the fact.
+#[derive(Clone, Copy, Debug)]
+pub struct CountSketchSpec {
+    pub rows: usize,
+    pub cols: usize,
+    /// Chebyshev slack. Per-row failure probability is `1 / kappa`.
+    pub kappa: f64,
+}
+
+impl CountSketchSpec {
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            kappa: 3.0,
+        }
+    }
+
+    /// `sqrt(kappa / w) * ||f_{-i}||_2` for one key's residual L2 norm.
+    pub fn error_scale(&self, residual_l2: f64) -> f64 {
+        (self.kappa / self.cols as f64).sqrt() * residual_l2
+    }
+
+    /// `1 / kappa` — Chebyshev's per-row failure probability.
+    pub fn per_row_failure(&self) -> f64 {
+        1.0 / self.kappa
+    }
+
+    /// `P[Binomial(d, 1/kappa) >= ceil(d/2)]` — failure after the row median.
+    pub fn per_key_failure(&self) -> f64 {
+        let majority = self.rows / 2 + 1;
+        binomial_tail_ge(self.rows, majority, self.per_row_failure())
+    }
+
+    /// Runs the L2 contract over every key in `truth`.
+    ///
+    /// The residual norm is recomputed per key from the exact frequency
+    /// vector: `||f_{-i}||_2 = sqrt(F2 - f(i)^2)`.
+    pub fn assert_contract<F>(&self, label: &str, truth: &FreqTruth, estimate: F, context: &str)
+    where
+        F: Fn(i64) -> f64,
+    {
+        let mut tally = Tally::default();
+        self.tally_into(&mut tally, truth, estimate);
+        let ctx = format!(
+            "{context}; rows={} cols={} kappa={} F2={:.3e} distinct={}",
+            self.rows,
+            self.cols,
+            self.kappa,
+            truth.f2(),
+            truth.distinct()
+        );
+        tally.assert_within(label, self.per_key_failure(), &ctx);
+    }
+
+    /// Same checks, accumulated into a caller-owned tally so several
+    /// independent trials share one acceptance rule.
+    pub fn tally_into<F>(&self, tally: &mut Tally, truth: &FreqTruth, estimate: F)
+    where
+        F: Fn(i64) -> f64,
+    {
+        let f2 = truth.f2();
+        for (key, count) in truth.pairs() {
+            let f = count as f64;
+            let residual_l2 = (f2 - f * f).max(0.0).sqrt();
+            let bound = self.error_scale(residual_l2);
+            let est = estimate(key);
+            tally.record((est - f).abs() <= bound, || {
+                format!(
+                    "key {key}: |{est:.1} - {f}| = {:.1} > sqrt(kappa/w)*||f_-i||_2 = {bound:.1}",
+                    (est - f).abs()
+                )
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Second moment (F2) from a Count Sketch row
+// ---------------------------------------------------------------------------
+
+/// F2 estimation from the counter matrix of a Count Sketch, as `CountL2HH`
+/// and UnivMon do.
+///
+/// Each row's `Y_r = sum_j C[r][j]^2` is the AMS tug-of-war estimator (Alon,
+/// Matias & Szegedy 1996; Charikar, Chen & Farach-Colton 2002):
+///
+/// ```text
+///   E[Y_r]   = F2
+///   Var[Y_r] = 2 (F2^2 - sum_i f_i^4) / w  <=  2 F2^2 / w
+/// ```
+///
+/// Chebyshev at `t = sqrt(2 kappa / w) * F2` gives a per-row failure
+/// probability of `1 / kappa`, and the reported value is the median over the
+/// `d` rows, so the query fails only when at least `ceil(d/2)` rows do.
+///
+/// This is *not* an exactly maintained quantity: the accumulator tracks the
+/// sketch's own counters, which carry collisions, so the answer is an estimate
+/// with a real error bound and must be checked as one.
+#[derive(Clone, Copy, Debug)]
+pub struct SecondMomentSpec {
+    pub rows: usize,
+    pub cols: usize,
+    pub kappa: f64,
+}
+
+impl SecondMomentSpec {
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            kappa: 3.0,
+        }
+    }
+
+    /// `sqrt(2 kappa / w)` — the relative half-width around the exact F2.
+    pub fn relative_bound(&self) -> f64 {
+        (2.0 * self.kappa / self.cols as f64).sqrt()
+    }
+
+    pub fn per_row_failure(&self) -> f64 {
+        1.0 / self.kappa
+    }
+
+    pub fn per_query_failure(&self) -> f64 {
+        binomial_tail_ge(self.rows, self.rows / 2 + 1, self.per_row_failure())
+    }
+
+    pub fn check(&self, estimate: f64, exact_f2: f64) -> Result<(), String> {
+        let rel = ((estimate - exact_f2) / exact_f2).abs();
+        let bound = self.relative_bound();
+        if rel <= bound {
+            Ok(())
+        } else {
+            Err(format!(
+                "F2 estimate {estimate:.6e} vs exact {exact_f2:.6e}: relative error {rel:.5} >                  sqrt(2*kappa/w) = {bound:.5} (rows={} cols={} kappa={})",
+                self.rows, self.cols, self.kappa
+            ))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KLL: rank error
+// ---------------------------------------------------------------------------
+
+/// Normalized-rank-error contract for a KLL sketch of parameter `k`.
+///
+/// KLL (Karnin, Lang & Liberty, FOCS 2016) promises *rank* error, not value
+/// error: for a query at normalized rank `q` the returned value `v` must
+/// satisfy
+///
+/// ```text
+///   rank_incl(v) >= q - eps   and   rank_excl(v) <= q + eps
+/// ```
+///
+/// where `rank_excl(v) = |{x < v}| / n` and `rank_incl(v) = |{x <= v}| / n`.
+/// Stating it on the *interval* of ranks that `v` occupies is what makes the
+/// check correct on streams with many repeated values, where a single value
+/// legitimately spans a wide rank range.
+///
+/// The constant comes from the Apache DataSketches published contract for KLL,
+/// `getNormalizedRankError(k, false)`:
+///
+/// ```text
+///   eps(k) = 2.446 / k^0.9433      (single-sided, at 99% confidence)
+/// ```
+///
+/// so `k = 200` gives `eps ~ 0.0165` and a per-query failure probability of
+/// 0.01. That is *tighter* than the 0.02/0.03 constants it replaces, and it is
+/// tied to `k`: doubling `k` halves the band, which a hard-coded 0.02 does not.
+#[derive(Clone, Copy, Debug)]
+pub struct RankErrorSpec {
+    pub k: usize,
+    /// Per-query failure probability the constant is quoted at.
+    pub failure_probability: f64,
+}
+
+impl RankErrorSpec {
+    /// The DataSketches contract at 99% confidence.
+    pub fn datasketches(k: usize) -> Self {
+        Self {
+            k,
+            failure_probability: 0.01,
+        }
+    }
+
+    /// `eps(k) = 2.446 / k^0.9433`.
+    pub fn epsilon(&self) -> f64 {
+        2.446 / (self.k as f64).powf(0.9433)
+    }
+
+    /// Checks one `(q, value)` answer against the rank band of `sorted`.
+    ///
+    /// `sorted` must be ascending. Returns `Ok(())` or a rendered violation.
+    pub fn check(&self, sorted: &[f64], q: f64, value: f64) -> Result<(), String> {
+        rank_violation(sorted, q, value, self.epsilon())
+            .map(|d| Err(format!("{d} (k={})", self.k)))
+            .unwrap_or(Ok(()))
+    }
+
+    /// Tallies one sketch's answers over a q grid.
+    pub fn tally_into<F>(&self, tally: &mut Tally, sorted: &[f64], qs: &[f64], quantile: F)
+    where
+        F: Fn(f64) -> f64,
+    {
+        for &q in qs {
+            let v = quantile(q);
+            let outcome = self.check(sorted, q, v);
+            tally.record(outcome.is_ok(), || outcome.unwrap_err());
+        }
+    }
+}
+
+/// The rank-error predicate itself, independent of where `eps` came from.
+///
+/// A quantile answer `value` for a query at normalized rank `q` is correct
+/// within `eps` when the interval of ranks `value` occupies overlaps
+/// `[q - eps, q + eps]`. Stating it on the interval rather than on a single
+/// rank is what keeps the predicate correct when values repeat.
+///
+/// Returns `None` when the answer is within the band, or a rendered violation.
+/// Shared so that estimators deriving `eps` from a different theorem — KLL
+/// from `k`, UnivMon-Q from its occurrence-sample bound — check the same
+/// predicate rather than each rolling their own.
+pub fn rank_violation(sorted: &[f64], q: f64, value: f64, eps: f64) -> Option<String> {
+    let n = sorted.len();
+    assert!(n > 0, "rank error is undefined on an empty stream");
+    let excl = sorted.partition_point(|x| *x < value) as f64 / n as f64;
+    let incl = sorted.partition_point(|x| *x <= value) as f64 / n as f64;
+    if incl >= q - eps && excl <= q + eps {
+        None
+    } else {
+        Some(format!(
+            "q={q}: value {value} occupies ranks [{excl:.5}, {incl:.5}], outside \
+             [q-eps, q+eps] = [{:.5}, {:.5}] for eps={eps:.5}",
+            q - eps,
+            q + eps
+        ))
+    }
+}
+
+/// Two-sided Dvoretzky-Kiefer-Wolfowitz / Hoeffding band for an empirical CDF
+/// built from `m` uniform samples of the stream:
+///
+/// ```text
+///   P[ sup_x |F_m(x) - F(x)| > sqrt(ln(2/delta) / (2m)) ] <= delta
+/// ```
+///
+/// This is the residual term `epsilon_R` in UnivMon-Q's documented
+/// ordered-query bound, and it is the whole bound in the diffuse regime where
+/// the heavy set is empty.
+pub fn occurrence_sample_epsilon(samples: usize, delta: f64) -> f64 {
+    ((2.0 / delta).ln() / (2.0 * samples as f64)).sqrt()
+}
+
+// ---------------------------------------------------------------------------
+// DDSketch: relative value error
+// ---------------------------------------------------------------------------
+
+/// Relative-value-error contract for a DDSketch of accuracy parameter `alpha`.
+///
+/// DDSketch's guarantee is on the *value*, not the rank: the returned estimate
+/// for the `q`-quantile must be within `alpha` relative error of the **exact
+/// nearest-rank order statistic** at the same `q`.
+///
+/// ```text
+///   |est - true| / |true| <= alpha + numerical_slack(true)
+/// ```
+///
+/// With the logarithmic mapping `k = floor(ln v / ln gamma)`,
+/// `gamma = (1+alpha)/(1-alpha)`, and bucket representative
+/// `gamma^k * (1+alpha)`, a value at the bucket's lower edge is over-estimated
+/// by exactly `alpha` and one approaching the upper edge is under-estimated by
+/// almost `alpha` — so `alpha` is attained but never exceeded in exact
+/// arithmetic.
+///
+/// `numerical_slack` is therefore a *floating-point* term only, on the order of
+/// a few ULP: `ln`, `floor` and `powf` compose to a relative error of roughly
+/// `|ln v| * f64::EPSILON`. It is emphatically not a percentage of `alpha` —
+/// `alpha * 1.05` would accept results that break the advertised guarantee by
+/// 5%, which is the entire thing the guarantee exists to forbid.
+#[derive(Clone, Copy, Debug)]
+pub struct RelativeQuantileSpec {
+    pub alpha: f64,
+}
+
+impl RelativeQuantileSpec {
+    pub fn new(alpha: f64) -> Self {
+        Self { alpha }
+    }
+
+    /// A few ULP of headroom, scaled by the magnitude of the logarithm because
+    /// that is what `powf`/`ln` round-off actually tracks.
+    pub fn numerical_slack(&self, true_value: f64) -> f64 {
+        8.0 * f64::EPSILON * (1.0 + true_value.abs().ln().abs())
+    }
+
+    pub fn tolerance(&self, true_value: f64) -> f64 {
+        self.alpha + self.numerical_slack(true_value)
+    }
+
+    /// Checks one estimate against the exact order statistic.
+    pub fn check(&self, q: f64, estimate: f64, true_value: f64) -> Result<(), String> {
+        let tol = self.tolerance(true_value);
+        let rel = ((estimate - true_value) / true_value.abs()).abs();
+        if rel <= tol {
+            Ok(())
+        } else {
+            Err(format!(
+                "q={q}: est {estimate:.10e} vs exact order statistic {true_value:.10e} \
+                 -> relative error {rel:.3e} > alpha + slack = {tol:.3e} (alpha={})",
+                self.alpha
+            ))
+        }
+    }
+
+    /// Tallies a sketch's answers over a q grid against exact order statistics.
+    ///
+    /// `sorted` must be ascending; the nearest-rank (ceil) convention is used,
+    /// matching `DDSketch::get_value_at_quantile`.
+    pub fn tally_into<F>(&self, tally: &mut Tally, sorted: &[f64], qs: &[f64], quantile: F)
+    where
+        F: Fn(f64) -> Option<f64>,
+    {
+        let n = sorted.len();
+        for &q in qs {
+            let idx = ((q.clamp(0.0, 1.0) * n as f64).ceil() as usize).clamp(1, n);
+            let truth = sorted[idx - 1];
+            match quantile(q) {
+                None => tally.record(false, || format!("q={q}: sketch returned None")),
+                Some(est) => {
+                    let outcome = self.check(q, est, truth);
+                    tally.record(outcome.is_ok(), || outcome.unwrap_err());
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HLL / KMV: cardinality confidence bands
+// ---------------------------------------------------------------------------
+
+/// Which estimator's error model a cardinality band is derived from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CardinalityModel {
+    /// Flajolet, Fusy, Gandouet & Meunier (2007): relative standard error
+    /// `1.04 / sqrt(m)` for `m = 2^precision` registers. Ertl's maximum
+    /// likelihood estimator (2017) attains the same Cramer-Rao bound
+    /// `sqrt(3 ln 2 - 1) / sqrt(m) = 1.0389 / sqrt(m)`, so both share this
+    /// constant.
+    HyperLogLogRegisters,
+    /// Historic Inverse Probability (Cohen 2015; Ting 2014): relative standard
+    /// error `sqrt(ln 2 / m) = 0.8326 / sqrt(m)`. HIP is strictly tighter than
+    /// the register-only estimators because it integrates the insertion
+    /// history, so it must not be checked against their constant.
+    HyperLogLogHip,
+    /// K-Minimum-Values: the estimator `(k-1)/U_(k)` has relative standard
+    /// error `1 / sqrt(k - 2)`, which this models as `1 / sqrt(k - 1)` — the
+    /// customary and marginally conservative form. Below `k` distinct
+    /// elements the sketch is exact, not estimated.
+    KMinimumValues,
+}
+
+/// A cardinality band `n * (1 +- z * sigma_rel)` with an explicit `z`.
+///
+/// Nothing here is a flat percentage: `sigma_rel` comes from the estimator's
+/// own error model and `z` is stated as a Gaussian quantile, so the failure
+/// probability of each check is `2 * (1 - Phi(z))` and the whole battery gets
+/// a binomial acceptance rule like every other spec.
+#[derive(Clone, Copy, Debug)]
+pub struct CardinalityConfidenceSpec {
+    pub model: CardinalityModel,
+    /// `m` registers for HLL, `k` retained minima for KMV.
+    pub size: usize,
+    /// Gaussian quantile. `z = 4` is a two-sided failure probability of
+    /// 6.3e-5 per check.
+    pub z: f64,
+}
+
+impl CardinalityConfidenceSpec {
+    pub fn hll(precision: u32, z: f64) -> Self {
+        Self {
+            model: CardinalityModel::HyperLogLogRegisters,
+            size: 1usize << precision,
+            z,
+        }
+    }
+
+    pub fn hll_hip(precision: u32, z: f64) -> Self {
+        Self {
+            model: CardinalityModel::HyperLogLogHip,
+            size: 1usize << precision,
+            z,
+        }
+    }
+
+    pub fn kmv(k: usize, z: f64) -> Self {
+        Self {
+            model: CardinalityModel::KMinimumValues,
+            size: k,
+            z,
+        }
+    }
+
+    /// The estimator's relative standard error.
+    pub fn sigma_rel(&self) -> f64 {
+        let n = self.size as f64;
+        match self.model {
+            CardinalityModel::HyperLogLogRegisters => 1.04 / n.sqrt(),
+            CardinalityModel::HyperLogLogHip => (std::f64::consts::LN_2 / n).sqrt(),
+            CardinalityModel::KMinimumValues => 1.0 / (n - 1.0).sqrt(),
+        }
+    }
+
+    /// `z * sigma_rel` — the half-width of the accepted relative band.
+    pub fn tolerance(&self) -> f64 {
+        self.z * self.sigma_rel()
+    }
+
+    /// Two-sided Gaussian failure probability at `z`.
+    pub fn per_check_failure(&self) -> f64 {
+        2.0 * (1.0 - standard_normal_cdf(self.z))
+    }
+
+    /// KMV below `k` distinct elements keeps every hash it has seen, so the
+    /// estimate is exact and no band applies.
+    pub fn is_exact_regime(&self, true_distinct: usize) -> bool {
+        self.model == CardinalityModel::KMinimumValues && true_distinct <= self.size
+    }
+
+    pub fn check(&self, estimate: f64, true_distinct: usize) -> Result<(), String> {
+        let t = true_distinct as f64;
+        if self.is_exact_regime(true_distinct) {
+            // Exact regime: the sketch holds every distinct hash it has seen.
+            return if (estimate - t).abs() <= 0.5 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "n={true_distinct} <= k={}: estimate {estimate} must be exact",
+                    self.size
+                ))
+            };
+        }
+        let tol = self.tolerance();
+        let rel = ((estimate - t) / t).abs();
+        if rel <= tol {
+            Ok(())
+        } else {
+            Err(format!(
+                "n={true_distinct}: estimate {estimate:.1} -> relative error {rel:.5} > \
+                 z*sigma = {:.2}*{:.5} = {tol:.5} (model {:?}, size {})",
+                self.z,
+                self.sigma_rel(),
+                self.model,
+                self.size
+            ))
+        }
+    }
+
+    pub fn tally_into(&self, tally: &mut Tally, estimate: f64, true_distinct: usize) {
+        let outcome = self.check(estimate, true_distinct);
+        tally.record(outcome.is_ok(), || outcome.unwrap_err());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nitro: sampling confidence
+// ---------------------------------------------------------------------------
+
+/// Confidence band for a Bernoulli-sampled counter, as NitroSketch uses.
+///
+/// Nitro admits each update with probability `p` and writes a weight of
+/// `ceil(1/p)`, so for a key of true count `f` the number of admitted updates
+/// is `X ~ Binomial(f, p)` and the estimate is `X * ceil(1/p)`. With `1/p`
+/// integral this is unbiased with
+///
+/// ```text
+///   sd(est) = (1/p) * sqrt(f * p * (1-p)) = sqrt(f * (1-p) / p)
+/// ```
+///
+/// so the accepted band is `f +- z * sqrt(f (1-p) / p)`, plus whatever the
+/// wrapped sketch's own error contributes. At `p = 1` the band collapses to
+/// zero width, which is correct — full sampling is exact.
+#[derive(Clone, Copy, Debug)]
+pub struct SamplingConfidenceSpec {
+    pub rate: f64,
+    pub z: f64,
+}
+
+impl SamplingConfidenceSpec {
+    pub fn new(rate: f64, z: f64) -> Self {
+        Self { rate, z }
+    }
+
+    /// Standard deviation of the scaled estimate for a key of count `f`.
+    pub fn sigma(&self, true_count: f64) -> f64 {
+        if self.rate >= 1.0 {
+            return 0.0;
+        }
+        (true_count * (1.0 - self.rate) / self.rate).sqrt()
+    }
+
+    /// Half-width of the accepted band, before any sketch-side error.
+    pub fn half_width(&self, true_count: f64) -> f64 {
+        self.z * self.sigma(true_count)
+    }
+
+    pub fn per_check_failure(&self) -> f64 {
+        2.0 * (1.0 - standard_normal_cdf(self.z))
+    }
+
+    /// `sketch_slack` is added to the sampling band for the wrapped sketch's
+    /// own error (zero when the sketch is exact for the probed key).
+    pub fn check(&self, estimate: f64, true_count: f64, sketch_slack: f64) -> Result<(), String> {
+        let half = self.half_width(true_count) + sketch_slack;
+        if (estimate - true_count).abs() <= half {
+            Ok(())
+        } else {
+            Err(format!(
+                "rate={} : estimate {estimate:.1} vs true {true_count:.0}, |error| {:.1} > \
+                 z*sigma + slack = {:.2}*{:.2} + {sketch_slack:.1} = {half:.1}",
+                self.rate,
+                (estimate - true_count).abs(),
+                self.z,
+                self.sigma(true_count),
+            ))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared numerics
+// ---------------------------------------------------------------------------
+
+/// `Phi(z)` via the Abramowitz & Stegun 7.1.26 error-function approximation
+/// (absolute error < 1.5e-7), which is far finer than any band it sizes.
+pub fn standard_normal_cdf(z: f64) -> f64 {
+    0.5 * (1.0 + erf(z / std::f64::consts::SQRT_2))
+}
+
+fn erf(x: f64) -> f64 {
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + 0.3275911 * x);
+    let y = 1.0
+        - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t
+            + 0.254829592)
+            * t
+            * (-x * x).exp();
+    sign * y
+}

--- a/tests/conformance_kit.rs
+++ b/tests/conformance_kit.rs
@@ -323,6 +323,15 @@ fn hll_variants_pass_cardinality_conformance() {
     .assert_ok();
 }
 
+/// Compaction-coin seed for the KLL adapters. The unseeded `init_kll`
+/// constructors draw from the wall clock, so a failure under them would not
+/// reproduce.
+const KIT_KLL_SEED: u64 = 0x4017_0001;
+
+/// The KLL family through the **rank-error** battery.
+///
+/// DDSketch is deliberately absent: it promises relative *value* error and has
+/// no rank guarantee, so it goes through `relative_quantile_battery` below.
 #[test]
 fn kll_family_passes_quantile_conformance() {
     let values: Vec<f64> = common::normal_f64(40_000, 500.0, 80.0, 7001)
@@ -332,7 +341,7 @@ fn kll_family_passes_quantile_conformance() {
 
     conformance::quantile_battery(
         "KLL",
-        || KllAdapter(KLL::init_kll(200)),
+        || KllAdapter(KLL::init_kll_with_seed(200, KIT_KLL_SEED)),
         &values,
         QuantileSpec::default(),
     )
@@ -340,28 +349,37 @@ fn kll_family_passes_quantile_conformance() {
 
     conformance::quantile_battery(
         "KLLDynamic",
-        || KllDynamicAdapter(KLLDynamic::<f64>::init_kll(200)),
+        || KllDynamicAdapter(KLLDynamic::<f64>::init_kll_with_seed(200, KIT_KLL_SEED)),
         &values,
         QuantileSpec::default(),
-    )
-    .assert_ok();
-
-    conformance::quantile_battery(
-        "PortableDds",
-        || PortableDdsAdapter(PortableDds::new(0.01)),
-        &values,
-        QuantileSpec {
-            rank_tol: 0.02,
-            ..QuantileSpec::default()
-        },
     )
     .assert_ok();
 
     conformance::quantile_battery(
         "KLL-cached",
-        || KllCachedAdapter(RefCell::new(KLL::init_kll(200))),
+        || KllCachedAdapter(RefCell::new(KLL::init_kll_with_seed(200, KIT_KLL_SEED))),
         &values,
         QuantileSpec::default(),
+    )
+    .assert_ok();
+}
+
+/// DDSketch through the **relative-value-error** battery, against exact
+/// nearest-rank order statistics — the guarantee it actually makes.
+#[test]
+fn ddsketch_passes_relative_quantile_conformance() {
+    const ALPHA: f64 = 0.01;
+    let values: Vec<f64> = common::normal_f64(40_000, 500.0, 80.0, 7001)
+        .into_iter()
+        .filter(|v| *v > 0.0)
+        .collect();
+
+    conformance::relative_quantile_battery(
+        "PortableDds",
+        || PortableDdsAdapter(PortableDds::new(ALPHA)),
+        &values,
+        common::specs::RelativeQuantileSpec::new(ALPHA),
+        &conformance::DEFAULT_QUANTILE_QS,
     )
     .assert_ok();
 }

--- a/tests/e2e_bulk.rs
+++ b/tests/e2e_bulk.rs
@@ -166,28 +166,35 @@ fn kll_bulk_data_input_batch_matches_loop() {
     assert_eq!(sk2.count(), 0);
 }
 
+/// With a seeded coin, `KLLDynamic`'s bulk path must be *exactly* the loop
+/// path — same retained mass, same quantile bits. The previous version of this
+/// test built both sides with the wall-clock-seeded `init_kll`, so the two
+/// sketches had different coins and the 5% count tolerance was absorbing
+/// nondeterminism rather than measuring anything about `bulk_update`.
 #[test]
-fn kll_dynamic_bulk_vs_loop_with_tolerance() {
-    // KLLDynamic is wall-clock seeded (non-deterministic), so we only check
-    // count within 5% and rank bands, not byte-identical.
+fn kll_dynamic_bulk_vs_loop_is_exact_under_a_shared_seed() {
+    const SKETCH_SEED: u64 = 0x5EED_0700;
     let vals = normal_f64(10_000, 0.0, 100.0, 9002);
     let truth = NumericTruth::new(vals.clone());
 
-    let mut via_loop = KLLDynamic::<f64>::init_kll(200);
+    let mut via_loop = KLLDynamic::<f64>::init_kll_with_seed(200, SKETCH_SEED);
     for v in &vals {
         via_loop.update(v);
     }
-    let mut via_bulk = KLLDynamic::<f64>::init_kll(200);
+    let mut via_bulk = KLLDynamic::<f64>::init_kll_with_seed(200, SKETCH_SEED);
     via_bulk.bulk_update(&vals);
 
-    let ca = via_loop.count() as f64;
-    let cb = via_bulk.count() as f64;
-    assert!(
-        (ca - cb).abs() / ca < 0.05,
-        "KLLDynamic count loop {ca} vs bulk {cb}"
+    assert_eq!(
+        via_loop.count(),
+        via_bulk.count(),
+        "KLLDynamic seeded bulk vs loop: retained mass diverged          (sketch_seed={SKETCH_SEED:#x}, stream seed 9002)"
     );
-
     for &q in &QS {
+        assert_eq!(
+            via_loop.quantile(q).to_bits(),
+            via_bulk.quantile(q).to_bits(),
+            "KLLDynamic q={q}: seeded bulk vs loop quantile bits differ              (sketch_seed={SKETCH_SEED:#x})"
+        );
         assert_in_rank_band(via_loop.quantile(q), &truth, q, RANK_TOL, "KLLDynamic loop");
         assert_in_rank_band(via_bulk.quantile(q), &truth, q, RANK_TOL, "KLLDynamic bulk");
     }

--- a/tests/e2e_cardinality.rs
+++ b/tests/e2e_cardinality.rs
@@ -1,104 +1,382 @@
-//! E2E cardinality pipelines on synthetic unique streams: core HLL variants
-//! (+ shard merge), the portable wire HLL, and SetAggregator exactness.
+//! E2E cardinality pipelines on synthetic unique streams.
+//!
+//! Every band here is computed from the estimator's own relative standard
+//! error and an explicit Gaussian quantile `z`; none is a flat percentage.
+//! That distinction matters because the three estimators do *not* share an
+//! error model:
+//!
+//! - `Classic` is Flajolet et al.'s register estimator, RSE `1.04 / sqrt(m)`.
+//! - `ErtlMLE` is the maximum-likelihood estimator over the same registers; it
+//!   attains the Cramer-Rao bound `sqrt(3 ln 2 - 1) / sqrt(m) = 1.0389/sqrt(m)`,
+//!   so the same constant applies.
+//! - `HIP` integrates the insertion history and is strictly tighter, RSE
+//!   `sqrt(ln 2 / m) = 0.8326 / sqrt(m)`. Holding it to Classic's constant
+//!   would pass a HIP implementation that had silently degraded to a register
+//!   estimator, so it is held to its own.
+//!
+//! A single hard-coded 2% would be simultaneously too loose at p16 (4.9 sigma)
+//! and too tight at p12 (1.2 sigma), which is why it is gone.
 
 mod common;
 
-use common::{assert_between, uniform_u64};
+use common::specs::{CardinalityConfidenceSpec, Tally};
+use common::uniform_u64;
 
 use asap_sketchlib::message_pack_format::portable::hll::{HllSketch, HllVariant};
-use asap_sketchlib::{DataInput, HyperLogLog, HyperLogLogHIP, SetAggregator};
+use asap_sketchlib::{
+    Classic, DataInput, ErtlMLE, HyperLogLogHIPP12, HyperLogLogHIPP14, HyperLogLogHIPP16,
+    HyperLogLogP12, HyperLogLogP14, HyperLogLogP16, SetAggregator,
+};
 
-#[test]
-fn hll_variants_checkpoints_and_shard_merge() {
-    // Checkpoints span the linear-counting regime (below the register count)
-    // and the estimator regime above it.
-    let checkpoints = [10u64, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000];
-    let mut classic = HyperLogLog::<asap_sketchlib::Classic>::new();
-    let mut ertl = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
-    let mut hip = HyperLogLogHIP::new();
-    // Even/odd shard split for the merge leg of the test.
-    let mut classic_even = HyperLogLog::<asap_sketchlib::Classic>::new();
-    let mut classic_odd = HyperLogLog::<asap_sketchlib::Classic>::new();
-    let mut ertl_even = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
-    let mut ertl_odd = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
+/// Gaussian quantile for every cardinality band below. `z = 4` is a two-sided
+/// failure probability of 6.3e-5 per check; with a few dozen checks per
+/// battery the binomial acceptance rule then tolerates zero failures, which is
+/// the intent — an estimator four standard errors out is broken, not unlucky.
+const Z: f64 = 4.0;
 
-    let mut seen = 0u64;
-    for &target in &checkpoints {
-        while seen < target {
-            let d = DataInput::U64(seen);
-            classic.insert(&d);
-            ertl.insert(&d);
-            hip.insert(&d);
-            if seen % 2 == 0 {
-                classic_even.insert(&d);
-                ertl_even.insert(&d);
-            } else {
-                classic_odd.insert(&d);
-                ertl_odd.insert(&d);
+/// Checkpoints spanning the linear-counting regime (far below the register
+/// count) and the raw-estimator regime well above it.
+///
+/// They deliberately avoid `n` between roughly `2m` and `4m`, where the 2007
+/// estimator switches from linear counting to the raw indicator and its error
+/// is *not* `1.04/sqrt(m)`. That band has its own test below rather than being
+/// swept under this one's tolerance.
+const CHECKPOINTS: [u64; 7] = [10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000];
+
+/// Runs one core HLL type across every checkpoint, in three ingestion modes:
+/// a single pass, a replay of the same identities (which must not move the
+/// estimate at all, since registers only ever take a maximum), and a merge of
+/// two disjoint shards.
+///
+/// `$merge` says whether the type supports merging: HIP's estimate is
+/// maintained incrementally from its own insertion history, so it has no
+/// merge operation and only the first two modes apply.
+macro_rules! hll_battery {
+    ($name:ident, $ty:ty, $precision:literal, $model:ident, mergeable) => {
+        hll_battery!(@body $name, $ty, $precision, $model, |even: &$ty, odd: &$ty| {
+            // Disjoint shards: registers max together, so the merge is exactly
+            // the sketch of the concatenated stream.
+            let mut merged = even.clone();
+            merged.merge(odd);
+            Some(merged.estimate() as f64)
+        });
+    };
+    ($name:ident, $ty:ty, $precision:literal, $model:ident, not_mergeable) => {
+        hll_battery!(@body $name, $ty, $precision, $model, |_even: &$ty, _odd: &$ty| None);
+    };
+    (@body $name:ident, $ty:ty, $precision:literal, $model:ident, $merge:expr) => {
+        #[test]
+        fn $name() {
+            let spec = CardinalityConfidenceSpec::$model($precision, Z);
+            let mut tally = Tally::default();
+            let context = format!(
+                "{} p{} : m={} sigma_rel={:.5} z={Z} tolerance={:.5}, identities 0..n",
+                stringify!($ty),
+                $precision,
+                1usize << $precision,
+                spec.sigma_rel(),
+                spec.tolerance()
+            );
+
+            let mut single = <$ty>::new();
+            let mut even = <$ty>::new();
+            let mut odd = <$ty>::new();
+            let mut seen = 0u64;
+
+            for &target in &CHECKPOINTS {
+                while seen < target {
+                    let d = DataInput::U64(seen);
+                    single.insert(&d);
+                    if seen % 2 == 0 {
+                        even.insert(&d);
+                    } else {
+                        odd.insert(&d);
+                    }
+                    seen += 1;
+                }
+                spec.tally_into(&mut tally, single.estimate() as f64, target as usize);
+
+                let merge_estimate: fn(&$ty, &$ty) -> Option<f64> = $merge;
+                if let Some(est) = merge_estimate(&even, &odd) {
+                    spec.tally_into(&mut tally, est, target as usize);
+                }
             }
-            seen += 1;
-        }
-        let t = target as f64;
-        for (label, est) in [
-            ("Classic", classic.estimate() as f64),
-            ("ErtlMLE", ertl.estimate() as f64),
-            ("HIP", hip.estimate() as f64),
-        ] {
-            assert_between(est, t * 0.98, t * 1.02, &format!("{label} @ {target}"));
-        }
 
-        let mut classic_merged = classic_even.clone();
-        classic_merged.merge(&classic_odd);
-        assert_between(
-            classic_merged.estimate() as f64,
-            t * 0.98,
-            t * 1.02,
-            &format!("Classic shard-merge @ {target}"),
-        );
+            // Duplicate replay: re-inserting every identity already seen must
+            // leave the estimate bit-identical, because a register only ever
+            // moves to a larger leading-zero count. This is structural, not a
+            // band.
+            let before = single.estimate();
+            for k in 0..CHECKPOINTS[CHECKPOINTS.len() - 1].min(200_000) {
+                single.insert(&DataInput::U64(k));
+            }
+            assert_eq!(
+                single.estimate(),
+                before,
+                "replaying seen identities moved the estimate. {context}"
+            );
 
-        let mut ertl_merged = ertl_even.clone();
-        ertl_merged.merge(&ertl_odd);
-        assert_between(
-            ertl_merged.estimate() as f64,
-            t * 0.98,
-            t * 1.02,
-            &format!("ErtlMLE shard-merge @ {target}"),
-        );
-    }
+            tally.assert_within(
+                concat!(stringify!($name), " / cardinality confidence band"),
+                spec.per_check_failure(),
+                &context,
+            );
+        }
+    };
 }
 
-#[test]
-fn portable_hll_precisions_over_byte_keys() {
-    for (precision, tol) in [(12u32, 0.03f64), (14u32, 0.02f64)] {
-        let mut hll = HllSketch::new(HllVariant::Regular, precision);
-        let stream = uniform_u64(200_000, u64::MAX / 4, 2001 + precision as u64);
-        let mut truth = std::collections::HashSet::new();
-        for k in stream {
-            truth.insert(k);
-            hll.update(k.to_be_bytes().as_slice());
-        }
-        let t = truth.len() as f64;
-        let est = hll.estimate();
-        assert_between(
-            est,
-            t * (1.0 - tol),
-            t * (1.0 + tol),
-            &format!("portable HLL p{precision}"),
-        );
+// Classic and Ertl-MLE share the register error model; HIP has its own.
+hll_battery!(
+    hll_classic_p12_satisfies_its_register_error_model,
+    HyperLogLogP12<Classic>,
+    12,
+    hll,
+    mergeable
+);
+hll_battery!(
+    hll_classic_p14_satisfies_its_register_error_model,
+    HyperLogLogP14<Classic>,
+    14,
+    hll,
+    mergeable
+);
+hll_battery!(
+    hll_classic_p16_satisfies_its_register_error_model,
+    HyperLogLogP16<Classic>,
+    16,
+    hll,
+    mergeable
+);
+hll_battery!(
+    hll_ertl_mle_p12_satisfies_the_cramer_rao_error_model,
+    HyperLogLogP12<ErtlMLE>,
+    12,
+    hll,
+    mergeable
+);
+hll_battery!(
+    hll_ertl_mle_p14_satisfies_the_cramer_rao_error_model,
+    HyperLogLogP14<ErtlMLE>,
+    14,
+    hll,
+    mergeable
+);
+hll_battery!(
+    hll_ertl_mle_p16_satisfies_the_cramer_rao_error_model,
+    HyperLogLogP16<ErtlMLE>,
+    16,
+    hll,
+    mergeable
+);
+hll_battery!(
+    hll_hip_p12_satisfies_the_hip_error_model,
+    HyperLogLogHIPP12,
+    12,
+    hll_hip,
+    not_mergeable
+);
+hll_battery!(
+    hll_hip_p14_satisfies_the_hip_error_model,
+    HyperLogLogHIPP14,
+    14,
+    hll_hip,
+    not_mergeable
+);
+hll_battery!(
+    hll_hip_p16_satisfies_the_hip_error_model,
+    HyperLogLogHIPP16,
+    16,
+    hll_hip,
+    not_mergeable
+);
 
-        // Merge a second sketch over the SAME identities (byte-identical
-        // encodings): registers max, so distinct count must not change.
-        let mut other = HllSketch::new(HllVariant::Regular, precision);
-        for k in &truth {
-            other.update((*k).to_be_bytes().as_slice());
+/// The portable wire type across every variant tag and precision.
+///
+/// `HllVariant` selects the *wire tag*, not the estimator: `HllSketch::estimate`
+/// runs the same register-based Classic formula for `Regular`, `Datafusion` and
+/// `Hip` alike. So all three are held to the register model — checking the
+/// `Hip` tag against HIP's tighter constant would be asserting a property this
+/// type does not implement.
+#[test]
+fn portable_hll_variants_and_precisions_satisfy_the_register_error_model() {
+    const N: usize = 200_000;
+    let mut tally = Tally::default();
+    let mut context = Vec::new();
+
+    for variant in [HllVariant::Regular, HllVariant::Datafusion, HllVariant::Hip] {
+        for precision in [12u32, 14, 16] {
+            let spec = CardinalityConfidenceSpec::hll(precision, Z);
+            let seed = 2001 + precision as u64;
+            let stream = uniform_u64(N, u64::MAX / 4, seed);
+            let truth: std::collections::HashSet<u64> = stream.iter().copied().collect();
+
+            let mut hll = HllSketch::new(variant, precision);
+            for k in &stream {
+                hll.update(k.to_be_bytes().as_slice());
+            }
+            spec.tally_into(&mut tally, hll.estimate(), truth.len());
+
+            // Merging a second sketch built over the SAME identities is a
+            // register-wise max with itself: the estimate must not move at all.
+            let mut other = HllSketch::new(variant, precision);
+            for k in &truth {
+                other.update((*k).to_be_bytes().as_slice());
+            }
+            let before = hll.estimate();
+            hll.merge(&other).expect("merge");
+            assert_eq!(
+                hll.estimate(),
+                before,
+                "{variant:?} p{precision}: merging identical identities moved the estimate"
+            );
+
+            // Disjoint shards must merge to the union's cardinality.
+            let mut left = HllSketch::new(variant, precision);
+            let mut right = HllSketch::new(variant, precision);
+            for (i, k) in stream.iter().enumerate() {
+                if i % 2 == 0 {
+                    left.update(k.to_be_bytes().as_slice());
+                } else {
+                    right.update(k.to_be_bytes().as_slice());
+                }
+            }
+            left.merge(&right).expect("shard merge");
+            spec.tally_into(&mut tally, left.estimate(), truth.len());
+
+            context.push(format!(
+                "{variant:?}/p{precision} sigma={:.5} tol={:.5} stream_seed={seed}",
+                spec.sigma_rel(),
+                spec.tolerance()
+            ));
         }
-        hll.merge(&other).expect("merge");
-        let rem = hll.estimate();
-        assert_between(
-            rem,
-            t * (1.0 - tol),
-            t * (1.0 + tol),
-            &format!("portable HLL p{precision} after duplicate-merge"),
+    }
+
+    tally.assert_within(
+        "portable HllSketch / cardinality confidence band",
+        CardinalityConfidenceSpec::hll(12, Z).per_check_failure(),
+        &format!("n={N} unique byte keys; {}", context.join("; ")),
+    );
+}
+
+/// A larger precision must actually buy accuracy. A fixed percentage band
+/// cannot see this — it passes identically at p12 and p16, so it would not
+/// notice a precision parameter that never reached the register array.
+///
+/// The measured quantity is the RSE itself, estimated as the root-mean-square
+/// relative error over eight disjoint identity blocks, so it is compared with
+/// `1.04/sqrt(m)` directly rather than through a single draw from it.
+#[test]
+fn hll_accuracy_improves_with_precision_as_the_error_model_predicts() {
+    // Comfortably inside the raw-estimator regime for every precision here
+    // (n/m is 244, 61 and 15 at p12, p14 and p16), so `1.04/sqrt(m)` is the
+    // applicable model at all three.
+    const N: u64 = 1_000_000;
+    const BLOCKS: u64 = 6;
+
+    macro_rules! measured_rse {
+        ($ty:ty) => {{
+            let mut sq = 0.0f64;
+            for b in 0..BLOCKS {
+                let mut s = <$ty>::new();
+                for i in 0..N {
+                    s.insert(&DataInput::U64(b * N + i));
+                }
+                let rel = (s.estimate() as f64 - N as f64) / N as f64;
+                sq += rel * rel;
+            }
+            (sq / BLOCKS as f64).sqrt()
+        }};
+    }
+
+    let errors = [
+        (12u32, measured_rse!(HyperLogLogP12<Classic>)),
+        (14, measured_rse!(HyperLogLogP14<Classic>)),
+        (16, measured_rse!(HyperLogLogP16<Classic>)),
+    ];
+
+    for (precision, rse) in &errors {
+        let predicted = CardinalityConfidenceSpec::hll(*precision, Z).sigma_rel();
+        assert!(
+            *rse <= predicted * 2.0,
+            "p{precision}: measured RSE {rse:.5} over {BLOCKS} disjoint blocks of {N} \
+             identities exceeds twice the predicted 1.04/sqrt(m) = {predicted:.5}"
+        );
+    }
+    // Sixteen times the registers must deliver at least twice the accuracy;
+    // the model predicts 4x.
+    assert!(
+        errors[0].1 >= errors[2].1 * 2.0,
+        "raising precision from p12 to p16 moved the measured RSE only from {:.5} to {:.5}; \
+         1.04/sqrt(m) predicts a 4x improvement, so precision is not reaching the registers",
+        errors[0].1,
+        errors[2].1
+    );
+}
+
+/// The Classic estimator's accuracy cliff at the linear-counting switchover.
+///
+/// `HyperLogLogImpl<Classic>::estimate` follows the original 2007 paper: it
+/// uses linear counting while the raw estimate is at or below `2.5m`, and the
+/// bias-corrected indicator above it. The two branches do not meet smoothly,
+/// so just around the switchover the relative error is several times
+/// `1.04/sqrt(m)` — this is the discontinuity HLL++ later removed with
+/// empirical bias correction, and it is a property of the estimator as
+/// shipped, not a defect introduced here.
+///
+/// Documented empirical regression, deliberately **not** presented as the
+/// register theorem: no theoretical constant covers this band.
+///
+/// Band source: RMS relative error over 6 disjoint identity blocks at
+/// `n = 2.5m`, measured as 2.1x the asymptotic RSE at p12, 3.5x at p14 and
+/// 6.3x at p16. The ceiling below is 10x, which pins the cliff without
+/// pretending it is not there; the floor asserts it is still a cliff, so that
+/// a future bias correction makes this test fail loudly and get updated rather
+/// than silently keeping a stale claim.
+#[test]
+fn hll_classic_switchover_band_stays_within_the_documented_empirical_band() {
+    const BLOCKS: u64 = 6;
+
+    macro_rules! rse_at {
+        ($ty:ty, $n:expr) => {{
+            let n: u64 = $n;
+            let mut sq = 0.0f64;
+            for b in 0..BLOCKS {
+                let mut s = <$ty>::new();
+                for i in 0..n {
+                    s.insert(&DataInput::U64(b * 20_000_000 + i));
+                }
+                let rel = (s.estimate() as f64 - n as f64) / n as f64;
+                sq += rel * rel;
+            }
+            (sq / BLOCKS as f64).sqrt()
+        }};
+    }
+
+    let measured = [
+        (
+            12u32,
+            rse_at!(HyperLogLogP12<Classic>, (2.5 * 4096.0) as u64),
+        ),
+        (14, rse_at!(HyperLogLogP14<Classic>, (2.5 * 16384.0) as u64)),
+        (16, rse_at!(HyperLogLogP16<Classic>, (2.5 * 65536.0) as u64)),
+    ];
+
+    for (precision, rse) in &measured {
+        let asymptotic = CardinalityConfidenceSpec::hll(*precision, Z).sigma_rel();
+        let ratio = rse / asymptotic;
+        assert!(
+            ratio <= 10.0,
+            "p{precision} at n = 2.5m: RMS relative error {rse:.5} is {ratio:.2}x the \
+             asymptotic 1.04/sqrt(m) = {asymptotic:.5}, past the documented 10x band for the \
+             linear-counting switchover"
+        );
+        assert!(
+            ratio >= 1.5,
+            "p{precision} at n = 2.5m: RMS relative error {rse:.5} is only {ratio:.2}x the \
+             asymptotic {asymptotic:.5}. The switchover cliff this test documents appears to \
+             be gone — if the estimator gained bias correction, delete this test and widen \
+             CHECKPOINTS to cover the band under the register model instead of leaving a \
+             stale claim here"
         );
     }
 }

--- a/tests/e2e_composition.rs
+++ b/tests/e2e_composition.rs
@@ -1,0 +1,947 @@
+//! Composition layers: `HashSketchEnsemble`, `NitroBatch`, `UnivMonQ`'s
+//! configuration surface, and the portable facade types that pair a sketch
+//! with a heap.
+//!
+//! The common thread is that none of these change what a sketch guarantees —
+//! they change how it is fed. So each is checked against a **standalone
+//! reference** built from the same stream, plus the underlying sketch's own
+//! error metric. A composition layer that quietly altered state would show up
+//! as a divergence from the reference, not as a widened tolerance.
+
+mod common;
+
+use common::specs::{
+    CardinalityConfidenceSpec, CountMinSpec, CountSketchSpec, RankErrorSpec,
+    SamplingConfidenceSpec, Tally,
+};
+use common::{FreqTruth, NumericTruth, uniform_u64, zipf_u64};
+
+use asap_sketchlib::{
+    Classic, Count, CountMin, CountMinSketchWithHeap, CountSketchWithHeap, DataInput,
+    EnsembleSketch, ErtlMLE, FastPath, HashSketchEnsemble, HyperLogLog, HyperLogLogHIP, KllSketch,
+    MessagePackCodec, NitroBatch, UnivMonQ, UnivMonQConfig, Vector2D,
+};
+
+const ROWS: usize = 3;
+const COLS: usize = 4_096;
+const N: usize = 40_000;
+const DOMAIN: usize = 2_048;
+const STREAM_SEED: u64 = 0xC090_5101;
+
+// ------------------------------------------------------ HashSketchEnsemble
+
+/// The ensemble's whole purpose is to compute one hash and hand it to several
+/// sketches, so every member is compared against a standalone sketch fed the
+/// same stream through its own `insert`.
+///
+/// The two kinds of member have different obligations, and conflating them
+/// would make this test either vacuous or wrong:
+///
+/// - **matrix members** (`CountMinFast`, `CountFast`) receive exactly the hash
+///   their own fast path would have computed, so they must match a standalone
+///   sketch *exactly*, key for key;
+/// - **HLL members** receive the low 64 bits of that shared matrix hash, not
+///   the canonical seed `HyperLogLog::insert` uses. Two different hash
+///   functions land the same stream in different registers, so the ensemble's
+///   readings are equally accurate but not equal. They are held to their own
+///   cardinality bands, and to agreeing with the standalone readings within
+///   the two estimators' combined band.
+#[test]
+fn ensemble_members_match_standalone_sketches_fed_the_same_stream() {
+    let stream = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+
+    let mut ens: HashSketchEnsemble = HashSketchEnsemble::new(vec![
+        EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+            ROWS, COLS,
+        )),
+        EnsembleSketch::from(Count::<Vector2D<i32>, FastPath>::with_dimensions(
+            ROWS, COLS,
+        )),
+        EnsembleSketch::from(HyperLogLog::<ErtlMLE>::new()),
+        EnsembleSketch::from(HyperLogLog::<Classic>::new()),
+        EnsembleSketch::from(HyperLogLogHIP::new()),
+    ])
+    .expect("all matrix members share dimensions");
+
+    let mut ref_cm = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(ROWS, COLS);
+    let mut ref_cs = Count::<Vector2D<i32>, FastPath>::with_dimensions(ROWS, COLS);
+    let mut ref_ertl = HyperLogLog::<ErtlMLE>::new();
+    let mut ref_classic = HyperLogLog::<Classic>::new();
+    let mut ref_hip = HyperLogLogHIP::new();
+
+    let mut truth = FreqTruth::default();
+    for k in &stream {
+        let d = DataInput::U64(*k);
+        truth.observe(*k as i64);
+        ens.insert(&d);
+        ref_cm.insert(&d);
+        ref_cs.insert(&d);
+        ref_ertl.insert(&d);
+        ref_classic.insert(&d);
+        ref_hip.insert(&d);
+    }
+
+    let context = format!(
+        "rows={ROWS} cols={COLS} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}, \
+         members: CountMinFast, CountFast, HllErtl, HllClassic, HllHip"
+    );
+
+    // Matrix members: identical estimates, key for key.
+    let mut cm_tally = Tally::default();
+    let mut cs_tally = Tally::default();
+    for (k, _) in truth.pairs() {
+        let d = DataInput::U64(k as u64);
+        let a = ens.estimate(0, &d).expect("CountMinFast cell");
+        let b = ref_cm.estimate(&d) as f64;
+        cm_tally.record(a == b, || format!("key {k}: ensemble {a} standalone {b}"));
+
+        let c = ens.estimate(1, &d).expect("CountFast cell");
+        let e = ref_cs.estimate(&d);
+        cs_tally.record(c == e, || format!("key {k}: ensemble {c} standalone {e}"));
+    }
+    cm_tally.assert_none("ensemble CountMinFast vs standalone", &context);
+    cs_tally.assert_none("ensemble CountFast vs standalone", &context);
+
+    // HLL members are deliberately *not* bit-identical to a standalone HLL.
+    // The ensemble feeds them the low 64 bits of the shared **matrix** hash
+    // (seed index 0), while `HyperLogLog::insert` hashes with the canonical
+    // seed index. Two different hash functions land the same stream in
+    // different registers, so the two are equally accurate rather than equal —
+    // which is the point of sharing a hash, not a defect.
+    //
+    // What must hold is that the ensemble's readings sit in the same
+    // cardinality band as the standalone ones, and agree with them to within
+    // the sum of their sampling errors.
+    let distinct = truth.distinct();
+    let register_spec = CardinalityConfidenceSpec::hll(14, 4.0);
+    let hip_spec = CardinalityConfidenceSpec::hll_hip(14, 4.0);
+    let mut card_tally = Tally::default();
+    for (idx, label, reference, spec) in [
+        (2usize, "HllErtl", ref_ertl.estimate() as f64, register_spec),
+        (
+            3,
+            "HllClassic",
+            ref_classic.estimate() as f64,
+            register_spec,
+        ),
+        (4, "HllHip", ref_hip.estimate() as f64, hip_spec),
+    ] {
+        let got = ens.cardinality(idx).expect("hll cell");
+        spec.tally_into(&mut card_tally, got, distinct);
+        spec.tally_into(&mut card_tally, reference, distinct);
+        // Both estimate the same truth, so they cannot be further apart than
+        // their two bands allow.
+        let gap = (got - reference).abs() / distinct as f64;
+        assert!(
+            gap <= 2.0 * spec.tolerance(),
+            "ensemble {label} reads {got} while the standalone reads {reference}; the gap \
+             {gap:.5} exceeds the two estimators' combined band {:.5}. They use different \
+             hashes, so they need not be equal — but they must agree this closely. {context}",
+            2.0 * spec.tolerance()
+        );
+    }
+    card_tally.assert_within(
+        "ensemble and standalone HLL members / cardinality bands",
+        register_spec.per_check_failure(),
+        &format!("{context}, distinct={distinct}"),
+    );
+}
+
+/// Every member still satisfies its own family's bound after riding the shared
+/// hash path. `CountFast` gets the L2 bound, not Count-Min's; the HLL members
+/// get their register models.
+#[test]
+fn ensemble_members_satisfy_their_own_error_bounds() {
+    let stream = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut ens: HashSketchEnsemble = HashSketchEnsemble::new(vec![
+        EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+            ROWS, COLS,
+        )),
+        EnsembleSketch::from(Count::<Vector2D<i32>, FastPath>::with_dimensions(
+            ROWS, COLS,
+        )),
+        EnsembleSketch::from(HyperLogLog::<ErtlMLE>::new()),
+        EnsembleSketch::from(HyperLogLog::<Classic>::new()),
+        EnsembleSketch::from(HyperLogLogHIP::new()),
+    ])
+    .expect("ensemble");
+
+    let mut truth = FreqTruth::default();
+    let mut distinct = std::collections::HashSet::new();
+    for k in &stream {
+        ens.insert(&DataInput::U64(*k));
+        truth.observe(*k as i64);
+        distinct.insert(*k);
+    }
+
+    let context =
+        format!("rows={ROWS} cols={COLS} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}");
+    CountMinSpec::new(ROWS, COLS).assert_contract(
+        "ensemble CountMinFast",
+        &truth,
+        |k| ens.estimate(0, &DataInput::U64(k as u64)).expect("cm"),
+        &context,
+    );
+    CountSketchSpec::new(ROWS, COLS).assert_contract(
+        "ensemble CountFast",
+        &truth,
+        |k| ens.estimate(1, &DataInput::U64(k as u64)).expect("cs"),
+        &context,
+    );
+
+    let mut card_tally = Tally::default();
+    let register_spec = CardinalityConfidenceSpec::hll(14, 4.0);
+    let hip_spec = CardinalityConfidenceSpec::hll_hip(14, 4.0);
+    register_spec.tally_into(&mut card_tally, ens.cardinality(2).unwrap(), distinct.len());
+    register_spec.tally_into(&mut card_tally, ens.cardinality(3).unwrap(), distinct.len());
+    hip_spec.tally_into(&mut card_tally, ens.cardinality(4).unwrap(), distinct.len());
+    card_tally.assert_within(
+        "ensemble HLL members / cardinality bands",
+        register_spec.per_check_failure(),
+        &format!("{context}, distinct={}", distinct.len()),
+    );
+}
+
+/// Compatibility inside an ensemble is by **hash layout**, not by literal
+/// dimensions.
+///
+/// The shared hash is `hash_for_matrix_seeded_with_mode(0, mode, rows, input)`,
+/// where `mode` is chosen from `rows * mask_bits(cols)`: it decides whether the
+/// row hashes are packed into one `u64`, one `u128`, or one value per row. Two
+/// sketches with the same `(mode, rows)` can share that hash even at different
+/// widths, because each one folds the row bits with its *own* `cols`.
+///
+/// So a 4096-column and a 2048-column member coexist correctly, and what must
+/// be rejected is a member whose row count — or whose width pushes it into a
+/// different packing mode — makes the shared hash unusable for it.
+#[test]
+fn ensemble_composes_by_hash_layout_and_rejects_incompatible_members() {
+    // Same rows, same packing mode, *different* widths: compatible, and each
+    // member must answer correctly at its own width.
+    let mut mixed = HashSketchEnsemble::<asap_sketchlib::DefaultXxHasher>::new(vec![
+        EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+            ROWS, COLS,
+        )),
+        EnsembleSketch::from(CountMin::<Vector2D<i64>, FastPath>::with_dimensions(
+            ROWS,
+            COLS / 2,
+        )),
+        EnsembleSketch::from(Count::<Vector2D<i32>, FastPath>::with_dimensions(
+            ROWS, COLS,
+        )),
+    ])
+    .expect("members sharing a hash layout must be accepted even at different widths");
+    assert_eq!(mixed.len(), 3);
+
+    let stream = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut truth = FreqTruth::default();
+    for k in &stream {
+        mixed.insert(&DataInput::U64(*k));
+        truth.observe(*k as i64);
+    }
+    let context = format!("zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}");
+    CountMinSpec::new(ROWS, COLS).assert_contract(
+        "ensemble member at full width",
+        &truth,
+        |k| mixed.estimate(0, &DataInput::U64(k as u64)).expect("cm"),
+        &context,
+    );
+    // The half-width member is judged at *its* width; folding must use each
+    // sketch's own `cols`, not the ensemble's first member's.
+    CountMinSpec::new(ROWS, COLS / 2).assert_contract(
+        "ensemble member at half width",
+        &truth,
+        |k| mixed.estimate(1, &DataInput::U64(k as u64)).expect("cm"),
+        &context,
+    );
+    CountSketchSpec::new(ROWS, COLS).assert_contract(
+        "ensemble Count member",
+        &truth,
+        |k| mixed.estimate(2, &DataInput::U64(k as u64)).expect("cs"),
+        &context,
+    );
+
+    // A different row count is a different hash layout: rejected, at
+    // construction and on push.
+    assert!(
+        HashSketchEnsemble::<asap_sketchlib::DefaultXxHasher>::new(vec![
+            EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+                ROWS, COLS
+            )),
+            EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+                ROWS + 2,
+                COLS
+            )),
+        ])
+        .is_err(),
+        "members with different row counts must be rejected"
+    );
+    let before = mixed.len();
+    assert!(
+        mixed
+            .push(EnsembleSketch::from(
+                Count::<Vector2D<i32>, FastPath>::with_dimensions(ROWS + 2, COLS)
+            ))
+            .is_err(),
+        "push must reject a member with a different row count"
+    );
+    assert_eq!(
+        mixed.len(),
+        before,
+        "a rejected push must not add the sketch"
+    );
+
+    // A width that pushes the same row count into a wider packing mode is also
+    // incompatible. The layout reserves `mask_bits(cols) + 1` bits per row (the
+    // extra bit is Count Sketch's sign), so at 5 rows: 1024 columns needs
+    // 5 * 11 = 55 bits and packs into a `u64`, while 4096 columns needs
+    // 5 * 13 = 65 and spills into a `u128`.
+    assert!(
+        HashSketchEnsemble::<asap_sketchlib::DefaultXxHasher>::new(vec![
+            EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+                5, 1024
+            )),
+            EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+                5, 4096
+            )),
+        ])
+        .is_err(),
+        "members whose widths select different packing modes must be rejected"
+    );
+    // ...while two widths on the same side of that boundary compose fine.
+    assert!(
+        HashSketchEnsemble::<asap_sketchlib::DefaultXxHasher>::new(vec![
+            EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(5, 512)),
+            EnsembleSketch::from(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+                5, 1024
+            )),
+        ])
+        .is_ok(),
+        "two widths that select the same packing mode must compose"
+    );
+
+    // HLL members carry no matrix dimensions, so they compose with any grid.
+    assert!(
+        mixed
+            .push(EnsembleSketch::from(HyperLogLogHIP::new()))
+            .is_ok(),
+        "an HLL member has no dimensions to clash with"
+    );
+}
+
+// ------------------------------------------------------------------- Nitro
+
+/// Sampling rates covered. `1.0` is the degenerate full-sampling case, where
+/// the band collapses to zero width and the estimate must be exact.
+const NITRO_RATES: [f64; 4] = [1.0, 0.5, 0.1, 0.01];
+/// Fixed sampling-RNG seeds. `NitroBatch::with_target` seeds from the OS, so
+/// an accuracy assertion on one would be re-rolled every run; the seeded
+/// constructor is what makes these reproducible.
+const NITRO_SEEDS: [u64; 4] = [0x0117_0001, 0x0117_0002, 0x0117_0003, 0x0117_0004];
+/// `z = 4` on the binomial sampling band: two-sided failure 6.3e-5 per check.
+const NITRO_Z: f64 = 4.0;
+
+/// Nitro admits each update with probability `p` and writes weight `ceil(1/p)`,
+/// so a key of true count `f` is estimated by `Binomial(f, p) * ceil(1/p)` —
+/// unbiased, with standard deviation `sqrt(f (1-p) / p)`. The accepted band is
+/// `z` of those, computed per rate rather than a flat percentage: at `f =
+/// 100_000` it is +-0.4% at `p = 0.5` but +-12.6% at `p = 0.01`, and a single
+/// fixed +-5% would be simultaneously far too loose for one and impossible for
+/// the other.
+#[test]
+fn nitro_estimates_stay_inside_the_binomial_sampling_band_on_every_target() {
+    const COUNT: i64 = 100_000;
+    let key = 42i64;
+    let data = vec![key; COUNT as usize];
+
+    for &rate in &NITRO_RATES {
+        let spec = SamplingConfidenceSpec::new(rate, NITRO_Z);
+        for &seed in &NITRO_SEEDS {
+            // Count-Min target. Only one key is present, so the sketch itself
+            // is exact and the whole error budget is sampling noise.
+            let mut cm = NitroBatch::with_target_and_seed(
+                rate,
+                CountMin::<Vector2D<i32>, FastPath>::with_dimensions(5, 2048),
+                seed,
+            );
+            cm.insert(&data);
+            let est = cm.estimate_median(&DataInput::I64(key));
+            if let Err(detail) = spec.check(est, COUNT as f64, 0.0) {
+                panic!("NitroBatch<CountMin> seed={seed:#x}: {detail}");
+            }
+
+            // Count Sketch target: same sampling model, signed estimator.
+            let mut cs = NitroBatch::with_target_and_seed(
+                rate,
+                Count::<Vector2D<i32>, FastPath>::with_dimensions(5, 2048),
+                seed,
+            );
+            cs.insert(&data);
+            let cs_est = cs.estimate_median(&DataInput::I64(key));
+            if let Err(detail) = spec.check(cs_est, COUNT as f64, 0.0) {
+                panic!("NitroBatch<Count> seed={seed:#x}: {detail}");
+            }
+        }
+    }
+}
+
+/// Full sampling is not approximate: at `rate = 1.0` every update is admitted
+/// with weight 1, so a single-key stream must come back exactly.
+#[test]
+fn nitro_at_full_sampling_is_exact() {
+    let data = vec![7i64; 50_000];
+    let mut cm = NitroBatch::with_target_and_seed(
+        1.0,
+        CountMin::<Vector2D<i32>, FastPath>::with_dimensions(5, 2048),
+        NITRO_SEEDS[0],
+    );
+    cm.insert(&data);
+    assert_eq!(
+        cm.estimate_median(&DataInput::I64(7)),
+        50_000.0,
+        "rate=1.0 must admit every update with unit weight"
+    );
+}
+
+/// Two runs with the same seed must be bit-identical, and two runs with
+/// different seeds must differ — otherwise the seed is not reaching the
+/// sampling RNG and the "deterministic" constructor is decorative.
+#[test]
+fn nitro_sampling_is_reproducible_from_its_seed() {
+    let data = vec![5i64; 20_000];
+    let run = |seed: u64| {
+        let mut n = NitroBatch::with_target_and_seed(
+            0.1,
+            CountMin::<Vector2D<i32>, FastPath>::with_dimensions(5, 2048),
+            seed,
+        );
+        n.insert(&data);
+        n.estimate_median(&DataInput::I64(5))
+    };
+    assert_eq!(
+        run(NITRO_SEEDS[0]),
+        run(NITRO_SEEDS[0]),
+        "the same seed must produce the same admitted subset"
+    );
+    let distinct: std::collections::HashSet<u64> =
+        NITRO_SEEDS.iter().map(|s| run(*s).to_bits()).collect();
+    assert!(
+        distinct.len() > 1,
+        "four different seeds all produced the same estimate; the seed is not \
+         reaching the sampling RNG"
+    );
+}
+
+/// `NitroBatch<Vector2D<u32>>` — the bare-storage target reached by
+/// `init_nitro` — has **no public query path**: `NitroEstimate` is implemented
+/// only for the `Vector2D<i32>`-backed Count-Min and Count Sketch, and
+/// `CountMin::estimate` cannot be instantiated over a `u32` counter because it
+/// needs `Counter: From<i32>`. So there is no per-key estimate to check here,
+/// and this test does not invent one by re-deriving the fast-path hash: doing
+/// exactly that is how the Nitro estimator once shipped broken while its tests
+/// passed.
+///
+/// What *is* publicly observable, and is what Nitro actually controls, is the
+/// total admitted mass. Every admitted update writes `ceil(1/rate)` into one
+/// cell of every row, so the sum over any single row is
+/// `admitted * ceil(1/rate)` — an unbiased estimate of the stream length with
+/// the same binomial sampling band, computed without touching a hash.
+#[test]
+fn nitro_over_a_bare_vector2d_target_admits_mass_inside_the_sampling_band() {
+    const COUNT: i64 = 100_000;
+    let data = vec![11i64; COUNT as usize];
+
+    for &rate in &NITRO_RATES {
+        let spec = SamplingConfidenceSpec::new(rate, NITRO_Z);
+        for &seed in &NITRO_SEEDS {
+            let mut nitro = NitroBatch::init_nitro_with_seed(rate, seed);
+            nitro.insert(&data);
+            let target = nitro.target();
+            let row0_mass: f64 = (0..target.cols())
+                .map(|c| target.query_one_counter(0, c) as f64)
+                .sum();
+            if let Err(detail) = spec.check(row0_mass, COUNT as f64, 0.0) {
+                panic!(
+                    "NitroBatch<Vector2D<u32>> rate={rate} seed={seed:#x}: row-0 admitted \
+                     mass out of band: {detail}"
+                );
+            }
+            // Every row receives the same weight from every admitted update,
+            // so all rows must carry identical total mass.
+            for r in 1..target.rows() {
+                let mass: f64 = (0..target.cols())
+                    .map(|c| target.query_one_counter(r, c) as f64)
+                    .sum();
+                assert_eq!(
+                    mass, row0_mass,
+                    "row {r} carries {mass} but row 0 carries {row0_mass}; every row must \
+                     receive each admitted update (rate={rate} seed={seed:#x})"
+                );
+            }
+        }
+    }
+}
+
+/// Merging two same-rate Nitro batches sums their admitted mass, so a key
+/// split across both must come back at the combined band.
+#[test]
+fn nitro_merge_sums_admitted_mass_at_the_combined_band() {
+    const HALF: i64 = 50_000;
+    let key = 3i64;
+    for &rate in &[0.5f64, 0.1] {
+        let spec = SamplingConfidenceSpec::new(rate, NITRO_Z);
+        let mut a = NitroBatch::with_target_and_seed(
+            rate,
+            CountMin::<Vector2D<i32>, FastPath>::with_dimensions(5, 2048),
+            NITRO_SEEDS[0],
+        );
+        let mut b = NitroBatch::with_target_and_seed(
+            rate,
+            CountMin::<Vector2D<i32>, FastPath>::with_dimensions(5, 2048),
+            NITRO_SEEDS[1],
+        );
+        a.insert(&vec![key; HALF as usize]);
+        b.insert(&vec![key; HALF as usize]);
+        a.merge(&b);
+        let est = a.estimate_median(&DataInput::I64(key));
+        if let Err(detail) = spec.check(est, (HALF * 2) as f64, 0.0) {
+            panic!("NitroBatch merge rate={rate}: {detail}");
+        }
+    }
+}
+
+/// Weight saturation: the scaled increment is clamped into the counter's
+/// domain rather than wrapping into a decrement.
+#[test]
+fn nitro_saturates_oversized_weights_instead_of_wrapping() {
+    assert_eq!(
+        asap_sketchlib::nitro_delta_saturated_i32(u64::MAX),
+        i32::MAX,
+        "an oversized weight must clamp to i32::MAX, not wrap negative"
+    );
+    assert_eq!(
+        asap_sketchlib::nitro_delta_saturated_u32(u64::MAX),
+        u32::MAX,
+        "an oversized weight must clamp to u32::MAX"
+    );
+    assert_eq!(asap_sketchlib::nitro_delta_saturated_i32(7), 7);
+    assert_eq!(asap_sketchlib::nitro_delta_saturated_u32(7), 7);
+
+    // A rate low enough to push `ceil(1/rate)` past `i32::MAX` must still
+    // leave counters non-negative.
+    let mut tiny = NitroBatch::with_target_and_seed(
+        1e-9,
+        CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 64),
+        NITRO_SEEDS[0],
+    );
+    tiny.insert(&vec![1i64; 4_000]);
+    let est = tiny.estimate_median(&DataInput::I64(1));
+    assert!(
+        est >= 0.0,
+        "a saturating weight must not turn Count-Min counters negative; got {est}"
+    );
+}
+
+// ---------------------------------------------------------------- UnivMonQ
+
+/// The configuration surface: each field must produce a working sketch whose
+/// exact aggregates stay exact, and the ones that gate a feature must gate it.
+#[test]
+fn univmonq_configuration_variants_all_build_and_keep_exact_aggregates() {
+    let values: Vec<f64> = uniform_u64(20_000, 100_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    let truth = NumericTruth::new(values.clone());
+
+    let base = UnivMonQConfig::default();
+    let variants: Vec<(&str, UnivMonQConfig)> = vec![
+        ("default", base),
+        (
+            "counter_bits=64",
+            UnivMonQConfig {
+                counter_bits: 64,
+                ..base
+            },
+        ),
+        (
+            "width_halving_period=2",
+            UnivMonQConfig {
+                width_halving_period: 2,
+                ..base
+            },
+        ),
+        (
+            "explicit hash_seed",
+            UnivMonQConfig {
+                hash_seed: 3,
+                ..base
+            },
+        ),
+    ];
+
+    for (name, config) in variants {
+        let mut q = UnivMonQ::new(config).unwrap_or_else(|e| panic!("{name} must build: {e:?}"));
+        for v in &values {
+            q.update(v);
+        }
+        assert_eq!(q.count() as usize, values.len(), "{name}: exact count");
+        assert_eq!(q.min(), Some(truth.min()), "{name}: exact min");
+        assert_eq!(q.max(), Some(truth.max()), "{name}: exact max");
+        assert!(
+            q.quantile(0.5).is_some(),
+            "{name}: ordered queries are enabled, so quantile must answer"
+        );
+        assert_eq!(
+            q.config().counter_bits,
+            config.counter_bits,
+            "{name}: config must round-trip through the sketch"
+        );
+    }
+}
+
+/// `ordered_samples = 0` is the documented way to switch ordered queries off.
+/// The exact aggregates and the frequency/moment estimators must keep working;
+/// only `rank`, `cdf` and interior `quantile` go dark.
+#[test]
+fn univmonq_with_ordered_samples_disabled_answers_everything_except_ordered_queries() {
+    let config = UnivMonQConfig {
+        ordered_samples: 0,
+        ..UnivMonQConfig::default()
+    };
+    let mut q = UnivMonQ::new(config).expect("ordered_samples=0 is a valid config");
+    let values: Vec<f64> = uniform_u64(10_000, 50_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    for v in &values {
+        q.update(v);
+    }
+    let truth = NumericTruth::new(values.clone());
+
+    assert_eq!(q.count() as usize, values.len());
+    assert_eq!(q.min(), Some(truth.min()));
+    assert_eq!(q.max(), Some(truth.max()));
+    assert!(
+        q.estimate_f2() > 0.0,
+        "F2 does not depend on ordered samples"
+    );
+    assert!(
+        q.estimate_distinct() > 0.0,
+        "distinct does not depend on ordered samples"
+    );
+
+    assert_eq!(q.rank(values[0]), None, "rank must be unavailable");
+    assert!(q.cdf().is_empty(), "cdf must be empty");
+    assert_eq!(q.quantile(0.5), None, "interior quantiles must be None");
+    // The endpoints are served from the exact min/max, not from samples.
+    assert_eq!(q.quantile(0.0), Some(truth.min()), "q=0 is the exact min");
+    assert_eq!(q.quantile(1.0), Some(truth.max()), "q=1 is the exact max");
+}
+
+/// `with_window_bound` picks the smallest hierarchy whose deepest sample still
+/// fits the candidate table at the requested failure probability. The chosen
+/// `levels` must actually satisfy that inequality, and must grow with the
+/// window it is asked to cover.
+#[test]
+fn univmonq_with_window_bound_chooses_a_hierarchy_that_satisfies_its_own_inequality() {
+    const DELTA: f64 = 1e-3;
+    let base = UnivMonQConfig::default();
+
+    let mut previous = 0usize;
+    for max_updates in [10_000u64, 1_000_000, 100_000_000] {
+        let cfg = base
+            .with_window_bound(max_updates, DELTA)
+            .unwrap_or_else(|e| panic!("window bound for {max_updates} updates: {e:?}"));
+
+        // Re-derive the Bernstein bound the constructor used: the deepest
+        // level sees `max_updates / 2^(levels-1)` updates in expectation, and
+        // its upper tail must sit under the candidate table's capacity.
+        let log_inv_delta = (1.0 / DELTA).ln();
+        let mean = max_updates as f64 / 2f64.powi((cfg.levels - 1) as i32);
+        let upper = mean + (2.0 * mean * log_inv_delta).sqrt() + (2.0 / 3.0) * log_inv_delta;
+        assert!(
+            upper < cfg.candidates as f64,
+            "levels={} leaves the deepest stratum with an upper bound of {upper:.1}, \
+             above the {} candidate slots",
+            cfg.levels,
+            cfg.candidates
+        );
+        // And it must be the *smallest* such hierarchy.
+        if cfg.levels > 2 {
+            let mean_lower = max_updates as f64 / 2f64.powi((cfg.levels - 2) as i32);
+            let upper_lower = mean_lower
+                + (2.0 * mean_lower * log_inv_delta).sqrt()
+                + (2.0 / 3.0) * log_inv_delta;
+            assert!(
+                upper_lower >= cfg.candidates as f64,
+                "levels={} is not minimal: {} levels would already fit",
+                cfg.levels,
+                cfg.levels - 1
+            );
+        }
+        assert!(
+            cfg.levels >= previous,
+            "a larger window must not need a shallower hierarchy"
+        );
+        previous = cfg.levels;
+
+        // The chosen config must build and answer.
+        let mut q = UnivMonQ::new(cfg).expect("chosen config must be valid");
+        for i in 0..1_000u64 {
+            q.update(&(i as f64));
+        }
+        assert_eq!(q.count(), 1_000);
+    }
+
+    assert!(
+        base.with_window_bound(1_000, 1.5).is_err(),
+        "a failure probability outside (0, 1) must be rejected"
+    );
+}
+
+/// Merging shards requires globally unique occurrence source IDs; with them,
+/// the merged sketch's exact aggregates cover the union.
+#[test]
+fn univmonq_multi_shard_merge_with_distinct_source_ids_covers_the_union() {
+    const SHARDS: usize = 4;
+    let config = UnivMonQConfig::default();
+    let values: Vec<f64> = uniform_u64(40_000, 1_000_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    let truth = NumericTruth::new(values.clone());
+
+    let mut shards: Vec<UnivMonQ> = (0..SHARDS)
+        .map(|i| {
+            UnivMonQ::with_hasher_and_source_id(config, i as u64 + 1)
+                .expect("explicit source id must be accepted")
+        })
+        .collect();
+    for (i, v) in values.iter().enumerate() {
+        shards[i % SHARDS].update(v);
+    }
+    for (i, s) in shards.iter().enumerate() {
+        assert_eq!(
+            s.source_id(),
+            i as u64 + 1,
+            "shard {i} must report the source id it was built with"
+        );
+    }
+
+    let mut merged = shards.remove(0);
+    for s in &shards {
+        merged.merge(s).expect("distinct source ids must merge");
+    }
+    assert_eq!(
+        merged.count() as usize,
+        values.len(),
+        "merged count must cover every observation"
+    );
+    assert_eq!(merged.min(), Some(truth.min()), "merged min must be exact");
+    assert_eq!(merged.max(), Some(truth.max()), "merged max must be exact");
+}
+
+// -------------------------------------------------------- Portable facade
+
+/// The portable sketch-plus-heap types, on a real stream against exact truth:
+/// the point estimate under the right family's bound, the heap consistent with
+/// it, and both surviving a MessagePack round trip and a merge.
+#[test]
+fn portable_count_min_with_heap_satisfies_the_count_min_bound_through_merge_and_wire() {
+    const HEAP: usize = 32;
+    let stream = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut truth = FreqTruth::default();
+    let mut single = CountMinSketchWithHeap::new(ROWS, COLS, HEAP);
+    let mut left = CountMinSketchWithHeap::new(ROWS, COLS, HEAP);
+    let mut right = CountMinSketchWithHeap::new(ROWS, COLS, HEAP);
+    for (i, k) in stream.iter().enumerate() {
+        truth.observe(*k as i64);
+        let key = format!("k{k}");
+        single.update(&key, 1.0);
+        if i % 2 == 0 {
+            left.update(&key, 1.0);
+        } else {
+            right.update(&key, 1.0);
+        }
+    }
+
+    let context = format!(
+        "rows={ROWS} cols={COLS} heap={HEAP} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}"
+    );
+    let spec = CountMinSpec::new(ROWS, COLS);
+    spec.assert_contract(
+        "portable CountMinSketchWithHeap",
+        &truth,
+        |k| single.estimate(&format!("k{k}")),
+        &context,
+    );
+
+    // The heap must agree with the sketch it sits beside.
+    let mut heap_tally = Tally::default();
+    for item in single.topk_heap_items() {
+        let est = single.estimate(&item.key);
+        heap_tally.record(item.value == est, || {
+            format!(
+                "key {}: heap holds {} but the sketch estimates {est}",
+                item.key, item.value
+            )
+        });
+    }
+    heap_tally.assert_none("portable CountMinSketchWithHeap heap consistency", &context);
+
+    // Merge, then the same contract.
+    let merged = CountMinSketchWithHeap::merge_refs(&[&left, &right]).expect("merge");
+    spec.assert_contract(
+        "portable CountMinSketchWithHeap after merge",
+        &truth,
+        |k| merged.estimate(&format!("k{k}")),
+        &context,
+    );
+
+    // Wire round trip, then the same contract again: serialization must not
+    // change a single answer.
+    let bytes = single.to_msgpack().expect("encode");
+    let decoded = CountMinSketchWithHeap::from_msgpack(&bytes).expect("decode");
+    let mut wire_tally = Tally::default();
+    for (k, _) in truth.pairs() {
+        let key = format!("k{k}");
+        let a = single.estimate(&key);
+        let b = decoded.estimate(&key);
+        wire_tally.record(a == b, || format!("key {key}: before {a} after {b}"));
+    }
+    wire_tally.assert_none("portable CountMinSketchWithHeap wire round trip", &context);
+    spec.assert_contract(
+        "portable CountMinSketchWithHeap after a wire round trip",
+        &truth,
+        |k| decoded.estimate(&format!("k{k}")),
+        &context,
+    );
+}
+
+#[test]
+fn portable_count_sketch_with_heap_satisfies_the_l2_bound_through_merge_and_wire() {
+    const HEAP: usize = 32;
+    const CS_ROWS: usize = 5;
+    let stream = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut truth = FreqTruth::default();
+    let mut single = CountSketchWithHeap::new(CS_ROWS, COLS, HEAP);
+    let mut left = CountSketchWithHeap::new(CS_ROWS, COLS, HEAP);
+    let mut right = CountSketchWithHeap::new(CS_ROWS, COLS, HEAP);
+    for (i, k) in stream.iter().enumerate() {
+        truth.observe(*k as i64);
+        let key = format!("k{k}");
+        single.update(&key, 1.0);
+        if i % 2 == 0 {
+            left.update(&key, 1.0);
+        } else {
+            right.update(&key, 1.0);
+        }
+    }
+
+    let context = format!(
+        "rows={CS_ROWS} cols={COLS} heap={HEAP} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}"
+    );
+    let spec = CountSketchSpec::new(CS_ROWS, COLS);
+    spec.assert_contract(
+        "portable CountSketchWithHeap",
+        &truth,
+        |k| single.estimate(&format!("k{k}")),
+        &context,
+    );
+
+    let mut heap_tally = Tally::default();
+    for item in single.topk_heap_items() {
+        let est = single.estimate(&item.key);
+        heap_tally.record(item.value == est, || {
+            format!(
+                "key {}: heap holds {} but the sketch estimates {est}",
+                item.key, item.value
+            )
+        });
+    }
+    heap_tally.assert_none("portable CountSketchWithHeap heap consistency", &context);
+
+    let merged = CountSketchWithHeap::merge_refs(&[&left, &right]).expect("merge");
+    spec.assert_contract(
+        "portable CountSketchWithHeap after merge",
+        &truth,
+        |k| merged.estimate(&format!("k{k}")),
+        &context,
+    );
+
+    let bytes = single.to_msgpack().expect("encode");
+    let decoded = CountSketchWithHeap::from_msgpack(&bytes).expect("decode");
+    spec.assert_contract(
+        "portable CountSketchWithHeap after a wire round trip",
+        &truth,
+        |k| decoded.estimate(&format!("k{k}")),
+        &context,
+    );
+}
+
+/// The portable KLL facade under the rank-error contract, seeded so a failure
+/// reproduces. `KllSketch::new` seeds from the wall clock; `with_seed` is what
+/// an accuracy test must use.
+#[test]
+fn portable_kll_sketch_satisfies_the_rank_error_contract_through_merge_and_wire() {
+    const K: u16 = 200;
+    const SKETCH_SEED: u64 = 0x5EED_0400;
+    let values: Vec<f64> = uniform_u64(N, 1_000_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    let truth = NumericTruth::new(values.clone());
+
+    let mut single = KllSketch::with_seed(K, SKETCH_SEED);
+    let mut left = KllSketch::with_seed(K, SKETCH_SEED ^ 0xAAAA);
+    let mut right = KllSketch::with_seed(K, SKETCH_SEED ^ 0x5555);
+    for (i, v) in values.iter().enumerate() {
+        single.update(*v);
+        if i % 2 == 0 {
+            left.update(*v);
+        } else {
+            right.update(*v);
+        }
+    }
+    left.merge(&right).expect("same-k merge");
+
+    let spec = RankErrorSpec::datasketches(K as usize);
+    let qs = [0.1f64, 0.25, 0.5, 0.75, 0.9];
+    let context =
+        format!("k={K} sketch_seed={SKETCH_SEED:#x} uniform n={N} stream_seed={STREAM_SEED:#x}");
+
+    let mut tally = Tally::default();
+    spec.tally_into(&mut tally, truth.sorted(), &qs, |q| single.quantile(q));
+    spec.tally_into(&mut tally, truth.sorted(), &qs, |q| left.quantile(q));
+
+    // Wire round trip must preserve every answer bit for bit.
+    let bytes = single.to_msgpack().expect("encode");
+    let decoded = KllSketch::from_msgpack(&bytes).expect("decode");
+    assert_eq!(decoded.k(), K, "k must survive the wire");
+    assert_eq!(
+        decoded.count(),
+        single.count(),
+        "retained mass must survive the wire"
+    );
+    let mut wire_tally = Tally::default();
+    for &q in &qs {
+        let (a, b) = (single.quantile(q), decoded.quantile(q));
+        wire_tally.record(a == b, || format!("q={q}: before {a} after {b}"));
+    }
+    wire_tally.assert_none("portable KllSketch wire round trip", &context);
+    spec.tally_into(&mut tally, truth.sorted(), &qs, |q| decoded.quantile(q));
+
+    // A mismatched `k` must be refused rather than silently merged.
+    let other_k = KllSketch::with_seed(K * 2, SKETCH_SEED);
+    assert!(
+        single.merge(&other_k).is_err(),
+        "merging sketches with different k must fail"
+    );
+
+    tally.assert_within(
+        "portable KllSketch / normalized rank error",
+        spec.failure_probability,
+        &format!("{context}; single pass, two-shard merge, and post-wire, q grid {qs:?}"),
+    );
+}

--- a/tests/e2e_experimental.rs
+++ b/tests/e2e_experimental.rs
@@ -1,6 +1,5 @@
-//! E2E suites for feature-gated (`experimental`) sketches: KMV cardinality
-//! and shard merge, UniformSampling's retention rate and same-rate merge, and
-//! the EHUnivOptimized exact map tier.
+//! E2E suites for feature-gated (`experimental`) sketches: KMV cardinality,
+//! UniformSampling's retention rate, and both tiers of EHUnivOptimized.
 //!
 //! CocoSketch and the Elastic sketch are a family of their own;
 //! `tests/e2e_heavy_hitters.rs` covers them.
@@ -11,49 +10,42 @@
 
 mod common;
 
-use common::{assert_between, uniform_u64};
+use common::specs::{CardinalityConfidenceSpec, Tally};
+use common::{FreqTruth, assert_between, uniform_u64, zipf_u64};
 
-use asap_sketchlib::{DataInput, EHUnivOptimized, KMV, UniformSampling};
+use asap_sketchlib::{
+    DataInput, EHUnivOptimized, EHUnivQueryResult, HeapItem, KMV, UniformSampling,
+};
 use std::collections::HashMap;
 
+// ---------------------------------------------------------------------- KMV
+
+/// Gaussian quantile for KMV's bands. `z = 4` is a two-sided failure
+/// probability of 6.3e-5 per check.
+const KMV_Z: f64 = 4.0;
+
+/// KMV's `(k-1)/U_(k)` estimator has relative standard error `1/sqrt(k-2)`,
+/// modelled here as `1/sqrt(k-1)`. At `k = 4096` that is 1.56%, so a `z = 4`
+/// band is **6.25%** — the previous suite claimed "4 standard errors" while
+/// asserting 4%, which is 2.56 sigma. The band is now computed rather than
+/// written down, so the two can no longer disagree.
+///
+/// Below `k` distinct elements the sketch retains every hash it has seen and
+/// the estimate is exact; `CardinalityConfidenceSpec` switches to an equality
+/// check there rather than applying a band that would not be testing anything.
 #[test]
-fn kmv_cardinality_and_shard_merge() {
-    let mut a = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
-    let mut b = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
-    let mut full = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
-
-    let stream = uniform_u64(60_000, 500_000, 5001);
-    let truth: std::collections::HashSet<u64> = stream.iter().copied().collect();
-    let t = truth.len() as f64;
-
-    for (i, k) in stream.iter().enumerate() {
-        full.insert(&DataInput::U64(*k));
-        if i % 2 == 0 {
-            a.insert(&DataInput::U64(*k));
-        } else {
-            b.insert(&DataInput::U64(*k));
-        }
-    }
-
-    // KMV standard error ~ 1/sqrt(k-1); allow 4x that for single-seed runs.
-    assert_between(full.estimate(), t * 0.96, t * 1.04, "KMV cardinality");
-
-    a.merge(&mut b);
-    let merged = a.estimate();
-    assert_between(merged, t * 0.96, t * 1.04, "KMV after shard merge");
-}
-
-/// Cardinality accuracy at checkpoints spanning the exact regime (below `k`)
-/// and the estimated regime (above `k`), single-pass and after an even/odd
-/// shard merge.
-#[test]
-fn kmv_accuracy_across_cardinality_checkpoints() {
+fn kmv_satisfies_its_relative_standard_error_across_both_regimes() {
+    const K: usize = 4096;
+    // Straddles k = 4096: the first three are the exact regime, the rest the
+    // estimated one.
     const CHECKPOINTS: [usize; 6] = [10, 100, 1_000, 10_000, 100_000, 1_000_000];
-    const TOL: f64 = 0.02;
 
-    let mut single = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
-    let mut even = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
-    let mut odd = KMV::<asap_sketchlib::DefaultXxHasher>::new(4096);
+    let spec = CardinalityConfidenceSpec::kmv(K, KMV_Z);
+    let mut tally = Tally::default();
+
+    let mut single = KMV::<asap_sketchlib::DefaultXxHasher>::new(K);
+    let mut even = KMV::<asap_sketchlib::DefaultXxHasher>::new(K);
+    let mut odd = KMV::<asap_sketchlib::DefaultXxHasher>::new(K);
     let mut inserted = 0usize;
 
     for &target in &CHECKPOINTS {
@@ -67,26 +59,68 @@ fn kmv_accuracy_across_cardinality_checkpoints() {
             }
             inserted += 1;
         }
+        spec.tally_into(&mut tally, single.estimate(), target);
 
-        let t = target as f64;
-        assert_between(
-            single.estimate(),
-            t * (1.0 - TOL),
-            t * (1.0 + TOL),
-            &format!("KMV cardinality @ {target}"),
-        );
-
+        // Shard merge keeps the k smallest hashes of the union, so it must
+        // land in the same band as the single pass.
         let mut merged = even.clone();
         let mut rhs = odd.clone();
         merged.merge(&mut rhs);
-        assert_between(
-            merged.estimate(),
-            t * (1.0 - TOL),
-            t * (1.0 + TOL),
-            &format!("KMV shard merge @ {target}"),
-        );
+        spec.tally_into(&mut tally, merged.estimate(), target);
     }
+
+    tally.assert_within(
+        "KMV / relative standard error band",
+        spec.per_check_failure(),
+        &format!(
+            "k={K} sigma_rel=1/sqrt(k-1)={:.5} z={KMV_Z} tolerance={:.5}, \
+             identities 0..n, checkpoints {CHECKPOINTS:?}",
+            spec.sigma_rel(),
+            spec.tolerance()
+        ),
+    );
 }
+
+/// KMV over a stream with duplicates, single pass and after an even/odd shard
+/// merge, against exact `HashSet` truth rather than the insert count.
+#[test]
+fn kmv_over_a_duplicate_bearing_stream_satisfies_its_error_model() {
+    const K: usize = 4096;
+    const STREAM_SEED: u64 = 5001;
+
+    let spec = CardinalityConfidenceSpec::kmv(K, KMV_Z);
+    let stream = uniform_u64(60_000, 500_000, STREAM_SEED);
+    let truth: std::collections::HashSet<u64> = stream.iter().copied().collect();
+
+    let mut full = KMV::<asap_sketchlib::DefaultXxHasher>::new(K);
+    let mut a = KMV::<asap_sketchlib::DefaultXxHasher>::new(K);
+    let mut b = KMV::<asap_sketchlib::DefaultXxHasher>::new(K);
+    for (i, k) in stream.iter().enumerate() {
+        full.insert(&DataInput::U64(*k));
+        if i % 2 == 0 {
+            a.insert(&DataInput::U64(*k));
+        } else {
+            b.insert(&DataInput::U64(*k));
+        }
+    }
+    a.merge(&mut b);
+
+    let mut tally = Tally::default();
+    spec.tally_into(&mut tally, full.estimate(), truth.len());
+    spec.tally_into(&mut tally, a.estimate(), truth.len());
+    tally.assert_within(
+        "KMV over a duplicate-bearing stream",
+        spec.per_check_failure(),
+        &format!(
+            "k={K} stream_seed={STREAM_SEED} n=60000 over domain 500000, \
+             distinct={} tolerance={:.5}",
+            truth.len(),
+            spec.tolerance()
+        ),
+    );
+}
+
+// ------------------------------------------------------------ UniformSampling
 
 #[test]
 fn uniform_sampling_rate_and_merge() {
@@ -126,6 +160,25 @@ fn uniform_sampling_rate_and_merge() {
         "retained samples bounded by combined budget"
     );
 }
+
+// --------------------------------------------------------- EHUnivOptimized
+
+/// A configuration whose promotion threshold (`layer_size * rows * cols`) is
+/// small enough that the sketch tier is actually populated by a test-sized
+/// stream, while `cols` stays wide enough for the UnivMon layers to be
+/// meaningful.
+fn promoting_eh(k: usize, window: u64) -> EHUnivOptimized {
+    EHUnivOptimized::new(k, window, 32, EH_ROWS, EH_COLS, EH_LAYERS)
+}
+
+const EH_ROWS: usize = 3;
+const EH_COLS: usize = 512;
+const EH_LAYERS: usize = 2;
+/// Smaller `k` merges buckets more aggressively, so the oldest map bucket
+/// reaches the promotion threshold (`layer_size * rows * cols / 2` distinct
+/// keys) within a test-sized stream.
+const EH_K: usize = 2;
+
 #[test]
 fn eh_univ_optimized_map_tier_exact_windows() {
     let window = 100u64;
@@ -137,7 +190,7 @@ fn eh_univ_optimized_map_tier_exact_windows() {
 
     // Interval fully inside the retained range: map tier answers EXACTLY.
     match eh.query_interval(120, 149) {
-        Some(asap_sketchlib::EHUnivQueryResult::Map {
+        Some(EHUnivQueryResult::Map {
             freq_map,
             total_count,
         }) => {
@@ -154,12 +207,329 @@ fn eh_univ_optimized_map_tier_exact_windows() {
             );
             for (k, v) in expect_freq {
                 assert_eq!(
-                    freq_map.get(&asap_sketchlib::HeapItem::U32(k)),
+                    freq_map.get(&HeapItem::U32(k)),
                     Some(&v),
                     "interval count for key {k}"
                 );
             }
         }
         _ => panic!("expected exact Map-tier result"),
+    }
+}
+
+/// The map tier fills, promotes into the sketch tier, and the sketch tier then
+/// answers interval queries — with the error model of a UnivMon sketch, not
+/// the map tier's exactness.
+///
+/// `UnivMon::calc_l1` returns the maintained `bucket_size`, an exactly
+/// accumulated weight, so L1 is asserted by equality on both tiers. L2 comes
+/// out of UnivMon's recursive g-sum recurrence across `layer_size` sampled
+/// substreams, for which the crate publishes no closed-form constant, so it is
+/// a documented empirical band and is named as such.
+///
+/// The stream is deliberately **skewed**. UnivMon recovers a g-sum from the
+/// heavy hitters it can isolate at each layer, and promotion guarantees the
+/// promoted sketch holds at least `layer_size * rows * cols / 2` distinct keys
+/// — so a flat stream leaves the counters uniformly loaded with nothing
+/// recoverable. Measured on this configuration, L2 lands within 3% of exact on
+/// a Zipf(1.1) stream and 57% *below* exact on a uniform one. That is a
+/// property of the estimator, not of this test, and the skew is stated here
+/// rather than hidden inside a wide tolerance.
+///
+/// Band source: measured on this exact configuration and stream (Zipf(1.1)
+/// over 30k keys, n=200k, k=2, rows=3, cols=512, layers=2, stream seed 4242),
+/// where L2 lands 3.0% below exact and entropy 20.4% above it.
+#[test]
+fn eh_univ_optimized_promotes_into_the_sketch_tier_and_answers_from_it() {
+    const N: usize = 80_000;
+    const DOMAIN: usize = 30_000;
+    const STREAM_SEED: u64 = 4242;
+
+    let keys = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut eh = promoting_eh(EH_K, 100_000_000);
+    for (t, k) in keys.iter().enumerate() {
+        eh.update(t as u64, &DataInput::U64(*k), 1);
+    }
+
+    assert!(
+        eh.um_buckets.len() >= 2,
+        "test premise: the map tier must have promoted at least two sketch \
+         buckets (max_map_size={}, got {} sketch and {} map buckets)",
+        eh.max_map_size,
+        eh.um_buckets.len(),
+        eh.map_buckets.len()
+    );
+
+    // Query exactly the span the sketch tier covers. Both endpoints are public
+    // bucket boundaries, so the reference window is known exactly.
+    let lo = eh.um_buckets[0].min_time;
+    let hi = eh.um_buckets[eh.um_buckets.len() - 1].max_time;
+    let result = eh.query_interval(lo, hi).expect("sketch-tier interval");
+    match &result {
+        EHUnivQueryResult::Sketch(_) => {}
+        EHUnivQueryResult::Map { .. } => panic!(
+            "expected a Sketch-tier result for the promoted span [{lo}, {hi}]; \
+             got the exact map tier, so promotion did not take effect"
+        ),
+    }
+
+    // Exact truth over the same window.
+    let mut truth = FreqTruth::default();
+    for t in lo..=hi {
+        truth.observe(keys[t as usize] as i64);
+    }
+    let context = format!(
+        "k={EH_K} rows={EH_ROWS} cols={EH_COLS} layers={EH_LAYERS} n={N} domain={DOMAIN} \
+         zipf(1.1) stream_seed={STREAM_SEED}, promoted span [{lo}, {hi}] with {} distinct \
+         keys and L1={}",
+        truth.distinct(),
+        truth.total()
+    );
+
+    // L1 is maintained, not estimated.
+    assert_eq!(
+        result.calc_l1(),
+        truth.total() as f64,
+        "sketch-tier L1 must be exact. {context}"
+    );
+
+    let l2_truth = truth.l2_norm();
+    assert_between(
+        result.calc_l2(),
+        l2_truth * 0.90,
+        l2_truth * 1.10,
+        &format!("EHUnivOptimized sketch-tier L2 (empirical band). {context}"),
+    );
+
+    let entropy_bits = truth.entropy(true);
+    assert_between(
+        result.calc_entropy(),
+        entropy_bits * 0.90,
+        entropy_bits * 1.40,
+        &format!("EHUnivOptimized sketch-tier entropy in bits (empirical band). {context}"),
+    );
+}
+
+/// The sketch tier's cardinality estimate is structurally unrecoverable, and
+/// this test pins that rather than letting a wide tolerance hide it.
+///
+/// UnivMon recovers `F0` from the deepest sampled layer, which needs roughly
+/// `log2(distinct)` layers before the surviving substream is small enough for
+/// the per-layer heap to hold it. But promotion only fires once the oldest map
+/// bucket holds `layer_size * rows * cols / 2` distinct keys, so the promoted
+/// sketch always carries at least `192 * layer_size` distinct keys (at the
+/// smallest sensible `rows = 3`, `cols = 128`), needing about
+/// `7.6 + log2(layer_size)` layers — more than `layer_size` for every
+/// configuration below about 13 layers, and raising `layer_size` raises the
+/// promotion threshold in lockstep. The two requirements cannot both be met by
+/// tuning.
+///
+/// Measured consequence: on the configurations probed here the sketch tier
+/// reports 0 to 11 distinct values for windows holding 16k to 40k of them —
+/// a ~100% underestimate, not a noisy one. Callers must take cardinality from
+/// the map tier or from a dedicated distinct-count sketch.
+///
+/// The lower guard makes a future fix fail this test loudly instead of leaving
+/// a stale claim in the suite.
+#[test]
+fn eh_univ_optimized_sketch_tier_cardinality_is_documented_as_unrecoverable() {
+    const N: usize = 80_000;
+    const DOMAIN: usize = 30_000;
+
+    let keys = zipf_u64(N, DOMAIN, 1.1, 4242);
+    let mut eh = promoting_eh(EH_K, 100_000_000);
+    for (t, k) in keys.iter().enumerate() {
+        eh.update(t as u64, &DataInput::U64(*k), 1);
+    }
+    let lo = eh.um_buckets[0].min_time;
+    let hi = eh.um_buckets[eh.um_buckets.len() - 1].max_time;
+    let result = eh.query_interval(lo, hi).expect("sketch-tier interval");
+
+    let mut truth = FreqTruth::default();
+    for t in lo..=hi {
+        truth.observe(keys[t as usize] as i64);
+    }
+    let distinct = truth.distinct() as f64;
+    let reported = result.calc_card();
+
+    // The promotion threshold really does outrun the layer count.
+    let needed_layers = distinct.log2().ceil();
+    assert!(
+        needed_layers > EH_LAYERS as f64,
+        "premise: recovering F0 for {distinct} distinct keys needs about \
+         {needed_layers} sampling layers, but this configuration has {EH_LAYERS}"
+    );
+    assert!(
+        reported < distinct * 0.10,
+        "sketch-tier cardinality reported {reported} for {distinct} distinct keys. \
+         If UnivMon's F0 recovery was fixed or EHUnivOptimized stopped coupling the \
+         promotion threshold to layer_size, delete this test and assert a real band \
+         instead of leaving this stale documentation in place"
+    );
+}
+
+/// A span crossing the tier boundary is answered as a Sketch: the map buckets
+/// inside the interval are replayed into a merged UnivMon. The result must
+/// still carry the whole window's L1 exactly.
+#[test]
+fn eh_univ_optimized_answers_a_mixed_map_and_sketch_interval() {
+    const N: u64 = 60_000;
+    const DOMAIN: u64 = 20_000;
+
+    let mut eh = promoting_eh(EH_K, 1_000_000);
+    for t in 0..N {
+        eh.update(t, &DataInput::U64(t % DOMAIN), 1);
+    }
+    assert!(!eh.um_buckets.is_empty() && !eh.map_buckets.is_empty());
+
+    // From inside the sketch tier to the newest map bucket.
+    let lo = eh.um_buckets[0].min_time;
+    let hi = eh.map_buckets[eh.map_buckets.len() - 1].max_time;
+    let result = eh.query_interval(lo, hi).expect("mixed interval");
+    match &result {
+        EHUnivQueryResult::Sketch(_) => {}
+        EHUnivQueryResult::Map { .. } => {
+            panic!("a span starting in the sketch tier must be answered as a Sketch")
+        }
+    }
+
+    let mut truth = FreqTruth::default();
+    for t in lo..=hi {
+        truth.observe((t % DOMAIN) as i64);
+    }
+    assert_eq!(
+        result.calc_l1(),
+        truth.total() as f64,
+        "mixed-tier L1 must still be the exact window weight over [{lo}, {hi}]"
+    );
+}
+
+/// Expiry drops buckets older than the window on both tiers, and the retained
+/// span shrinks accordingly. Bucket bookkeeping is arithmetic, so these are
+/// equalities rather than bands.
+#[test]
+fn eh_univ_optimized_expires_buckets_past_the_window() {
+    const WINDOW: u64 = 5_000;
+    let mut eh = promoting_eh(8, WINDOW);
+    for t in 0..40_000u64 {
+        eh.update(t, &DataInput::U64(t % 8_000), 1);
+    }
+
+    let min_time = eh.get_min_time().expect("buckets present");
+    let max_time = eh.get_max_time().expect("buckets present");
+    assert_eq!(max_time, 39_999, "newest retained time");
+
+    // The expiry rule drops a bucket once its *max_time* falls below the
+    // cutoff, so a retained bucket may still reach back before the cutoff with
+    // its min_time — that is bucket granularity, not a leak. What must hold is
+    // that no retained bucket lies entirely in the past.
+    let cutoff = max_time - WINDOW;
+    assert!(
+        min_time <= max_time,
+        "retained span [{min_time}, {max_time}] must be ordered"
+    );
+    for b in &eh.um_buckets {
+        assert!(
+            b.max_time >= cutoff,
+            "sketch bucket [{}, {}] is entirely older than the cutoff {cutoff}",
+            b.min_time,
+            b.max_time
+        );
+    }
+    for b in &eh.map_buckets {
+        assert!(
+            b.max_time >= cutoff,
+            "map bucket [{}, {}] is entirely older than the cutoff {cutoff}",
+            b.min_time,
+            b.max_time
+        );
+    }
+    assert!(
+        eh.cover(min_time, max_time),
+        "the structure must cover its own retained span"
+    );
+    assert!(
+        !eh.cover(0, max_time),
+        "expired times must no longer be covered"
+    );
+
+    // Continuing past the window must not grow the structure without bound.
+    let buckets_before = eh.bucket_count();
+    for t in 40_000..70_000u64 {
+        eh.update(t, &DataInput::U64(t % 8_000), 1);
+    }
+    assert!(
+        eh.bucket_count() <= buckets_before * 2,
+        "bucket count grew from {buckets_before} to {} over a fixed window",
+        eh.bucket_count()
+    );
+}
+
+/// Recycling through the sketch pool must not leak state between windows: a
+/// sketch taken from the pool has to behave like a fresh one.
+#[test]
+fn eh_univ_optimized_reuses_pooled_sketches_without_leaking_state() {
+    const DOMAIN: u64 = 20_000;
+    // Long run with a short window, so buckets are created, promoted, merged
+    // and expired repeatedly and the pool is exercised.
+    let mut eh = promoting_eh(8, 20_000);
+    for t in 0..80_000u64 {
+        eh.update(t, &DataInput::U64(t % DOMAIN), 1);
+    }
+
+    let lo = eh.get_min_time().expect("buckets");
+    let hi = eh.get_max_time().expect("buckets");
+    let result = eh.query_interval(lo, hi).expect("interval");
+    let mut truth = FreqTruth::default();
+    for t in lo..=hi {
+        truth.observe((t % DOMAIN) as i64);
+    }
+    // A pooled sketch that kept counters from a previous window would inflate
+    // L1 above the retained window's exact weight.
+    assert_eq!(
+        result.calc_l1(),
+        truth.total() as f64,
+        "L1 over the retained span [{lo}, {hi}] must equal the exact window weight; \
+         a larger value means a recycled sketch carried state across windows"
+    );
+}
+
+/// The two tiers must agree on a span they can both answer: a weighted,
+/// skewed stream small enough to stay in the map tier gives exact per-key
+/// counts, which is the reference the sketch tier's estimates are compared to
+/// elsewhere in this file.
+#[test]
+fn eh_univ_optimized_map_tier_matches_exact_per_key_counts_on_a_skewed_stream() {
+    const N: u64 = 4_000;
+    let mut eh = EHUnivOptimized::with_defaults(4, 1_000_000);
+    let keys = zipf_u64(N as usize, 64, 1.2, 9_001);
+    let mut truth = FreqTruth::default();
+    for (t, k) in keys.iter().enumerate() {
+        let w = 1 + (t % 3) as i64;
+        eh.update(t as u64, &DataInput::U64(*k), w);
+        truth.observe_weighted(*k as i64, w);
+    }
+
+    match eh.query_interval(0, N - 1) {
+        Some(EHUnivQueryResult::Map {
+            freq_map,
+            total_count,
+        }) => {
+            assert_eq!(total_count as i64, truth.total(), "map-tier total weight");
+            for (k, c) in truth.pairs() {
+                assert_eq!(
+                    freq_map.get(&HeapItem::U64(k as u64)),
+                    Some(&c),
+                    "map-tier count for key {k}"
+                );
+            }
+        }
+        other => panic!(
+            "expected the map tier to answer a {N}-update stream exactly; got {}",
+            match other {
+                Some(EHUnivQueryResult::Sketch(_)) => "a Sketch result",
+                _ => "nothing",
+            }
+        ),
     }
 }

--- a/tests/e2e_frameworks.rs
+++ b/tests/e2e_frameworks.rs
@@ -11,9 +11,8 @@ use common::{FreqTruth, assert_between, zipf_u64};
 
 use asap_sketchlib::input::{HydraCounter, HydraQuery};
 use asap_sketchlib::{
-    Count, CountMin, DataInput, EHSketchList, EnsembleSketch, ExponentialHistogram, FastPath,
-    FoldCMS, FoldCMSConfig, HashSketchEnsemble, Hydra, HyperLogLog, KLL, TumblingWindow, UnivMon,
-    UnivMonPyramid, Vector2D,
+    Count, CountMin, DataInput, EHSketchList, ExponentialHistogram, FastPath, FoldCMS,
+    FoldCMSConfig, Hydra, KLL, TumblingWindow, UnivMon, UnivMonPyramid, Vector2D,
 };
 
 // ------------------------------------------------------------------- Hydra
@@ -74,8 +73,13 @@ fn hydra_cm_multilabel_frequencies() {
 
 #[test]
 fn hydra_kll_head_quantile_and_cdf() {
-    let mut hydra = Hydra::with_schema(4, 512, ["shard"], HydraCounter::KLL(KLL::init_kll(200)))
-        .expect("schema");
+    let mut hydra = Hydra::with_schema(
+        4,
+        512,
+        ["shard"],
+        HydraCounter::KLL(KLL::init_kll_with_seed(200, 0x5EED_0600)),
+    )
+    .expect("schema");
     let values: Vec<f64> = common::uniform_u64(20_000, 1_000_000, 4001)
         .iter()
         .map(|v| *v as f64)
@@ -1519,40 +1523,13 @@ fn univmon_pyramid_weighted_metrics() {
 }
 
 // ------------------------------------------------------------------- Nitro
-
-#[test]
-fn nitro_unbiased_across_rates_cm_and_cs_targets() {
-    let n = 100_000i64;
-    for rate in [1.0f64, 0.5] {
-        let mut cm_batch = asap_sketchlib::NitroBatch::with_target(
-            rate,
-            CountMin::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(5, 2048),
-        );
-        cm_batch.insert(&vec![42i64; n as usize]);
-        let est = cm_batch.estimate_median(&DataInput::I64(42));
-        assert_between(
-            est,
-            n as f64 * 0.95,
-            n as f64 * 1.05,
-            &format!("Nitro CM rate={rate}"),
-        );
-
-        let mut cs_batch = asap_sketchlib::NitroBatch::with_target(
-            rate,
-            asap_sketchlib::Count::<Vector2D<i32>, asap_sketchlib::FastPath>::with_dimensions(
-                5, 2048,
-            ),
-        );
-        cs_batch.insert(&vec![42i64; n as usize]);
-        let cs_est = cs_batch.estimate_median(&DataInput::I64(42));
-        assert_between(
-            cs_est,
-            n as f64 * 0.90,
-            n as f64 * 1.10,
-            &format!("Nitro CS rate={rate}"),
-        );
-    }
-}
+//
+// `NitroBatch` moved to `tests/e2e_composition.rs`. The version that lived
+// here built its batches with `NitroBatch::with_target`, which seeds the
+// sampling RNG from the OS — so its +-5% and +-10% bands were re-rolled on
+// every run and neither reproduced a failure nor derived from the estimator's
+// variance. The replacement uses the seeded constructor and the binomial
+// sampling band, across rates 1.0 / 0.5 / 0.1 / 0.01 and all three targets.
 
 // -------------------------------------------------- ExponentialHistogram
 
@@ -1634,40 +1611,9 @@ fn tumbling_foldcms_weighted_windows_exact_counts() {
 }
 
 // ------------------------------------------------------ HashSketchEnsemble
-
-#[test]
-fn ensemble_layer_mixed_cms_and_hll() {
-    let cms = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 4096);
-    let ertl = HyperLogLog::<asap_sketchlib::ErtlMLE>::new();
-    let mut ens: HashSketchEnsemble =
-        HashSketchEnsemble::new(vec![EnsembleSketch::from(cms), EnsembleSketch::from(ertl)])
-            .expect("ensemble");
-
-    // Dominant head: 6000 copies of key 0; tail: 15k uniform over 3000 keys.
-    let mut distinct = std::collections::HashSet::new();
-    let mut truth_hot0 = 0i64;
-    for k in common::uniform_u64(15_000, 3000, 2103) {
-        ens.insert(&DataInput::I64(k as i64));
-        distinct.insert(k as i64);
-    }
-    for _ in 0..6000 {
-        ens.insert(&DataInput::I64(0));
-        distinct.insert(0);
-        truth_hot0 += 1;
-    }
-
-    // CMS cell: one-sided frequency estimate for the dominant key. Upper
-    // slack is generous (3x) because the shared-hash fan-out across the
-    // ensemble's 15k-tail stream can collide into key 0's cells; the lower
-    // bound carries the real one-sided guarantee.
-    let cm_est = ens.estimate(0, &DataInput::I64(0)).expect("cms estimate");
-    assert!(
-        cm_est >= truth_hot0 as f64 && cm_est <= truth_hot0 as f64 * 3.0,
-        "ensemble CMS estimate {cm_est} vs true {truth_hot0} (must be one-sided)"
-    );
-
-    // HLL cell: shared-hash cardinality within 3%.
-    let card = ens.cardinality(1).expect("hll cardinality");
-    let t = distinct.len() as f64;
-    assert_between(card, t * 0.97, t * 1.03, "ensemble HLL cardinality");
-}
+//
+// `HashSketchEnsemble` moved to `tests/e2e_composition.rs`, where every member
+// variant (CountMinFast, CountFast, HllErtl, HllClassic, HllHip) is compared
+// against a standalone reference and held to its own family's bound. The
+// version that lived here covered two members with a hand-picked 3x upper
+// slack on the Count-Min cell.

--- a/tests/e2e_frequency.rs
+++ b/tests/e2e_frequency.rs
@@ -1,10 +1,22 @@
 //! E2E frequency-sketch pipelines on synthetic streams with exact ground
-//! truth: CountMin (regular/fast + shard merge), CountSketch turnstile,
-//! top-k heaps, CountL2HH weighted F2, FoldCMS/FoldCS counts and hierarchical
-//! merge, portable wire twins (string keys).
+//! truth.
+//!
+//! Two different error metrics live in this file and must not be confused:
+//!
+//! - **Count-Min** is one-sided and *additive*: `est >= f` always, and the
+//!   excess is bounded by `e * (N - f) / w` with probability `1 - e^-d`.
+//! - **Count Sketch** is two-sided and *L2*: the error is
+//!   `sqrt(kappa / w) * ||f_-i||_2`, rank-independent, and has nothing to do
+//!   with `eps * N`. A Count Sketch checked against `e/w * N` is not being
+//!   checked against its own theorem — that bound is enormously looser on a
+//!   skewed stream, and passing it says almost nothing.
+//!
+//! Both bounds live in `common::specs` alongside the binomial acceptance rules
+//! that turn a per-key failure probability into a pass/fail decision.
 
 mod common;
 
+use common::specs::{CountMinSpec, CountSketchSpec, SecondMomentSpec, Tally};
 use common::{FreqTruth, uniform_u64, zipf_u64};
 use std::collections::HashMap;
 
@@ -17,16 +29,21 @@ use asap_sketchlib::{
 
 // ----------------------------------------------------------------- CountMin
 
+/// Count-Min's own theorem end to end: the one-sided guarantee on every key,
+/// the additive `e*(N-f)/w` excess under the binomial acceptance rule, and
+/// exact equality between a shard-merged sketch and a single-pass one.
 #[test]
-fn countmin_zipf_one_sided_bound_and_shard_merge() {
-    let (rows, cols) = (4usize, 4096usize);
-    let stream = zipf_u64(100_000, 8192, 1.1, 1001);
+fn countmin_zipf_satisfies_the_count_min_additive_bound_and_shard_merge() {
+    const ROWS: usize = 4;
+    const COLS: usize = 4096;
+    const STREAM_SEED: u64 = 1001;
 
-    let mut single = CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols);
+    let stream = zipf_u64(100_000, 8192, 1.1, STREAM_SEED);
+    let mut single = CountMin::<Vector2D<i64>, FastPath>::with_dimensions(ROWS, COLS);
     let (mut shard_a, mut shard_b, mut shard_c) = (
-        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols),
-        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols),
-        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(rows, cols),
+        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(ROWS, COLS),
+        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(ROWS, COLS),
+        CountMin::<Vector2D<i64>, FastPath>::with_dimensions(ROWS, COLS),
     );
     let mut truth = FreqTruth::default();
     for (i, k) in stream.iter().enumerate() {
@@ -41,62 +58,77 @@ fn countmin_zipf_one_sided_bound_and_shard_merge() {
     }
     shard_b.merge(&shard_c);
     shard_a.merge(&shard_b);
-    let merged = &shard_a;
 
-    // One-sided guarantee: est >= true, excess within eps*N (eps = e/cols).
-    let eps_n = std::f64::consts::E / cols as f64 * truth.total() as f64;
-    for (k, c) in truth.pairs() {
-        if c < 50 {
-            continue; // only assert keys dense enough to be meaningful
-        }
-        let est_single = single.estimate(&DataInput::I64(k));
-        let est_merged = merged.estimate(&DataInput::I64(k));
-        assert!(
-            est_single >= c && est_merged >= c,
-            "underestimate: key {k} true {c} single {est_single} merged {est_merged}"
-        );
-        assert!(
-            (est_single - c) as f64 <= eps_n && (est_merged - c) as f64 <= eps_n,
-            "excess beyond eps*N: key {k} true {c} single {est_single} merged {est_merged}"
-        );
-    }
+    let spec = CountMinSpec::new(ROWS, COLS);
+    let context = format!("zipf(1.1) domain=8192 n=100000 stream_seed={STREAM_SEED}");
+    spec.assert_contract(
+        "CountMin<Vector2D<i64>, FastPath> single-pass",
+        &truth,
+        |k| single.estimate(&DataInput::I64(k)) as f64,
+        &context,
+    );
+    spec.assert_contract(
+        "CountMin<Vector2D<i64>, FastPath> 3-way shard merge",
+        &truth,
+        |k| shard_a.estimate(&DataInput::I64(k)) as f64,
+        &context,
+    );
 
-    // Shard-merge must equal the single-pass estimate on hot keys.
-    for (k, _) in truth.top_k(50) {
+    // Merging counter matrices is exact addition, so a merged sketch is not
+    // merely close to the single-pass one — it is identical on every key.
+    let mut merge_equality = Tally::default();
+    for (k, _) in truth.pairs() {
         let a = single.estimate(&DataInput::I64(k));
-        let b = merged.estimate(&DataInput::I64(k));
-        assert_eq!(a, b, "merged counters diverge from single pass for key {k}");
+        let b = shard_a.estimate(&DataInput::I64(k));
+        merge_equality.record(a == b, || {
+            format!("key {k}: single-pass {a} != shard-merged {b}")
+        });
     }
+    merge_equality.assert_none("CountMin merge equality", &context);
 }
 
+/// Both hashing paths satisfy Count-Min's contract on the same stream.
+///
+/// They are *not* required to return equal estimates and generally do not:
+/// `RegularPath` makes one hash call per row with `seed_list[r]`, while
+/// `FastPath` makes a single call with `seed_list[0]` and slices row bits out
+/// of it. Different hash functions place keys in different columns, so the two
+/// collide on different key pairs. On a 40k-update Zipf stream at 3x4096 they
+/// disagree on roughly a third of keys — every disagreement inside the bound.
+/// An earlier version of this test asserted equality on four hand-picked keys,
+/// which held by coincidence at those dimensions rather than by contract.
+///
+/// `e2e_matrix_instances.rs` covers the equality that *is* contractual: on a
+/// collision-free workload both paths return exact counts.
 #[test]
-fn countmin_regular_fast_paths_agree_on_stream() {
-    let mut reg = CountMin::<Vector2D<i64>, RegularPath>::with_dimensions(3, 2048);
-    let mut fast = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 2048);
-    let stream = zipf_u64(20_000, 512, 1.2, 1002);
+fn countmin_both_paths_satisfy_the_bound_on_the_same_stream() {
+    const ROWS: usize = 3;
+    const COLS: usize = 2048;
+    const STREAM_SEED: u64 = 1002;
+
+    let mut reg = CountMin::<Vector2D<i64>, RegularPath>::with_dimensions(ROWS, COLS);
+    let mut fast = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(ROWS, COLS);
+    let mut truth = FreqTruth::default();
+    let stream = zipf_u64(20_000, 512, 1.2, STREAM_SEED);
     for k in &stream {
+        truth.observe(*k as i64);
         reg.insert(&DataInput::I64(*k as i64));
         fast.insert(&DataInput::I64(*k as i64));
     }
-    for k in [0i64, 7, 42, 511] {
-        assert_eq!(
-            reg.estimate(&DataInput::I64(k)),
-            fast.estimate(&DataInput::I64(k)) as i64,
-            "regular/fast paths disagree for key {k}"
-        );
-    }
-}
-
-/// Counts keys whose estimate sits within `bound` of the exact count.
-fn keys_within_bound<F>(truth: &FreqTruth, estimate: F, bound: f64) -> usize
-where
-    F: Fn(i64) -> f64,
-{
-    truth
-        .pairs()
-        .into_iter()
-        .filter(|(k, c)| (estimate(*k) - *c as f64).abs() < bound)
-        .count()
+    let spec = CountMinSpec::new(ROWS, COLS);
+    let context = format!("zipf(1.2) domain=512 n=20000 stream_seed={STREAM_SEED}");
+    spec.assert_contract(
+        "CountMin<Vector2D<i64>, RegularPath>",
+        &truth,
+        |k| reg.estimate(&DataInput::I64(k)) as f64,
+        &context,
+    );
+    spec.assert_contract(
+        "CountMin<Vector2D<i32>, FastPath>",
+        &truth,
+        |k| fast.estimate(&DataInput::I64(k)) as f64,
+        &context,
+    );
 }
 
 /// Bounded integer draws mapped onto distinct f64 values in `[100, 1000)`,
@@ -116,66 +148,71 @@ fn u64_input(key: i64) -> DataInput<'static> {
 /// A named key stream paired with the `DataInput` constructor for its keys.
 type BoundStream = (&'static str, Vec<i64>, fn(i64) -> DataInput<'static>);
 
-/// Zipf over `u64` keys and uniform over `f64` keys, exercising both
-/// `DataInput` hashing paths.
-fn bound_streams() -> [BoundStream; 2] {
+const BOUND_ROWS: usize = 3;
+const BOUND_COLS: usize = 4096;
+const BOUND_N: usize = 120_000;
+/// Independent key populations per shape. The library fixes its hash seed
+/// table, so a test cannot resample the hash function; what it *can* resample
+/// is the key population, which under the random-oracle model the sketches
+/// assume yields an independent collision configuration per trial. This is
+/// stated plainly rather than dressed up as seed independence.
+const BOUND_TRIALS: u64 = 3;
+
+/// Zipf over `u64` keys and uniform over `f64` keys for one trial, exercising
+/// both `DataInput` hashing paths. Each trial uses a disjoint key domain so
+/// its collisions are unrelated to the previous trial's.
+fn bound_streams(trial: u64) -> [BoundStream; 2] {
     [
         (
             "zipf/u64",
-            zipf_u64(BOUND_N, 8192, 1.1, 1005)
+            zipf_u64(BOUND_N, 8192, 1.1, 1005 + trial * 977)
                 .into_iter()
-                .map(|v| v as i64)
+                .map(|v| v as i64 + (trial as i64) * 100_000)
                 .collect(),
             u64_input as fn(i64) -> DataInput<'static>,
         ),
         (
             "uniform/f64",
-            uniform_u64(BOUND_N, 4096, 1006)
+            uniform_u64(BOUND_N, 4096, 1006 + trial * 977)
                 .into_iter()
-                .map(uniform_f64_key)
+                .map(|v| uniform_f64_key(v + trial * 8192))
                 .collect(),
             f64_input as fn(i64) -> DataInput<'static>,
         ),
     ]
 }
 
-const BOUND_ROWS: usize = 3;
-const BOUND_COLS: usize = 4096;
-const BOUND_N: usize = 200_000;
-
-/// Probabilistic bound with `eps = e / cols` and `delta = e^-rows`: at least a
-/// `1 - delta` fraction of keys estimate within `eps * N`, on both insert paths.
+/// Count-Min Theorem 1 on both insert paths and both `DataInput` hash
+/// domains, over independent key populations.
 #[test]
-fn countmin_error_bound_covers_most_keys_on_both_paths() {
-    for (name, keys, to_input) in bound_streams() {
-        let mut truth = FreqTruth::default();
-        let mut regular =
-            CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(BOUND_ROWS, BOUND_COLS);
-        let mut fast = CountMin::<Vector2D<i32>, FastPath>::with_dimensions(BOUND_ROWS, BOUND_COLS);
-        for k in &keys {
-            let d = to_input(*k);
-            truth.observe(*k);
-            regular.insert(&d);
-            fast.insert(&d);
-        }
-
-        let eps_n = std::f64::consts::E / BOUND_COLS as f64 * BOUND_N as f64;
-        let floor =
-            truth.distinct() as f64 * (1.0 - 1.0 / std::f64::consts::E.powi(BOUND_ROWS as i32));
-        for (path, within) in [
-            (
-                "regular",
-                keys_within_bound(&truth, |k| regular.estimate(&to_input(k)) as f64, eps_n),
-            ),
-            (
-                "fast",
-                keys_within_bound(&truth, |k| fast.estimate(&to_input(k)) as f64, eps_n),
-            ),
-        ] {
-            assert!(
-                within as f64 > floor,
-                "CountMin {name}/{path}: {within} of {} keys within eps*N={eps_n:.0}, need > {floor:.1}",
-                truth.distinct()
+fn countmin_satisfies_the_count_min_theorem_on_both_paths() {
+    let spec = CountMinSpec::new(BOUND_ROWS, BOUND_COLS);
+    for trial in 0..BOUND_TRIALS {
+        for (name, keys, to_input) in bound_streams(trial) {
+            let mut truth = FreqTruth::default();
+            let mut regular =
+                CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(BOUND_ROWS, BOUND_COLS);
+            let mut fast =
+                CountMin::<Vector2D<i32>, FastPath>::with_dimensions(BOUND_ROWS, BOUND_COLS);
+            for k in &keys {
+                let d = to_input(*k);
+                truth.observe(*k);
+                regular.insert(&d);
+                fast.insert(&d);
+            }
+            let context =
+                format!("{name} trial={trial} n={BOUND_N} (see bound_streams for stream seeds)");
+            spec.assert_contract(
+                &format!("CountMin RegularPath {name}"),
+                &truth,
+                |k| regular.estimate(&to_input(k)) as f64,
+                &context,
+            );
+            spec.assert_contract(
+                &format!("CountMin FastPath {name}"),
+                &truth,
+                |k| fast.estimate(&to_input(k)) as f64,
+                &context,
             );
         }
     }
@@ -183,9 +220,15 @@ fn countmin_error_bound_covers_most_keys_on_both_paths() {
 
 // -------------------------------------------------------------- CountSketch
 
+/// Count Sketch's median-of-rows L2 bound, plus exact turnstile cancellation.
+///
+/// The bound asserted here is `sqrt(kappa / w) * ||f_-i||_2` per key, with
+/// `||f_-i||_2` recomputed from the exact frequency vector for each key —
+/// *not* Count-Min's `e/w * N`. See `CountSketchSpec` for the derivation.
 #[test]
-fn countsketch_turnstile_net_zero_and_median_bound() {
-    // True turnstile: +500 then -500 must net to zero.
+fn countsketch_turnstile_cancels_and_satisfies_the_l2_median_bound() {
+    // True turnstile: +500 then -500 must net to zero. Exact, not approximate:
+    // the same cells are incremented and decremented.
     let mut cs = asap_sketchlib::Count::<Vector2D<i64>, RegularPath>::with_dimensions(4, 1024);
     cs.insert_many(&DataInput::U32(9), 500);
     cs.insert_many(&DataInput::U32(9), -500);
@@ -195,74 +238,146 @@ fn countsketch_turnstile_net_zero_and_median_bound() {
         "turnstile did not cancel"
     );
 
-    // Median estimator bound |est - true| <= sqrt(e/cols) * L2.
-    let (rows, cols) = (5usize, 4096usize);
-    let mut cs = asap_sketchlib::Count::<Vector2D<i64>, RegularPath>::with_dimensions(rows, cols);
-    let stream = zipf_u64(200_000, 8192, 1.1, 1003);
+    const ROWS: usize = 5;
+    const COLS: usize = 4096;
+    const STREAM_SEED: u64 = 1003;
+    let mut cs = asap_sketchlib::Count::<Vector2D<i64>, RegularPath>::with_dimensions(ROWS, COLS);
+    let stream = zipf_u64(200_000, 8192, 1.1, STREAM_SEED);
     let mut truth = FreqTruth::default();
     for k in &stream {
         truth.observe(*k as i64);
         cs.insert(&DataInput::I64(*k as i64));
     }
-    let bound = (std::f64::consts::E / cols as f64).sqrt() * truth.l2_norm();
-    for (k, c) in truth.top_k(100) {
-        let est = cs.estimate(&DataInput::I64(k));
-        assert!(
-            (est - c as f64).abs() <= 1.5 * bound,
-            "key {k}: |{est:.0} - {c}| > 1.5 * median bound {:.0}",
-            1.5 * bound
+    let spec = CountSketchSpec::new(ROWS, COLS);
+    spec.assert_contract(
+        "Count<Vector2D<i64>, RegularPath>",
+        &truth,
+        |k| cs.estimate(&DataInput::I64(k)),
+        &format!("zipf(1.1) domain=8192 n=200000 stream_seed={STREAM_SEED}"),
+    );
+}
+
+/// Count Sketch's L2 bound on both insert paths and both `DataInput` hash
+/// domains, with every key in every trial pooled into one binomial acceptance
+/// rule at the theorem's own post-median failure probability.
+#[test]
+fn countsketch_satisfies_the_l2_median_bound_on_both_paths() {
+    let spec = CountSketchSpec::new(BOUND_ROWS, BOUND_COLS);
+    // One tally per (shape, path): all trials pool into a single acceptance
+    // rule, so the decision is made on the whole population rather than on
+    // whichever trial happened to look worst.
+    let mut tallies: HashMap<String, Tally> = HashMap::new();
+    for trial in 0..BOUND_TRIALS {
+        for (name, keys, to_input) in bound_streams(trial) {
+            let mut truth = FreqTruth::default();
+            let mut regular = asap_sketchlib::Count::<Vector2D<i32>, RegularPath>::with_dimensions(
+                BOUND_ROWS, BOUND_COLS,
+            );
+            let mut fast = asap_sketchlib::Count::<Vector2D<i32>, FastPath>::with_dimensions(
+                BOUND_ROWS, BOUND_COLS,
+            );
+            for k in &keys {
+                let d = to_input(*k);
+                truth.observe(*k);
+                regular.insert(&d);
+                fast.insert(&d);
+            }
+            spec.tally_into(
+                tallies.entry(format!("{name}/RegularPath")).or_default(),
+                &truth,
+                |k| regular.estimate(&to_input(k)),
+            );
+            spec.tally_into(
+                tallies.entry(format!("{name}/FastPath")).or_default(),
+                &truth,
+                |k| fast.estimate(&to_input(k)),
+            );
+        }
+    }
+    for (label, tally) in tallies {
+        tally.assert_within(
+            &format!("Count {label} / L2 median bound"),
+            spec.per_key_failure(),
+            &format!(
+                "rows={BOUND_ROWS} cols={BOUND_COLS} kappa={} n={BOUND_N} \
+                 trials={BOUND_TRIALS} (independent key populations, fixed library hash seed)",
+                spec.kappa
+            ),
         );
     }
 }
 
-/// The same `1 - delta` coverage bound as CountMin, for the signed sketch.
+/// Count Sketch's error is *rank-independent*: a cold key carries the same
+/// absolute error band as the hottest one, which is exactly what separates it
+/// from Count-Min. Documented empirical regression, not a theorem: the
+/// theorem bounds each key individually and says nothing about how the
+/// measured mean error compares across frequency strata.
+///
+/// Band source: measured on this exact stream (zipf(1.1), domain 8192,
+/// n=200_000, seed 1007, rows=5, cols=4096) where the mean |error| per decile
+/// spans 20.6 to 26.5 — a spread of 1.29x. The 3x ceiling below leaves ample
+/// room for run-to-run movement while still failing loudly if the error ever
+/// starts tracking frequency the way Count-Min's does (on this stream
+/// Count-Min's per-decile mean error spans more than 40x).
 #[test]
-fn countsketch_error_bound_covers_most_keys_on_both_paths() {
-    for (name, keys, to_input) in bound_streams() {
-        let mut truth = FreqTruth::default();
-        let mut regular = asap_sketchlib::Count::<Vector2D<i32>, RegularPath>::with_dimensions(
-            BOUND_ROWS, BOUND_COLS,
-        );
-        let mut fast = asap_sketchlib::Count::<Vector2D<i32>, FastPath>::with_dimensions(
-            BOUND_ROWS, BOUND_COLS,
-        );
-        for k in &keys {
-            let d = to_input(*k);
-            truth.observe(*k);
-            regular.insert(&d);
-            fast.insert(&d);
-        }
+fn countsketch_error_stays_rank_independent_within_the_documented_empirical_band() {
+    const ROWS: usize = 5;
+    const COLS: usize = 4096;
+    const STREAM_SEED: u64 = 1007;
+    const DECILES: usize = 10;
 
-        let eps_n = std::f64::consts::E / BOUND_COLS as f64 * BOUND_N as f64;
-        let floor =
-            truth.distinct() as f64 * (1.0 - 1.0 / std::f64::consts::E.powi(BOUND_ROWS as i32));
-        for (path, within) in [
-            (
-                "regular",
-                keys_within_bound(&truth, |k| regular.estimate(&to_input(k)), eps_n),
-            ),
-            (
-                "fast",
-                keys_within_bound(&truth, |k| fast.estimate(&to_input(k)), eps_n),
-            ),
-        ] {
-            assert!(
-                within as f64 > floor,
-                "CountSketch {name}/{path}: {within} of {} keys within eps*N={eps_n:.0}, need > {floor:.1}",
-                truth.distinct()
-            );
-        }
+    let stream = zipf_u64(200_000, 8192, 1.1, STREAM_SEED);
+    let mut truth = FreqTruth::default();
+    let mut cs = asap_sketchlib::Count::<Vector2D<i64>, RegularPath>::with_dimensions(ROWS, COLS);
+    for k in &stream {
+        truth.observe(*k as i64);
+        cs.insert(&DataInput::I64(*k as i64));
     }
+
+    let mut pairs = truth.pairs();
+    pairs.sort_by_key(|(_, c)| *c);
+    let per = pairs.len() / DECILES;
+    let means: Vec<f64> = (0..DECILES)
+        .map(|d| {
+            let slice = &pairs[d * per..(d + 1) * per];
+            slice
+                .iter()
+                .map(|(k, c)| (cs.estimate(&DataInput::I64(*k)) - *c as f64).abs())
+                .sum::<f64>()
+                / slice.len() as f64
+        })
+        .collect();
+    let lo = means.iter().cloned().fold(f64::INFINITY, f64::min);
+    let hi = means.iter().cloned().fold(0.0f64, f64::max);
+    assert!(
+        hi <= lo * 3.0,
+        "Count Sketch mean |error| per frequency decile spans {lo:.1}..{hi:.1} ({:.2}x), \
+         beyond the documented 3x empirical band — the error has started tracking key \
+         frequency, which Count Sketch's L2 guarantee says it must not. \
+         stream_seed={STREAM_SEED} rows={ROWS} cols={COLS} deciles={means:?}",
+        hi / lo
+    );
 }
 
 // ------------------------------------------------------------- Top-k heaps
 
+/// The two heap-backed sketches share heap bookkeeping but not an error
+/// metric: `CMSHeap` carries Count-Min's one-sided additive bound and
+/// `CSHeap` carries Count Sketch's L2 bound. Both must keep every heap entry
+/// equal to what the sketch itself estimates, and both must recover the true
+/// heavy hitters that the top-k contract actually guarantees.
 #[test]
-fn heaps_top_k_recall_and_consistency() {
-    let (top_k, domain) = (16usize, 1024usize);
-    let mut cms_heap = CMSHeap::<Vector2D<i64>, RegularPath>::new(3, 4096, top_k);
-    let mut cs_heap = CSHeap::<Vector2D<i64>, RegularPath>::new(5, 4096, top_k);
-    let stream = zipf_u64(20_000, domain, 1.1, 1004);
+fn heaps_satisfy_their_own_bounds_and_stay_heap_consistent() {
+    const TOP_K: usize = 16;
+    const DOMAIN: usize = 1024;
+    const CM_ROWS: usize = 3;
+    const CS_ROWS: usize = 5;
+    const COLS: usize = 4096;
+    const STREAM_SEED: u64 = 1004;
+
+    let mut cms_heap = CMSHeap::<Vector2D<i64>, RegularPath>::new(CM_ROWS, COLS, TOP_K);
+    let mut cs_heap = CSHeap::<Vector2D<i64>, RegularPath>::new(CS_ROWS, COLS, TOP_K);
+    let stream = zipf_u64(20_000, DOMAIN, 1.1, STREAM_SEED);
     let mut truth = FreqTruth::default();
     for k in &stream {
         let d = DataInput::I64(*k as i64);
@@ -270,13 +385,31 @@ fn heaps_top_k_recall_and_consistency() {
         cms_heap.insert(&d);
         cs_heap.insert(&d);
     }
-    let expected_min_count = truth.top_k(top_k)[top_k - 1].1;
+    let context = format!("zipf(1.1) domain={DOMAIN} n=20000 stream_seed={STREAM_SEED}");
 
+    // Each sketch against its own theorem.
+    CountMinSpec::new(CM_ROWS, COLS).assert_contract(
+        "CMSHeap point estimate",
+        &truth,
+        |k| cms_heap.estimate(&DataInput::I64(k)) as f64,
+        &context,
+    );
+    CountSketchSpec::new(CS_ROWS, COLS).assert_contract(
+        "CSHeap point estimate",
+        &truth,
+        |k| cs_heap.estimate(&DataInput::I64(k)),
+        &context,
+    );
+
+    // Heap/sketch consistency is structural: a heap entry that disagrees with
+    // the sketch is a bug regardless of any error bound.
+    let kth_count = truth.top_k(TOP_K)[TOP_K - 1].1;
     for (label, items, cms) in [
         ("CMSHeap", cms_heap.heap().heap().to_vec(), true),
         ("CSHeap", cs_heap.heap().heap().to_vec(), false),
     ] {
-        assert!(items.len() <= top_k, "{label} heap exceeded capacity");
+        assert!(items.len() <= TOP_K, "{label} heap exceeded capacity");
+        let mut consistency = Tally::default();
         let mut recall = 0usize;
         for it in &items {
             let key = match &it.key {
@@ -288,30 +421,45 @@ fn heaps_top_k_recall_and_consistency() {
             } else {
                 cs_heap.estimate(&DataInput::I64(key)) as i64
             };
-            // Invariant: heap entry must always equal the sketch estimate.
-            assert_eq!(
-                it.count, est,
-                "{label}: heap {} != estimate {est} for key {key}",
-                it.count
-            );
-            if truth.get(key) >= expected_min_count {
+            consistency.record(it.count == est, || {
+                format!(
+                    "key {key}: heap holds {} but the sketch estimates {est}",
+                    it.count
+                )
+            });
+            if truth.get(key) >= kth_count {
                 recall += 1;
             }
         }
+        consistency.assert_none(&format!("{label} heap/sketch consistency"), &context);
+
+        // Recall target: a key whose true count is at least the true k-th
+        // count must be admitted. Count-Min never underestimates, so every
+        // such key's estimate dominates the heap minimum once seen; one
+        // displacement slot of slack covers the eviction race at the
+        // boundary, where several keys share the k-th count.
         assert!(
-            recall >= top_k - 1,
-            "{label} recovered only {recall}/{top_k} heavy hitters"
+            recall >= TOP_K - 1,
+            "{label} recovered only {recall}/{TOP_K} keys at or above the true k-th count \
+             ({kth_count}); {context}"
         );
     }
 }
 
 // -------------------------------------------------------------- CountL2HH
 
+/// CountL2HH is a Count Sketch carrying a running F2, so its point estimates
+/// obey the Count Sketch L2 bound and its `get_l2_sqr` tracks the exact F2.
 #[test]
-fn countl2hh_weighted_f2_with_decrements() {
-    let mut sk = CountL2HH::<DefaultXxHasher>::with_dimensions_and_seed(4, 2048, 11);
+fn countl2hh_weighted_turnstile_satisfies_the_l2_median_bound() {
+    const ROWS: usize = 4;
+    const COLS: usize = 2048;
+    const HASH_SEED_IDX: usize = 11;
+    const STREAM_SEED: u64 = 1005;
+
+    let mut sk = CountL2HH::<DefaultXxHasher>::with_dimensions_and_seed(ROWS, COLS, HASH_SEED_IDX);
     let mut truth = FreqTruth::default();
-    let stream = zipf_u64(30_000, 512, 1.3, 1005);
+    let stream = zipf_u64(30_000, 512, 1.3, STREAM_SEED);
     for (i, k) in stream.iter().enumerate() {
         let w = 1 + (i % 5) as i64;
         sk.fast_insert_with_count(&DataInput::I64(*k as i64), w);
@@ -321,18 +469,25 @@ fn countl2hh_weighted_f2_with_decrements() {
     let hot = truth.top_k(1)[0].0;
     sk.fast_insert_with_count(&DataInput::I64(hot), -10);
     truth.observe_weighted(hot, -10);
-    let est_hot = sk.fast_update_and_est(&DataInput::I64(hot), 0);
-    let rel = ((est_hot - truth.get(hot) as f64) / truth.get(hot) as f64).abs();
-    assert!(
-        rel <= 0.02,
-        "hot-key frequency after decrement: {est_hot} vs {}",
-        truth.get(hot)
+
+    let context = format!(
+        "zipf(1.3) domain=512 n=30000 weighted 1..5 with one -10 decrement, \
+         stream_seed={STREAM_SEED} hash_seed_idx={HASH_SEED_IDX}"
+    );
+    CountSketchSpec::new(ROWS, COLS).assert_contract(
+        "CountL2HH point estimate",
+        &truth,
+        |k| sk.fast_get_est(&DataInput::I64(k)),
+        &context,
     );
 
-    assert!(
-        (sk.get_l2_sqr() - truth.f2()).abs() / truth.f2() <= 0.10,
-        "F2 over weighted turnstile stream off by >10%"
-    );
+    // F2 comes from the median of the per-row counter sums, i.e. the AMS
+    // tug-of-war estimator over this sketch's own matrix — an estimate with a
+    // real bound, not an exactly maintained total.
+    let f2_spec = SecondMomentSpec::new(ROWS, COLS);
+    if let Err(detail) = f2_spec.check(sk.get_l2_sqr(), truth.f2()) {
+        panic!("CountL2HH F2: {detail}\n  context: {context}");
+    }
 }
 
 // ------------------------------------------- FoldCMS / FoldCS counts + merge
@@ -379,18 +534,24 @@ fn build_fold_cms(key: &'static str, n: usize) -> FoldCMS<DefaultXxHasher> {
 }
 
 /// Sixteen sub-window sketches folded to a quarter width, then hierarchically
-/// merged: the merged answers must still satisfy the `1 - delta` coverage
-/// bound, additive `eps * N` for FoldCMS and `sqrt(eps) * L2` for FoldCS.
+/// merged. Folding halves the width `fold_level` times, so the merged sketches
+/// answer at `FULL_COLS >> FOLD_LEVEL` columns — and that, not the unfolded
+/// width, is the `w` each theorem is evaluated at. FoldCMS keeps Count-Min's
+/// additive bound; FoldCS keeps Count Sketch's L2 bound.
 #[test]
-fn fold_sketches_survive_a_sixteen_way_hierarchical_merge() {
+fn folded_sketches_keep_their_own_bounds_through_a_sixteen_way_merge() {
     const ROWS: usize = 3;
     const FULL_COLS: usize = 4096;
     const FOLD_LEVEL: u32 = 4;
     const TOP_K: usize = 20;
     const WINDOWS: usize = 16;
-    const N: usize = 500_000;
+    // Enough per window that folding to 256 columns is a real test, while an
+    // unoptimised `cargo test` run stays affordable. The bounds are computed
+    // from the exact truth, so a shorter stream narrows nothing.
+    const N: usize = 240_000;
+    const STREAM_SEED: u64 = 1009;
 
-    let stream = zipf_u64(N, 10_000, 1.1, 1009);
+    let stream = zipf_u64(N, 10_000, 1.1, STREAM_SEED);
     let per_window = N / WINDOWS;
     let mut truth = FreqTruth::default();
     let mut cms_windows = Vec::with_capacity(WINDOWS);
@@ -411,68 +572,63 @@ fn fold_sketches_survive_a_sixteen_way_hierarchical_merge() {
 
     let cms_merged = FoldCMS::hierarchical_merge(&cms_windows);
     let cs_merged = FoldCS::hierarchical_merge(&cs_windows);
+    let folded_cols = FULL_COLS >> FOLD_LEVEL;
+    let context = format!(
+        "zipf(1.1) domain=10000 n={N} stream_seed={STREAM_SEED}, {WINDOWS} windows folded \
+         {FOLD_LEVEL} levels: {FULL_COLS} -> {folded_cols} columns"
+    );
 
-    let floor = truth.distinct() as f64 * (1.0 - 1.0 / std::f64::consts::E.powi(ROWS as i32));
-    let cms_bound = std::f64::consts::E / FULL_COLS as f64 * truth.total() as f64;
-    let cs_bound = (std::f64::consts::E / FULL_COLS as f64).sqrt() * truth.l2_norm();
-
-    let cms_within = keys_within_bound(
+    CountMinSpec::new(ROWS, folded_cols).assert_contract(
+        "FoldCMS after a 16-way hierarchical merge",
         &truth,
         |k| cms_merged.query(&DataInput::U64(k as u64)) as f64,
-        cms_bound,
+        &context,
     );
-    assert!(
-        cms_within as f64 > floor,
-        "FoldCMS 16-way merge: {cms_within} of {} keys within eps*N={cms_bound:.0}, need > {floor:.1}",
-        truth.distinct()
-    );
-
-    let cs_within = keys_within_bound(
+    CountSketchSpec::new(ROWS, folded_cols).assert_contract(
+        "FoldCS after a 16-way hierarchical merge",
         &truth,
         |k| cs_merged.query(&DataInput::U64(k as u64)) as f64,
-        cs_bound,
-    );
-    assert!(
-        cs_within as f64 > floor,
-        "FoldCS 16-way merge: {cs_within} of {} keys within sqrt(eps)*L2={cs_bound:.0}, need > {floor:.1}",
-        truth.distinct()
+        &context,
     );
 }
 
 // ------------------------------------------------------ Portable wire twins
 
+/// The portable wire twins answer over string keys and must satisfy the same
+/// two theorems as their core counterparts — Count-Min additive, Count Sketch
+/// L2 — with no extra slack for being on the wire side.
 #[test]
-fn portable_cms_and_cs_string_keys_zipf_bound() {
-    let stream = zipf_u64(50_000, 2048, 1.1, 1006);
-    let mut truth: HashMap<String, i64> = HashMap::new();
+fn portable_cms_and_cs_string_keys_satisfy_their_own_bounds() {
+    const CM_ROWS: usize = 3;
+    const CS_ROWS: usize = 5;
+    const COLS: usize = 4096;
+    const STREAM_SEED: u64 = 1006;
 
-    let mut pcs = CountMinSketch::new(3, 4096);
-    let mut pcss = CountSketch::new(5, 4096);
+    let stream = zipf_u64(50_000, 2048, 1.1, STREAM_SEED);
+    // The portable types key on strings; `FreqTruth` keys on i64. The stream's
+    // u64 values are the identity behind both, so `k -> "k{k}"` is injective
+    // and the two truths agree key for key.
+    let mut truth = FreqTruth::default();
+    let mut pcs = CountMinSketch::new(CM_ROWS, COLS);
+    let mut pcss = CountSketch::new(CS_ROWS, COLS);
     for k in &stream {
+        truth.observe(*k as i64);
         let key = format!("k{k}");
-        *truth.entry(key.clone()).or_insert(0) += 1;
         pcs.update(&key, 1.0);
         pcss.update(&key, 1.0);
     }
-    let l2sq: f64 = truth.values().map(|c| (*c as f64) * (*c as f64)).sum();
-    let l2 = l2sq.sqrt();
-    let total = truth.values().sum::<i64>() as f64;
-    let cm_bound = std::f64::consts::E / 4096.0 * total;
-    let cs_bound = (std::f64::consts::E / 4096.0).sqrt() * l2;
+    let context = format!("zipf(1.1) domain=2048 n=50000 string keys, stream_seed={STREAM_SEED}");
 
-    let mut by_freq: Vec<(String, i64)> = truth.into_iter().collect();
-    by_freq.sort_by_key(|(_, c)| -*c);
-    for (k, c) in by_freq.iter().take(60) {
-        let cm_est = pcs.estimate(k);
-        assert!(
-            cm_est >= *c as f64 && cm_est <= *c as f64 + cm_bound,
-            "portable CM key {k}: est {cm_est} vs true {c}"
-        );
-        let cs_est = pcss.estimate(k);
-        assert!(
-            (cs_est - *c as f64).abs() <= 1.5 * cs_bound,
-            "portable CS key {k}: est {cs_est} vs true {c} (bound {:.0})",
-            1.5 * cs_bound
-        );
-    }
+    CountMinSpec::new(CM_ROWS, COLS).assert_contract(
+        "portable CountMinSketch",
+        &truth,
+        |k| pcs.estimate(&format!("k{k}")),
+        &context,
+    );
+    CountSketchSpec::new(CS_ROWS, COLS).assert_contract(
+        "portable CountSketch",
+        &truth,
+        |k| pcss.estimate(&format!("k{k}")),
+        &context,
+    );
 }

--- a/tests/e2e_matrix_instances.rs
+++ b/tests/e2e_matrix_instances.rs
@@ -1,0 +1,668 @@
+//! Every built-in `(storage, hashing path)` instance of the four matrix-backed
+//! frequency families, held to its own family's theorem.
+//!
+//! The deep, production-sized accuracy runs live in `e2e_frequency.rs` on each
+//! family's headline instance. This file is about *coverage of the instance
+//! matrix*: a storage backend that silently mis-indexes, a counter width that
+//! wraps, or a fast path that reads cells the regular path never wrote, would
+//! all pass a suite that only ever exercised `Vector2D<i64>`.
+//!
+//! Each instance therefore gets a medium stream and three checks:
+//!
+//! 1. its family's error bound (`CountMinSpec` or `CountSketchSpec`) evaluated
+//!    at the dimensions the instance itself reports, so the fixed 5x2048 and
+//!    3x4096 layouts are judged at their own `w` rather than a borrowed one;
+//! 2. agreement between the regular and fast paths on the same storage, which
+//!    is exact — they are two ways of deriving the same cells;
+//! 3. shard merge, which for counter matrices is exact addition.
+//!
+//! Counter-width overflow is covered separately, once per width, because that
+//! is where `i32`, `i64` and `i128` actually differ.
+
+mod common;
+
+use common::specs::{CountMinSpec, CountSketchSpec, Tally};
+use common::{FreqTruth, zipf_u64};
+
+use asap_sketchlib::{
+    CMSHeap, CSHeap, Count, CountMin, DataInput, DefaultMatrixI32, DefaultMatrixI64,
+    DefaultMatrixI128, FastPath, FixedMatrix, HeapItem, QuickMatrixI64, QuickMatrixI128,
+    RegularPath, Vector2D,
+};
+
+/// Medium stream: large enough that collisions are statistically meaningful at
+/// 2048 and 4096 columns, small enough that seventy instances stay quick.
+const N: usize = 40_000;
+const DOMAIN: usize = 4_096;
+const STREAM_SEED: u64 = 0x10BE_C700;
+
+fn stream_and_truth() -> (Vec<u64>, FreqTruth) {
+    let stream = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut truth = FreqTruth::default();
+    for k in &stream {
+        truth.observe(*k as i64);
+    }
+    (stream, truth)
+}
+
+fn context(label: &str, rows: usize, cols: usize) -> String {
+    format!("{label} rows={rows} cols={cols} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}")
+}
+
+/// Counter values reach the assertions as `f64`; the concrete counter type is
+/// known at each macro expansion, so this stays a plain conversion rather than
+/// a lossy generic cast scattered through the tests.
+trait CounterValue: Copy {
+    fn as_f64(self) -> f64;
+}
+impl CounterValue for i32 {
+    fn as_f64(self) -> f64 {
+        self as f64
+    }
+}
+impl CounterValue for i64 {
+    fn as_f64(self) -> f64 {
+        self as f64
+    }
+}
+impl CounterValue for i128 {
+    fn as_f64(self) -> f64 {
+        self as f64
+    }
+}
+impl CounterValue for f64 {
+    fn as_f64(self) -> f64 {
+        self
+    }
+}
+
+// ----------------------------------------------------------------- CountMin
+
+/// One `CountMin<$storage, $path>` instance: build it from `Default` (which is
+/// what fixes each fixed-layout storage's dimensions), run the stream, and
+/// assert Count-Min's own contract at the dimensions it reports.
+macro_rules! countmin_instance {
+    ($storage:ty, $path:ty, $stream:expr, $truth:expr) => {{
+        let mut single = CountMin::<$storage, $path>::default();
+        let mut left = CountMin::<$storage, $path>::default();
+        let mut right = CountMin::<$storage, $path>::default();
+        for (i, k) in $stream.iter().enumerate() {
+            let d = DataInput::U64(*k);
+            single.insert(&d);
+            if i % 2 == 0 {
+                left.insert(&d);
+            } else {
+                right.insert(&d);
+            }
+        }
+        left.merge(&right);
+
+        let (rows, cols) = (single.rows(), single.cols());
+        let label = concat!(
+            "CountMin<",
+            stringify!($storage),
+            ", ",
+            stringify!($path),
+            ">"
+        );
+        let ctx = context(label, rows, cols);
+        let spec = CountMinSpec::new(rows, cols);
+        spec.assert_contract(
+            label,
+            $truth,
+            |k| single.estimate(&DataInput::U64(k as u64)).as_f64(),
+            &ctx,
+        );
+        spec.assert_contract(
+            &format!("{label} shard merge"),
+            $truth,
+            |k| left.estimate(&DataInput::U64(k as u64)).as_f64(),
+            &ctx,
+        );
+
+        // Merging counter matrices is exact addition, so the merged sketch is
+        // identical to the single-pass one, not merely close.
+        let mut equality = Tally::default();
+        for (k, _) in $truth.pairs() {
+            let a = single.estimate(&DataInput::U64(k as u64)).as_f64();
+            let b = left.estimate(&DataInput::U64(k as u64)).as_f64();
+            equality.record(a == b, || format!("key {k}: single {a} merged {b}"));
+        }
+        equality.assert_none(&format!("{label} merge equality"), &ctx);
+        single
+    }};
+}
+
+/// On a workload small enough to be collision-free, *both* paths must return
+/// exact counts — every probed cell belongs to the queried key alone.
+///
+/// This, and not estimate-for-estimate equality, is the cross-path contract.
+/// `RegularPath` makes one hash call per row with `seed_list[r]`; `FastPath`
+/// makes a single call with `seed_list[0]` and slices row bits out of it.
+/// They are different hash functions, so they place keys in different columns
+/// and legitimately disagree wherever either one collides. Asserting equality
+/// on a colliding stream would be asserting a coincidence: on a 40k-update
+/// Zipf stream at 3x4096 the two paths differ on roughly a third of keys, all
+/// of them inside Count-Min's bound.
+macro_rules! assert_both_paths_exact_without_collisions {
+    ($sketch:ident, $storage:ty, $keys:expr) => {{
+        let mut regular = $sketch::<$storage, RegularPath>::default();
+        let mut fast = $sketch::<$storage, FastPath>::default();
+        let mut truth = FreqTruth::default();
+        for (i, k) in $keys.iter().enumerate() {
+            for _ in 0..(i + 1) * 10 {
+                let d = DataInput::U64(*k);
+                regular.insert(&d);
+                fast.insert(&d);
+                truth.observe(*k as i64);
+            }
+        }
+        let label = concat!(
+            stringify!($sketch),
+            "<",
+            stringify!($storage),
+            "> collision-free exactness on both paths"
+        );
+        let ctx = context(label, regular.rows(), regular.cols());
+        let mut tally = Tally::default();
+        for (k, c) in truth.pairs() {
+            let r = regular.estimate(&DataInput::U64(k as u64)).as_f64();
+            let f = fast.estimate(&DataInput::U64(k as u64)).as_f64();
+            tally.record(r == c as f64 && f == c as f64, || {
+                format!("key {k}: true {c}, regular {r}, fast {f}")
+            });
+        }
+        tally.assert_none(label, &ctx);
+    }};
+}
+
+/// Eight well-separated keys in a 2048- or 4096-column grid: the chance that
+/// any pair collides in every row is negligible, and with fixed seeds the
+/// outcome is deterministic, so a failure here means a storage backend is
+/// mis-indexing rather than that the stream was unlucky.
+const COLLISION_FREE_KEYS: [u64; 8] = [
+    1,
+    7,
+    4_242,
+    90_210,
+    1_000_003,
+    2_147_483_647,
+    4_294_967_311,
+    9_007_199_254_740_993,
+];
+
+macro_rules! countmin_matrix_test {
+    ($name:ident, $path:ty, $( $storage:ty ),+ $(,)?) => {
+        #[test]
+        fn $name() {
+            let (stream, truth) = stream_and_truth();
+            $( { let _ = countmin_instance!($storage, $path, stream, &truth); } )+
+        }
+    };
+}
+
+countmin_matrix_test!(
+    countmin_regular_path_instances_satisfy_the_count_min_bound,
+    RegularPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    Vector2D<i128>,
+    Vector2D<f64>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    QuickMatrixI128,
+    DefaultMatrixI64,
+    DefaultMatrixI128,
+);
+
+countmin_matrix_test!(
+    countmin_fast_path_instances_satisfy_the_count_min_bound,
+    FastPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    Vector2D<i128>,
+    Vector2D<f64>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    QuickMatrixI128,
+    DefaultMatrixI64,
+    DefaultMatrixI128,
+);
+
+#[test]
+fn countmin_both_paths_are_exact_on_a_collision_free_workload() {
+    assert_both_paths_exact_without_collisions!(CountMin, Vector2D<i32>, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, Vector2D<i64>, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, Vector2D<i128>, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, Vector2D<f64>, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, FixedMatrix, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, DefaultMatrixI32, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, QuickMatrixI64, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, QuickMatrixI128, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, DefaultMatrixI64, COLLISION_FREE_KEYS);
+    assert_both_paths_exact_without_collisions!(CountMin, DefaultMatrixI128, COLLISION_FREE_KEYS);
+}
+
+// -------------------------------------------------------------- CountSketch
+
+macro_rules! count_instance {
+    ($storage:ty, $path:ty, $stream:expr, $truth:expr) => {{
+        let mut single = Count::<$storage, $path>::default();
+        let mut left = Count::<$storage, $path>::default();
+        let mut right = Count::<$storage, $path>::default();
+        for (i, k) in $stream.iter().enumerate() {
+            let d = DataInput::U64(*k);
+            single.insert(&d);
+            if i % 2 == 0 {
+                left.insert(&d);
+            } else {
+                right.insert(&d);
+            }
+        }
+        left.merge(&right);
+
+        let (rows, cols) = (single.rows(), single.cols());
+        let label = concat!("Count<", stringify!($storage), ", ", stringify!($path), ">");
+        let ctx = context(label, rows, cols);
+        let spec = CountSketchSpec::new(rows, cols);
+        spec.assert_contract(
+            label,
+            $truth,
+            |k| single.estimate(&DataInput::U64(k as u64)),
+            &ctx,
+        );
+        spec.assert_contract(
+            &format!("{label} shard merge"),
+            $truth,
+            |k| left.estimate(&DataInput::U64(k as u64)),
+            &ctx,
+        );
+
+        // Signed counters still add exactly on merge.
+        let mut equality = Tally::default();
+        for (k, _) in $truth.pairs() {
+            let a = single.estimate(&DataInput::U64(k as u64));
+            let b = left.estimate(&DataInput::U64(k as u64));
+            equality.record(a == b, || format!("key {k}: single {a} merged {b}"));
+        }
+        equality.assert_none(&format!("{label} merge equality"), &ctx);
+    }};
+}
+
+macro_rules! count_matrix_test {
+    ($name:ident, $path:ty, $( $storage:ty ),+ $(,)?) => {
+        #[test]
+        fn $name() {
+            let (stream, truth) = stream_and_truth();
+            $( count_instance!($storage, $path, stream, &truth); )+
+        }
+    };
+}
+
+count_matrix_test!(
+    countsketch_regular_path_instances_satisfy_the_l2_bound,
+    RegularPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    Vector2D<i128>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    QuickMatrixI128,
+    DefaultMatrixI64,
+    DefaultMatrixI128,
+);
+
+count_matrix_test!(
+    countsketch_fast_path_instances_satisfy_the_l2_bound,
+    FastPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    Vector2D<i128>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    QuickMatrixI128,
+    DefaultMatrixI64,
+    DefaultMatrixI128,
+);
+
+/// The same collision-free exactness contract for the signed family: with no
+/// collisions every row reports `sign * sign * f = f`, so the median is exact
+/// on both paths.
+#[test]
+fn countsketch_both_paths_are_exact_on_a_collision_free_workload() {
+    macro_rules! exact {
+        ($storage:ty) => {{
+            let mut regular = Count::<$storage, RegularPath>::default();
+            let mut fast = Count::<$storage, FastPath>::default();
+            let mut truth = FreqTruth::default();
+            for (i, k) in COLLISION_FREE_KEYS.iter().enumerate() {
+                for _ in 0..(i + 1) * 10 {
+                    let d = DataInput::U64(*k);
+                    regular.insert(&d);
+                    fast.insert(&d);
+                    truth.observe(*k as i64);
+                }
+            }
+            let label = concat!(
+                "Count<",
+                stringify!($storage),
+                "> collision-free exactness on both paths"
+            );
+            let ctx = context(label, regular.rows(), regular.cols());
+            let mut tally = Tally::default();
+            for (k, c) in truth.pairs() {
+                let r = regular.estimate(&DataInput::U64(k as u64));
+                let f = fast.estimate(&DataInput::U64(k as u64));
+                tally.record(r == c as f64 && f == c as f64, || {
+                    format!("key {k}: true {c}, regular {r}, fast {f}")
+                });
+            }
+            tally.assert_none(label, &ctx);
+        }};
+    }
+    exact!(Vector2D<i32>);
+    exact!(Vector2D<i64>);
+    exact!(Vector2D<i128>);
+    exact!(FixedMatrix);
+    exact!(DefaultMatrixI32);
+    exact!(QuickMatrixI64);
+    exact!(QuickMatrixI128);
+    exact!(DefaultMatrixI64);
+    exact!(DefaultMatrixI128);
+}
+
+// ------------------------------------------------------------ Heap variants
+
+/// `CMSHeap` is a Count-Min plus a top-k heap. The point estimate carries
+/// Count-Min's bound; the heap must stay consistent with it and must recover
+/// the keys the top-k contract actually guarantees.
+macro_rules! cmsheap_instance {
+    ($storage:ty, $path:ty, $stream:expr, $truth:expr) => {{
+        let mut single = CMSHeap::<$storage, $path>::default();
+        let mut left = CMSHeap::<$storage, $path>::default();
+        let mut right = CMSHeap::<$storage, $path>::default();
+        for (i, k) in $stream.iter().enumerate() {
+            let d = DataInput::U64(*k);
+            single.insert(&d);
+            if i % 2 == 0 {
+                left.insert(&d);
+            } else {
+                right.insert(&d);
+            }
+        }
+        left.merge(&right);
+
+        let (rows, cols) = (single.rows(), single.cols());
+        let label = concat!(
+            "CMSHeap<",
+            stringify!($storage),
+            ", ",
+            stringify!($path),
+            ">"
+        );
+        let ctx = context(label, rows, cols);
+        let spec = CountMinSpec::new(rows, cols);
+        spec.assert_contract(
+            label,
+            $truth,
+            |k| single.estimate(&DataInput::U64(k as u64)).as_f64(),
+            &ctx,
+        );
+        spec.assert_contract(
+            &format!("{label} shard merge"),
+            $truth,
+            |k| left.estimate(&DataInput::U64(k as u64)).as_f64(),
+            &ctx,
+        );
+        assert_heap_matches_sketch(label, &ctx, single.heap().heap(), $truth, |k| {
+            single.estimate(&DataInput::U64(k as u64)).as_f64()
+        });
+    }};
+}
+
+/// `CSHeap` is a Count Sketch plus the same heap, so the point estimate
+/// carries the L2 bound instead.
+macro_rules! csheap_instance {
+    ($storage:ty, $path:ty, $stream:expr, $truth:expr) => {{
+        let mut single = CSHeap::<$storage, $path>::default();
+        let mut left = CSHeap::<$storage, $path>::default();
+        let mut right = CSHeap::<$storage, $path>::default();
+        for (i, k) in $stream.iter().enumerate() {
+            let d = DataInput::U64(*k);
+            single.insert(&d);
+            if i % 2 == 0 {
+                left.insert(&d);
+            } else {
+                right.insert(&d);
+            }
+        }
+        left.merge(&right);
+
+        let (rows, cols) = (single.rows(), single.cols());
+        let label = concat!(
+            "CSHeap<",
+            stringify!($storage),
+            ", ",
+            stringify!($path),
+            ">"
+        );
+        let ctx = context(label, rows, cols);
+        let spec = CountSketchSpec::new(rows, cols);
+        spec.assert_contract(
+            label,
+            $truth,
+            |k| single.estimate(&DataInput::U64(k as u64)),
+            &ctx,
+        );
+        spec.assert_contract(
+            &format!("{label} shard merge"),
+            $truth,
+            |k| left.estimate(&DataInput::U64(k as u64)),
+            &ctx,
+        );
+        assert_heap_matches_sketch(label, &ctx, single.heap().heap(), $truth, |k| {
+            single.estimate(&DataInput::U64(k as u64))
+        });
+    }};
+}
+
+/// Shared heap checks: every entry agrees with the sketch's own estimate, and
+/// the heap holds keys the top-k contract guarantees.
+fn assert_heap_matches_sketch<F>(
+    label: &str,
+    ctx: &str,
+    items: &[asap_sketchlib::HHItem],
+    truth: &FreqTruth,
+    estimate: F,
+) where
+    F: Fn(i64) -> f64,
+{
+    let mut consistency = Tally::default();
+    let capacity = items.len().max(1);
+    let kth = truth.top_k(capacity)[capacity.min(truth.distinct()) - 1].1;
+    let mut recall = 0usize;
+    for it in items {
+        let key = match it.key {
+            HeapItem::U64(v) => v as i64,
+            ref other => panic!("{label}: unexpected heap key {other:?}"),
+        };
+        let est = estimate(key);
+        consistency.record(it.count as f64 == est, || {
+            format!(
+                "key {key}: heap holds {} but the sketch estimates {est}",
+                it.count
+            )
+        });
+        if truth.get(key) >= kth {
+            recall += 1;
+        }
+    }
+    consistency.assert_none(&format!("{label} heap/sketch consistency"), ctx);
+    assert!(
+        recall + 1 >= items.len(),
+        "{label}: only {recall} of {} heap entries are at or above the true k-th count \
+         ({kth}). {ctx}",
+        items.len()
+    );
+}
+
+macro_rules! heap_matrix_test {
+    ($name:ident, $mac:ident, $path:ty, $( $storage:ty ),+ $(,)?) => {
+        #[test]
+        fn $name() {
+            let (stream, truth) = stream_and_truth();
+            $( $mac!($storage, $path, stream, &truth); )+
+        }
+    };
+}
+
+// `CMSHeap`/`CSHeap` bound their insert paths on `S::Counter: Into<i64>` so
+// that a heap entry can hold the estimate. `i128` does not satisfy that, so
+// `CMSHeap<QuickMatrixI128>`, `CMSHeap<DefaultMatrixI128>` and their `CSHeap`
+// twins are *constructible but not insertable*: their `Default` impls exist
+// and compile, but calling `insert` on one does not. Those four instances per
+// family are therefore absent below by necessity rather than oversight; see
+// `docs/e2e_coverage_matrix.md`.
+heap_matrix_test!(
+    cmsheap_regular_path_instances_satisfy_the_count_min_bound,
+    cmsheap_instance,
+    RegularPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    DefaultMatrixI64,
+);
+
+heap_matrix_test!(
+    cmsheap_fast_path_instances_satisfy_the_count_min_bound,
+    cmsheap_instance,
+    FastPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    DefaultMatrixI64,
+);
+
+heap_matrix_test!(
+    csheap_regular_path_instances_satisfy_the_l2_bound,
+    csheap_instance,
+    RegularPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    DefaultMatrixI64,
+);
+
+heap_matrix_test!(
+    csheap_fast_path_instances_satisfy_the_l2_bound,
+    csheap_instance,
+    FastPath,
+    Vector2D<i32>,
+    Vector2D<i64>,
+    FixedMatrix,
+    DefaultMatrixI32,
+    QuickMatrixI64,
+    DefaultMatrixI64,
+);
+
+// ------------------------------------------------------- Counter-width edges
+
+/// The only thing the three counter widths actually promise differently is how
+/// much mass a single cell can hold. Each width must carry a count the next
+/// smaller one cannot, and the estimate must come back intact rather than
+/// wrapped.
+#[test]
+fn countmin_counter_widths_carry_the_mass_their_type_allows() {
+    let key = DataInput::U64(0xFEED_FACE);
+
+    // i32: just under the signed 32-bit ceiling.
+    let mut cm32 = CountMin::<Vector2D<i32>, RegularPath>::with_dimensions(3, 64);
+    let near_i32 = i32::MAX - 1;
+    cm32.insert_many(&key, near_i32);
+    assert_eq!(
+        cm32.estimate(&key),
+        near_i32,
+        "i32 counters must hold {near_i32} without wrapping"
+    );
+
+    // i64: a count an i32 cell could not represent at all.
+    let mut cm64 = CountMin::<Vector2D<i64>, RegularPath>::with_dimensions(3, 64);
+    let beyond_i32 = i32::MAX as i64 * 4;
+    cm64.insert_many(&key, beyond_i32);
+    assert_eq!(
+        cm64.estimate(&key),
+        beyond_i32,
+        "i64 counters must hold {beyond_i32}, which overflows i32"
+    );
+
+    // i128: a count an i64 cell could not represent.
+    let mut cm128 = CountMin::<Vector2D<i128>, RegularPath>::with_dimensions(3, 64);
+    let beyond_i64 = i64::MAX as i128 * 4;
+    cm128.insert_many(&key, beyond_i64);
+    assert_eq!(
+        cm128.estimate(&key),
+        beyond_i64,
+        "i128 counters must hold {beyond_i64}, which overflows i64"
+    );
+
+    // Merging two sketches each holding half the i64 range must not wrap the
+    // i128 target either.
+    let mut a = CountMin::<Vector2D<i128>, RegularPath>::with_dimensions(3, 64);
+    let mut b = CountMin::<Vector2D<i128>, RegularPath>::with_dimensions(3, 64);
+    a.insert_many(&key, i64::MAX as i128);
+    b.insert_many(&key, i64::MAX as i128);
+    a.merge(&b);
+    assert_eq!(
+        a.estimate(&key),
+        i64::MAX as i128 * 2,
+        "merging two i64::MAX counts into i128 storage must not wrap"
+    );
+}
+
+/// The signed families have a symmetric requirement: a decrement must reach
+/// the negative end of the counter's range without wrapping.
+#[test]
+fn countsketch_counter_widths_carry_signed_mass_in_both_directions() {
+    let key = DataInput::U64(0xDEAD_BEEF);
+
+    let mut cs32 = Count::<Vector2D<i32>, RegularPath>::with_dimensions(3, 64);
+    cs32.insert_many(&key, i32::MAX / 2);
+    cs32.insert_many(&key, -(i32::MAX / 2));
+    assert_eq!(
+        cs32.estimate(&key),
+        0.0,
+        "i32 Count Sketch must cancel a half-range increment exactly"
+    );
+
+    let mut cs64 = Count::<Vector2D<i64>, RegularPath>::with_dimensions(3, 64);
+    let big = i32::MAX as i64 * 4;
+    cs64.insert_many(&key, big);
+    assert_eq!(cs64.estimate(&key), big as f64);
+    cs64.insert_many(&key, -big * 2);
+    assert_eq!(
+        cs64.estimate(&key),
+        -(big as f64),
+        "i64 Count Sketch must reach the negative side of the i32 range"
+    );
+
+    let mut cs128 = Count::<Vector2D<i128>, RegularPath>::with_dimensions(3, 64);
+    let huge = i64::MAX as i128 * 4;
+    cs128.insert_many(&key, huge);
+    assert_eq!(cs128.estimate(&key), huge as f64);
+    cs128.insert_many(&key, -huge * 2);
+    assert_eq!(
+        cs128.estimate(&key),
+        -(huge as f64),
+        "i128 Count Sketch must reach the negative side of the i64 range"
+    );
+}

--- a/tests/e2e_numeric_types.rs
+++ b/tests/e2e_numeric_types.rs
@@ -1,0 +1,353 @@
+//! Every built-in `NumericalValue` type carried through the generic sketches:
+//! `KLL<T>`, `KLLDynamic<T>` and `DDSketch::add<T>`.
+//!
+//! The library implements `NumericalValue` for fourteen concrete types —
+//! `i8 i16 i32 i64 i128 isize`, `u8 u16 u32 u64 u128 usize`, `f32 f64` — and
+//! each is a public instance a caller can reach. A suite that only ever
+//! instantiates `f64` would not notice a type whose ordering or `to_f64`
+//! projection was wrong for its own domain: `u128` overflowing an intermediate,
+//! `i8` wrapping in a comparison, `f32` losing a tie.
+//!
+//! Both sketches keep their own error metric here — rank error for the KLL
+//! family, relative value error for DDSketch. The type is what varies, not the
+//! contract.
+//!
+//! ## The `to_f64` projection
+//!
+//! `NumericalValue::to_f64` is how a value reaches the sketch's arithmetic, and
+//! for `i128`/`u128` (and `i64`/`u64` past `2^53`) that projection is itself
+//! lossy — 64 and 128-bit integers have more distinct values than `f64` has
+//! mantissa bits. Ground truth here is therefore taken over the **projected**
+//! values, which is precisely what the sketch was handed. The precision limit
+//! that belongs to the caller's type choice is covered separately and
+//! explicitly by `the_f64_projection_is_exact_below_two_to_the_53`.
+
+mod common;
+
+use common::specs::{RankErrorSpec, RelativeQuantileSpec, Tally};
+use common::{NumericTruth, uniform_u64};
+
+use asap_sketchlib::{DDSketch, KLL, KLLDynamic, NumericalValue};
+
+/// KLL parameter used throughout; `eps(200) = 1.65%` at 99% confidence.
+const K: i32 = 200;
+/// Compaction-coin seeds. Fixed, and separate from the stream seed.
+const SKETCH_SEEDS: [u64; 3] = [0x4E17_0001, 0x4E17_0002, 0x4E17_0003];
+const STREAM_SEED: u64 = 0x57EA_0001;
+const N: usize = 20_000;
+const QS: [f64; 7] = [0.0, 0.01, 0.1, 0.5, 0.9, 0.99, 1.0];
+
+/// A positive-valued stream of `$ty`, drawn from one seeded `u64` source and
+/// folded into the type's own range so every type sees the same shape at its
+/// own scale. Values stay strictly positive because DDSketch only tracks
+/// positive reals, and the same stream feeds all three sketches.
+macro_rules! typed_stream {
+    ($ty:ty, $span:expr) => {{
+        let span: u64 = $span;
+        uniform_u64(N, span, STREAM_SEED)
+            .into_iter()
+            .map(|v| (v + 1) as $ty)
+            .collect::<Vec<$ty>>()
+    }};
+}
+
+/// Ground truth over the projected values — what the sketch actually saw.
+fn projected_truth<T: NumericalValue>(values: &[T]) -> NumericTruth {
+    NumericTruth::new(values.iter().map(|v| v.to_f64()).collect())
+}
+
+// --------------------------------------------------------------- KLL family
+
+/// One numeric type through both KLL implementations, single pass and after a
+/// shard merge, against the normalized-rank-error contract.
+macro_rules! kll_type_case {
+    ($tally:ident, $ty:ty, $span:expr) => {{
+        let values = typed_stream!($ty, $span);
+        let truth = projected_truth(&values);
+        let spec = RankErrorSpec::datasketches(K as usize);
+
+        for &seed in &SKETCH_SEEDS {
+            let mut fixed = KLL::<$ty>::init_kll_with_seed(K, seed);
+            let mut dynamic = KLLDynamic::<$ty>::init_kll_with_seed(K, seed);
+            for v in &values {
+                fixed.update(v);
+                dynamic.update(v);
+            }
+            spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| fixed.quantile(q));
+            spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| dynamic.quantile(q));
+
+            // Two shards merged must answer under the same contract.
+            let mut left = KLL::<$ty>::init_kll_with_seed(K, seed ^ 0xAAAA);
+            let mut right = KLL::<$ty>::init_kll_with_seed(K, seed ^ 0x5555);
+            let mut dleft = KLLDynamic::<$ty>::init_kll_with_seed(K, seed ^ 0xAAAA);
+            let mut dright = KLLDynamic::<$ty>::init_kll_with_seed(K, seed ^ 0x5555);
+            for (i, v) in values.iter().enumerate() {
+                if i % 2 == 0 {
+                    left.update(v);
+                    dleft.update(v);
+                } else {
+                    right.update(v);
+                    dright.update(v);
+                }
+            }
+            left.merge(&right);
+            dleft.merge(&dright);
+            spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| left.quantile(q));
+            spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| dleft.quantile(q));
+
+            // Bulk ingestion must be equivalent to the loop.
+            let mut bulk = KLL::<$ty>::init_kll_with_seed(K, seed);
+            bulk.bulk_update(&values);
+            spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| bulk.quantile(q));
+            let mut dbulk = KLLDynamic::<$ty>::init_kll_with_seed(K, seed);
+            dbulk.bulk_update(&values);
+            spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| dbulk.quantile(q));
+        }
+    }};
+}
+
+/// Every built-in `NumericalValue` type through `KLL<T>` and `KLLDynamic<T>`.
+///
+/// The spans are the type's own usable range, so the narrow types genuinely
+/// exercise the tie-dense case: an `i8` stream of 20,000 observations over 127
+/// distinct values gives every value a rank interval nearly 1% wide, which the
+/// rank-interval predicate handles and a value-error check could not.
+#[test]
+fn every_numeric_type_satisfies_the_kll_rank_error_contract() {
+    let mut tally = Tally::default();
+    kll_type_case!(tally, i8, 127);
+    kll_type_case!(tally, i16, 32_767);
+    kll_type_case!(tally, i32, 1_000_000_000);
+    kll_type_case!(tally, i64, 1_000_000_000_000_000);
+    kll_type_case!(tally, i128, 1_000_000_000_000_000);
+    kll_type_case!(tally, isize, 1_000_000_000_000_000);
+    kll_type_case!(tally, u8, 255);
+    kll_type_case!(tally, u16, 65_535);
+    kll_type_case!(tally, u32, 4_000_000_000);
+    kll_type_case!(tally, u64, 1_000_000_000_000_000);
+    kll_type_case!(tally, u128, 1_000_000_000_000_000);
+    kll_type_case!(tally, usize, 1_000_000_000_000_000);
+    kll_type_case!(tally, f32, 1_000_000);
+    kll_type_case!(tally, f64, 1_000_000_000_000_000);
+
+    tally.assert_within(
+        "KLL<T> / KLLDynamic<T> across every built-in NumericalValue type",
+        RankErrorSpec::datasketches(K as usize).failure_probability,
+        &format!(
+            "k={K} sketch seeds {SKETCH_SEEDS:02x?} stream_seed={STREAM_SEED:#x} n={N}, \
+             modes: single pass, bulk update, two-shard merge; q grid {QS:?}"
+        ),
+    );
+}
+
+/// The KLL family must also order negative and mixed-sign values correctly.
+/// The unsigned types cannot represent them, so this covers the signed and
+/// floating types only — and it is where a `total_cmp` that fell back to a
+/// bitwise comparison would show up.
+#[test]
+fn signed_numeric_types_order_negative_values_correctly_in_kll() {
+    macro_rules! signed_case {
+        ($tally:ident, $ty:ty, $span:expr) => {{
+            let span: i64 = $span;
+            let values: Vec<$ty> = uniform_u64(N, (span * 2) as u64, STREAM_SEED)
+                .into_iter()
+                .map(|v| (v as i64 - span) as $ty)
+                .collect();
+            let truth = projected_truth(&values);
+            let spec = RankErrorSpec::datasketches(K as usize);
+            for &seed in &SKETCH_SEEDS {
+                let mut fixed = KLL::<$ty>::init_kll_with_seed(K, seed);
+                let mut dynamic = KLLDynamic::<$ty>::init_kll_with_seed(K, seed);
+                for v in &values {
+                    fixed.update(v);
+                    dynamic.update(v);
+                }
+                spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| fixed.quantile(q));
+                spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| dynamic.quantile(q));
+            }
+            // KLL answers with *retained* items, and compaction may discard
+            // the actual extremes — so q=0 is not required to be the exact
+            // minimum (its rank-error obligation at q=0 is already tallied
+            // above). What is structural is that the sketch never invents a
+            // value: every answer must lie inside the observed range, on the
+            // correct side of zero. A `total_cmp` that ordered negatives by
+            // their bit pattern would break this immediately.
+            let mut probe = KLL::<$ty>::init_kll_with_seed(K, SKETCH_SEEDS[0]);
+            for v in &values {
+                probe.update(v);
+            }
+            for q in [0.0f64, 0.25, 0.5, 0.75, 1.0] {
+                let got = probe.quantile(q);
+                assert!(
+                    got >= truth.min() && got <= truth.max(),
+                    concat!(
+                        stringify!($ty),
+                        ": quantile({}) returned {}, outside the observed range [{}, {}]"
+                    ),
+                    q,
+                    got,
+                    truth.min(),
+                    truth.max()
+                );
+            }
+            // The median of a symmetric mixed-sign stream must land near zero,
+            // which a broken sign ordering could not produce.
+            let median = probe.quantile(0.5);
+            assert!(
+                median.abs() <= truth.max() * 0.10,
+                concat!(
+                    stringify!($ty),
+                    ": median {} is far from zero on a stream symmetric about it \
+                     (range [{}, {}]); check the type's ordering"
+                ),
+                median,
+                truth.min(),
+                truth.max()
+            );
+        }};
+    }
+
+    let mut tally = Tally::default();
+    signed_case!(tally, i8, 100);
+    signed_case!(tally, i16, 30_000);
+    signed_case!(tally, i32, 1_000_000_000);
+    signed_case!(tally, i64, 1_000_000_000_000_000);
+    signed_case!(tally, i128, 1_000_000_000_000_000);
+    signed_case!(tally, isize, 1_000_000_000_000_000);
+    signed_case!(tally, f32, 1_000_000);
+    signed_case!(tally, f64, 1_000_000_000_000_000);
+
+    tally.assert_within(
+        "KLL family over signed and mixed-sign values",
+        RankErrorSpec::datasketches(K as usize).failure_probability,
+        &format!("k={K} sketch seeds {SKETCH_SEEDS:02x?} stream_seed={STREAM_SEED:#x} n={N}"),
+    );
+}
+
+// ------------------------------------------------------------------ DDSketch
+
+/// `DDSketch::add<T>` accepts any `NumericalValue`. The relative-error
+/// guarantee is on the projected value, so converting through a wider integer
+/// type must not change it: the same numbers must come back within `alpha`
+/// whether they arrived as `u8` or `u128`.
+macro_rules! dds_type_case {
+    ($alpha:expr, $tally:ident, $ty:ty, $span:expr) => {{
+        let values = typed_stream!($ty, $span);
+        let truth = projected_truth(&values);
+        let spec = RelativeQuantileSpec::new($alpha);
+        let mut sketch = DDSketch::new($alpha);
+        for v in &values {
+            sketch.add(v);
+        }
+        assert_eq!(
+            sketch.get_count() as usize,
+            values.len(),
+            concat!(
+                stringify!($ty),
+                ": every positive value must be trackable at this alpha"
+            )
+        );
+        spec.tally_into(&mut $tally, truth.sorted(), &QS, |q| {
+            sketch.get_value_at_quantile(q)
+        });
+    }};
+}
+
+#[test]
+fn every_numeric_type_satisfies_the_ddsketch_relative_value_error_contract() {
+    for alpha in [0.001f64, 0.01, 0.05] {
+        let mut tally = Tally::default();
+        dds_type_case!(alpha, tally, i8, 127);
+        dds_type_case!(alpha, tally, i16, 32_767);
+        dds_type_case!(alpha, tally, i32, 1_000_000_000);
+        dds_type_case!(alpha, tally, i64, 1_000_000_000_000_000);
+        dds_type_case!(alpha, tally, i128, 1_000_000_000_000_000);
+        dds_type_case!(alpha, tally, isize, 1_000_000_000_000_000);
+        dds_type_case!(alpha, tally, u8, 255);
+        dds_type_case!(alpha, tally, u16, 65_535);
+        dds_type_case!(alpha, tally, u32, 4_000_000_000);
+        dds_type_case!(alpha, tally, u64, 1_000_000_000_000_000);
+        dds_type_case!(alpha, tally, u128, 1_000_000_000_000_000);
+        dds_type_case!(alpha, tally, usize, 1_000_000_000_000_000);
+        dds_type_case!(alpha, tally, f32, 1_000_000);
+        dds_type_case!(alpha, tally, f64, 1_000_000_000_000_000);
+
+        // Deterministic guarantee: no hashing, no sampling, so no violations
+        // are tolerated at any alpha.
+        tally.assert_none(
+            "DDSketch::add<T> across every built-in NumericalValue type",
+            &format!("alpha={alpha} stream_seed={STREAM_SEED:#x} n={N} q grid {QS:?}"),
+        );
+    }
+}
+
+/// The 128-bit types past `f64`'s exact-integer range.
+///
+/// `2^53` is where `f64` stops representing consecutive integers, and
+/// `NumericalValue::to_f64` is a plain `as` cast, so an `i128`/`u128` above it
+/// reaches the sketch already rounded. The relative-error contract still holds
+/// on the projected value — the rounding is at most one part in `2^53`, twelve
+/// orders of magnitude below the smallest alpha the library supports — but the
+/// *identity* of the value is not preserved, and that is a documented limit of
+/// the caller's type choice rather than a sketch defect.
+#[test]
+fn the_f64_projection_is_exact_below_two_to_the_53() {
+    const TWO_53: u128 = 1u128 << 53;
+
+    // Exact below the boundary, in both 128-bit types.
+    for v in [1u128, 1_000, TWO_53 - 1, TWO_53] {
+        assert_eq!(
+            (v as f64) as u128,
+            v,
+            "u128 {v} must project into f64 exactly (at or below 2^53)"
+        );
+        assert_eq!(
+            ((v as i128).to_f64()) as i128,
+            v as i128,
+            "i128 {v} must project into f64 exactly (at or below 2^53)"
+        );
+    }
+    // Just past it, consecutive integers collapse — this is the documented
+    // limit, asserted so the boundary cannot move unnoticed.
+    assert_eq!(
+        (TWO_53 + 1) as f64,
+        TWO_53 as f64,
+        "2^53 + 1 is expected to collapse onto 2^53 in f64"
+    );
+
+    // The relative-error contract survives regardless: a stream of very large
+    // 128-bit values still answers within alpha of the projected truth.
+    const ALPHA: f64 = 0.01;
+    let values: Vec<u128> = uniform_u64(5_000, 1_000_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| (v as u128 + 1) * (1u128 << 70))
+        .collect();
+    let truth = projected_truth(&values);
+    let mut sketch = DDSketch::new(ALPHA);
+    for v in &values {
+        sketch.add(v);
+    }
+    assert_eq!(sketch.get_count() as usize, values.len());
+    let mut tally = Tally::default();
+    RelativeQuantileSpec::new(ALPHA).tally_into(&mut tally, truth.sorted(), &QS, |q| {
+        sketch.get_value_at_quantile(q)
+    });
+    tally.assert_none(
+        "DDSketch over u128 values above 2^70",
+        &format!("alpha={ALPHA} values in [2^70, 10^6 * 2^70], stream_seed={STREAM_SEED:#x}"),
+    );
+
+    // And the KLL family orders them correctly at that magnitude.
+    let mut kll = KLL::<u128>::init_kll_with_seed(K, SKETCH_SEEDS[0]);
+    for v in &values {
+        kll.update(v);
+    }
+    let mut rank_tally = Tally::default();
+    RankErrorSpec::datasketches(K as usize)
+        .tally_into(&mut rank_tally, truth.sorted(), &QS, |q| kll.quantile(q));
+    rank_tally.assert_within(
+        "KLL<u128> over values above 2^70",
+        RankErrorSpec::datasketches(K as usize).failure_probability,
+        &format!("k={K} sketch_seed={:#x}", SKETCH_SEEDS[0]),
+    );
+}

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -4246,3 +4246,429 @@ mod heavy_hitters {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// The top-k plans: CmTopKOctoPlan and CountTopKOctoPlan
+// ---------------------------------------------------------------------------
+
+/// `CmTopKOctoPlan` / `CountTopKOctoPlan` are the plans in which the *aggregator*
+/// owns the pipeline's only heavy-hitter heap: workers keep no flow keys, and
+/// instead ship the key alongside every promoted counter (§3.2, Idea 3).
+///
+/// That design choice is what these tests are about. Because workers hold no
+/// key storage, they also have **no flush**: a residual counter cannot be
+/// attributed back to a key, so a flow that never crossed τ on any worker is
+/// absent from the aggregator's heap entirely and estimates zero — not merely
+/// undercounted. Every bound below is stated with that in mind.
+mod top_k_plans {
+    use super::*;
+    use asap_sketchlib::{
+        CMSHeap, CSHeap, CmTopKOctoAggregator, CmTopKOctoPlan, CountTopKOctoAggregator,
+        CountTopKOctoPlan, HeapItem, KeyedHashes,
+    };
+    use common::specs::{CountMinSpec, CountSketchSpec, Tally};
+
+    const WORKERS: usize = 4;
+    const TOP_K: usize = 32;
+    const N: usize = 200_000;
+    const DOMAIN: usize = 8_192;
+    const STREAM_SEED: u64 = 0x0C70_1101;
+
+    /// The per-counter gap the paper's deterministic half allows between the
+    /// aggregator and a single-threaded sketch: every one of the `k` workers
+    /// may hold back up to `τ` of its own share of a shared counter.
+    fn counter_ceiling() -> f64 {
+        (WORKERS as i32 * TAU) as f64
+    }
+
+    fn stream() -> Vec<u64> {
+        zipf_u64(N, DOMAIN, 1.1, STREAM_SEED)
+    }
+
+    fn truth_of(stream: &[u64]) -> FreqTruth {
+        let mut t = FreqTruth::default();
+        for k in stream {
+            t.observe(*k as i64);
+        }
+        t
+    }
+
+    /// Drives a top-k plan across `WORKERS` workers under one partition rule
+    /// and returns the aggregator.
+    fn drive_cm(route: Route, stream: &[u64]) -> CmTopKOctoAggregator {
+        let plan = CmTopKOctoPlan::new(ROWS, COLS);
+        let mut workers: Vec<_> = (0..WORKERS).map(|i| plan.worker(i)).collect();
+        let mut parent = plan.aggregator(TOP_K);
+        for (i, k) in stream.iter().enumerate() {
+            let input = DataInput::U64(*k);
+            let w = route.worker(i, &input, WORKERS);
+            let payload: KeyedHashes = plan.prepare(&input);
+            let mut shipped = Vec::new();
+            workers[w].process(&payload, &mut |d| shipped.push(d));
+            for d in shipped {
+                parent.apply(d);
+            }
+        }
+        parent
+    }
+
+    fn drive_count(route: Route, stream: &[u64]) -> CountTopKOctoAggregator {
+        let plan = CountTopKOctoPlan::new(ROWS, COLS);
+        let mut workers: Vec<_> = (0..WORKERS).map(|i| plan.worker(i)).collect();
+        let mut parent = plan.aggregator(TOP_K);
+        for (i, k) in stream.iter().enumerate() {
+            let input = DataInput::U64(*k);
+            let w = route.worker(i, &input, WORKERS);
+            let payload: KeyedHashes = plan.prepare(&input);
+            let mut shipped = Vec::new();
+            workers[w].process(&payload, &mut |d| shipped.push(d));
+            for d in shipped {
+                parent.apply(d);
+            }
+        }
+        parent
+    }
+
+    /// Single-threaded reference: the same sketch fed the same stream with no
+    /// promotion protocol in between.
+    fn reference_cm(stream: &[u64]) -> CMSHeap<Vector2D<i32>, RegularPath> {
+        let mut sk: CMSHeap<Vector2D<i32>, RegularPath> = CMSHeap::new(ROWS, COLS, TOP_K);
+        for k in stream {
+            sk.insert(&DataInput::U64(*k));
+        }
+        sk
+    }
+
+    fn reference_cs(stream: &[u64]) -> CSHeap<Vector2D<i32>, RegularPath> {
+        let mut sk: CSHeap<Vector2D<i32>, RegularPath> = CSHeap::new(ROWS, COLS, TOP_K);
+        for k in stream {
+            sk.insert(&DataInput::U64(*k));
+        }
+        sk
+    }
+
+    /// `(key, count)` pairs out of an aggregator's heap.
+    fn heap_entries(items: &[asap_sketchlib::HHItem]) -> Vec<(i64, i64)> {
+        items
+            .iter()
+            .map(|it| match it.key {
+                HeapItem::U64(v) => (v as i64, it.count),
+                ref other => panic!("unexpected heap key {other:?}"),
+            })
+            .collect()
+    }
+
+    /// Point estimates from the Count-Min top-k aggregator, against the
+    /// single-threaded reference and against exact truth.
+    ///
+    /// Two bounds apply and both are asserted:
+    ///
+    /// - **against the reference**, deterministically: Count-Min never
+    ///   underestimates and each of the `k` workers withholds at most `τ` per
+    ///   counter, so `ref - k*τ <= octo <= ref` for every key, under either
+    ///   partition;
+    /// - **against exact truth**, probabilistically: Count-Min's own additive
+    ///   bound, widened by exactly that same `k*τ` promotion residual and by
+    ///   nothing else.
+    #[test]
+    fn cm_top_k_point_estimates_trail_the_single_thread_reference_by_at_most_k_tau() {
+        let stream = stream();
+        let truth = truth_of(&stream);
+        let reference = reference_cm(&stream);
+        let ceiling = counter_ceiling();
+
+        for route in [Route::HashByKey, Route::RoundRobin] {
+            let parent = drive_cm(route, &stream);
+            let context = format!(
+                "{route:?} workers={WORKERS} rows={ROWS} cols={COLS} tau={TAU} top_k={TOP_K} \
+                 zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}"
+            );
+
+            let mut gap = Tally::default();
+            for (k, _) in truth.pairs() {
+                let d = DataInput::U64(k as u64);
+                let octo = parent.sketch.estimate(&d) as f64;
+                let single = reference.estimate(&d) as f64;
+                gap.record(octo <= single && single - octo <= ceiling, || {
+                    format!(
+                        "key {k}: octo {octo}, single-thread {single}, gap {} outside \
+                         [0, k*tau = {ceiling}]",
+                        single - octo
+                    )
+                });
+            }
+            gap.assert_none(
+                &format!("CmTopK octo vs single-thread ({route:?})"),
+                &context,
+            );
+
+            // Count-Min's own bound, widened only by the promotion residual.
+            let spec = CountMinSpec::new(ROWS, COLS);
+            let total = truth.total() as f64;
+            let mut bound = Tally::default();
+            let mut one_sided = Tally::default();
+            for (k, c) in truth.pairs() {
+                let est = parent.sketch.estimate(&DataInput::U64(k as u64)) as f64;
+                let f = c as f64;
+                // One-sided modulo the residual: the parent can only read low
+                // by what the workers are still holding.
+                one_sided.record(est >= f - ceiling, || {
+                    format!("key {k}: true {f}, octo {est}, deficit beyond k*tau = {ceiling}")
+                });
+                let hi = f + spec.excess_bound(total, f);
+                bound.record(est <= hi, || {
+                    format!("key {k}: true {f}, octo {est} above e*(N-f)/w ceiling {hi:.1}")
+                });
+            }
+            one_sided.assert_none(
+                &format!("CmTopK one-sided modulo k*tau ({route:?})"),
+                &context,
+            );
+            bound.assert_within(
+                &format!("CmTopK additive bound ({route:?})"),
+                spec.per_key_failure(),
+                &context,
+            );
+        }
+    }
+
+    /// The same two bounds for the signed plan: Count Sketch's L2 bound, and a
+    /// two-sided `k*τ` gap against the single-threaded reference (signed
+    /// counters can be withheld in either direction).
+    #[test]
+    fn count_top_k_point_estimates_satisfy_the_l2_bound_within_the_promotion_residual() {
+        let stream = stream();
+        let truth = truth_of(&stream);
+        let reference = reference_cs(&stream);
+        let ceiling = counter_ceiling();
+        let spec = CountSketchSpec::new(ROWS, COLS);
+
+        for route in [Route::HashByKey, Route::RoundRobin] {
+            let parent = drive_count(route, &stream);
+            let context = format!(
+                "{route:?} workers={WORKERS} rows={ROWS} cols={COLS} tau={TAU} top_k={TOP_K} \
+                 zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}"
+            );
+
+            let mut gap = Tally::default();
+            for (k, _) in truth.pairs() {
+                let d = DataInput::U64(k as u64);
+                let octo = parent.sketch.estimate(&d);
+                let single = reference.estimate(&d);
+                gap.record((octo - single).abs() <= ceiling, || {
+                    format!(
+                        "key {k}: octo {octo}, single-thread {single}, |gap| {} above \
+                         k*tau = {ceiling}",
+                        (octo - single).abs()
+                    )
+                });
+            }
+            gap.assert_none(
+                &format!("CountTopK octo vs single-thread ({route:?})"),
+                &context,
+            );
+
+            // The L2 bound with the promotion residual added; nothing else.
+            let f2 = truth.f2();
+            let mut bound = Tally::default();
+            for (k, c) in truth.pairs() {
+                let f = c as f64;
+                let est = parent.sketch.estimate(&DataInput::U64(k as u64));
+                let residual_l2 = (f2 - f * f).max(0.0).sqrt();
+                let allowed = spec.error_scale(residual_l2) + ceiling;
+                bound.record((est - f).abs() <= allowed, || {
+                    format!(
+                        "key {k}: true {f}, octo {est}, |error| {:.1} above \
+                         sqrt(kappa/w)*||f_-i||_2 + k*tau = {allowed:.1}",
+                        (est - f).abs()
+                    )
+                });
+            }
+            bound.assert_within(
+                &format!("CountTopK L2 bound + promotion residual ({route:?})"),
+                spec.per_key_failure(),
+                &context,
+            );
+        }
+    }
+
+    /// Heavy-hitter recall and precision for both top-k plans.
+    ///
+    /// Recall is stated over the keys the protocol can actually deliver: a
+    /// flow must cross τ on some worker before its key ever reaches the
+    /// aggregator, so the guaranteed set is the flows whose count clears the
+    /// worst-case promotion floor, `k*τ`. Precision is stated over the reported
+    /// set: every key the heap holds must genuinely be heavy, which for
+    /// Count-Min means at or above the true k-th count minus the residual.
+    ///
+    /// The `HashByKey` premise matters and is named in the assertion: under it
+    /// a flow's whole count lands on one worker, so a flow of count `f`
+    /// promotes `floor(f/τ)` times. Under `RoundRobin` the same flow is split
+    /// `k` ways and may promote less, which is why recall is measured
+    /// separately per partition instead of averaged.
+    #[test]
+    fn top_k_plans_recover_the_heavy_hitters_their_promotion_floor_guarantees() {
+        let stream = stream();
+        let truth = truth_of(&stream);
+        let floor = counter_ceiling();
+        let true_top: Vec<(i64, i64)> = truth.top_k(TOP_K);
+        let kth = true_top[TOP_K - 1].1 as f64;
+
+        for route in [Route::HashByKey, Route::RoundRobin] {
+            let context = format!(
+                "{route:?} workers={WORKERS} tau={TAU} top_k={TOP_K} promotion floor k*tau={floor} \
+                 zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}, true k-th count {kth}"
+            );
+
+            // Each entry is (key, count held in the heap, estimate the
+            // aggregator's own sketch returns for that key).
+            for (label, entries) in [
+                {
+                    let parent = drive_cm(route, &stream);
+                    let e: Vec<(i64, i64, f64)> = heap_entries(parent.sketch.heap().heap())
+                        .into_iter()
+                        .map(|(k, held)| {
+                            (
+                                k,
+                                held,
+                                parent.sketch.estimate(&DataInput::U64(k as u64)) as f64,
+                            )
+                        })
+                        .collect();
+                    ("CmTopK", e)
+                },
+                {
+                    let parent = drive_count(route, &stream);
+                    let e: Vec<(i64, i64, f64)> = heap_entries(parent.sketch.heap().heap())
+                        .into_iter()
+                        .map(|(k, held)| {
+                            (k, held, parent.sketch.estimate(&DataInput::U64(k as u64)))
+                        })
+                        .collect();
+                    ("CountTopK", e)
+                },
+            ] {
+                let keys: Vec<i64> = entries.iter().map(|(k, _, _)| *k).collect();
+                assert!(
+                    keys.len() <= TOP_K,
+                    "{label} {route:?}: heap holds {} entries, capacity {TOP_K}",
+                    keys.len()
+                );
+                let unique: std::collections::HashSet<i64> = keys.iter().copied().collect();
+                assert_eq!(
+                    unique.len(),
+                    keys.len(),
+                    "{label} {route:?}: the heap holds a duplicate key"
+                );
+
+                // Recall over the guaranteed set: every true top-k key whose
+                // count clears the promotion floor must be present.
+                let guaranteed: Vec<i64> = true_top
+                    .iter()
+                    .filter(|(_, c)| *c as f64 > floor)
+                    .map(|(k, _)| *k)
+                    .collect();
+                assert!(
+                    guaranteed.len() >= TOP_K / 2,
+                    "test premise: only {} of the true top {TOP_K} clear the promotion floor \
+                     {floor}; pick a heavier stream. {context}",
+                    guaranteed.len()
+                );
+                let found = guaranteed.iter().filter(|k| keys.contains(k)).count();
+                assert_eq!(
+                    found,
+                    guaranteed.len(),
+                    "{label} {route:?}: recovered {found} of {} keys above the promotion \
+                     floor. {context}",
+                    guaranteed.len()
+                );
+
+                // Precision over the reported set: nothing in the heap may be
+                // lighter than the true k-th count, allowing for the residual.
+                let mut precision = Tally::default();
+                for (k, _, _) in &entries {
+                    let exact = truth.get(*k) as f64;
+                    precision.record(exact >= kth - floor, || {
+                        format!(
+                            "key {k} is in the top-{TOP_K} heap with a true count of {exact}, \
+                             below the true k-th count {kth} minus the residual {floor}"
+                        )
+                    });
+                }
+                precision.assert_none(&format!("{label} {route:?} precision"), &context);
+
+                // Heap/sketch consistency is structural: the aggregator writes
+                // the estimate into the heap as it applies each delta, so an
+                // entry that disagrees with the sketch means one of the two
+                // was updated and the other was not.
+                let mut consistency = Tally::default();
+                for (k, held, est) in &entries {
+                    consistency.record(*held == *est as i64, || {
+                        format!("key {k}: heap holds {held} but the sketch estimates {est}")
+                    });
+                }
+                consistency.assert_none(&format!("{label} {route:?} heap consistency"), &context);
+            }
+        }
+    }
+
+    /// The top-k workers have no `flush`, and that is a contract, not an
+    /// omission: with no key storage a residual counter cannot be attributed
+    /// back to a flow. A key that never crosses τ therefore never reaches the
+    /// aggregator at all and estimates zero — which is what makes the `k*τ`
+    /// deficit above a *deficit* rather than an unbounded miss.
+    #[test]
+    fn a_key_below_the_promotion_threshold_never_reaches_the_top_k_aggregator() {
+        let plan = CmTopKOctoPlan::new(ROWS, COLS);
+        let mut worker = plan.worker(0);
+        let mut parent = plan.aggregator(TOP_K);
+
+        // One key, fewer arrivals than τ: nothing may be shipped.
+        let cold = DataInput::U64(0xC01D);
+        let payload = plan.prepare(&cold);
+        let mut shipped = 0usize;
+        for _ in 0..(TAU - 1) {
+            worker.process(&payload, &mut |_| shipped += 1);
+        }
+        assert_eq!(
+            shipped, 0,
+            "a flow below tau={TAU} must not promote a single counter"
+        );
+        assert_eq!(
+            parent.sketch.estimate(&cold),
+            0,
+            "an unpromoted flow must estimate zero at the aggregator, not a partial count"
+        );
+        assert!(
+            parent.sketch.heap().heap().is_empty(),
+            "an unpromoted flow must be absent from the heap entirely"
+        );
+
+        // One more arrival crosses tau and the key appears, carrying exactly
+        // the promoted window.
+        let mut promoted = Vec::new();
+        worker.process(&payload, &mut |d| promoted.push(d));
+        assert!(
+            !promoted.is_empty(),
+            "crossing tau={TAU} must promote at least one counter"
+        );
+        for d in promoted {
+            assert_eq!(
+                d.key,
+                asap_sketchlib::input_to_owned(&cold),
+                "every top-k delta must carry the flow key that produced it"
+            );
+            parent.apply(d);
+        }
+        assert_eq!(
+            parent.sketch.estimate(&cold),
+            TAU,
+            "the first promotion must hand over exactly the tau-sized window"
+        );
+        assert_eq!(
+            parent.sketch.heap().heap().len(),
+            1,
+            "the promoted key must now hold a heap slot"
+        );
+    }
+}

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -1,411 +1,1017 @@
-//! E2E quantile pipelines on synthetic numeric streams: KLL / KLLDynamic
-//! (typed + shard merge), DDSketch core & portable across distributions,
-//! UnivMon-Q's full metric surface, TumblingWindow<KLL> window queries, and
-//! the portable HydraKll per-key medians.
+//! E2E quantile pipelines on synthetic numeric streams.
+//!
+//! The two quantile families here answer *different questions* and are held to
+//! *different* error metrics:
+//!
+//! - **KLL** promises **rank** error: the returned value's rank must be within
+//!   `eps(k)` of the requested `q`. Its value error is unbounded — on a
+//!   heavy-tailed stream a correct KLL can return a value 100x off and still
+//!   be within its guarantee — so checking `|est - true| / true` against a
+//!   percentage tests nothing KLL claims.
+//! - **DDSketch** promises **relative value** error: the returned value must
+//!   be within `alpha` of the exact order statistic. Its rank error is
+//!   unbounded, so a rank band tests nothing DDSketch claims.
+//!
+//! Neither may be run through the other's battery. `RankErrorSpec` and
+//! `RelativeQuantileSpec` in `common::specs` keep them apart.
+//!
+//! Every sketch here is built with an explicit compaction seed. KLL's coin is
+//! the sketch's own randomness and is entirely separate from the stream seed;
+//! the wall-clock-seeded `KLL::init_kll` / `KLLDynamic::init_kll` constructors
+//! cannot be used in an accuracy test because a failure would not reproduce.
 
 mod common;
 
+use common::specs::{RankErrorSpec, RelativeQuantileSpec, Tally};
 use common::{
-    NumericTruth, assert_between, assert_in_rank_band, exponential_f64, log_uniform_f64,
-    normal_f64, uniform_u64, zipf_u64,
+    NumericTruth, assert_between, duplicate_heavy_f64, exponential_f64, log_uniform_f64,
+    monotonic_f64, normal_f64, outside_in_ordering, uniform_u64, zipf_f64,
 };
 
 use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketch as PortableDds;
 use asap_sketchlib::message_pack_format::portable::hydra_kll::HydraKllSketch;
 use asap_sketchlib::{
-    DDSketch, DataInput, KLL, KLLConfig, TumblingWindow, UnivMonQ, UnivMonQPoint,
+    DDSketch, DataInput, KLL, KLLConfig, KLLDynamic, TumblingWindow, UnivMonQ, UnivMonQConfig,
 };
 use std::collections::HashMap;
 
-const QS: [f64; 5] = [0.1, 0.25, 0.5, 0.75, 0.9];
-
 // --------------------------------------------------------------------- KLL
 
-#[test]
-fn kll_quantile_rank_bands_and_shard_merge() {
-    let values: Vec<f64> = uniform_u64(80_000, 1_000_000, 3001)
-        .into_iter()
-        .map(|v| v as f64)
-        .chain(normal_f64(20_000, 500_000.0, 120_000.0, 3002))
-        .collect();
-    let truth = NumericTruth::new(values.clone());
+/// The quantile grid every rank-error battery runs, including both endpoints
+/// and the far tails the interior grid would otherwise never reach.
+const RANK_QS: [f64; 7] = [0.0, 0.01, 0.1, 0.5, 0.9, 0.99, 1.0];
 
-    let mut kll = KLL::init_kll(200);
-    let mut left = KLL::init_kll_with_seed(200, 77);
-    let mut right = KLL::init_kll_with_seed(200, 99);
-    for (i, v) in values.iter().enumerate() {
-        kll.update(v);
-        if i % 2 == 0 {
-            left.update(v);
-        } else {
-            right.update(v);
+/// Fixed sketch (compaction-coin) seeds. Independent of the stream seeds
+/// below: one controls which values arrive, the other controls which of them
+/// survive compaction, and conflating the two makes a failure impossible to
+/// localise.
+const KLL_SKETCH_SEEDS: [u64; 4] = [0x5EED_0001, 0x5EED_0002, 0x5EED_0003, 0x5EED_0004];
+
+/// Named stream shapes with a fixed seed each. Covers the light-tailed,
+/// heavy-tailed, tie-dense, sorted and adversarially-ordered cases a
+/// compaction scheme can behave differently on.
+fn rank_streams(trial: usize, n: usize) -> Vec<(&'static str, Vec<f64>)> {
+    let s = 0xA5A5_0000u64 + trial as u64 * 7919;
+    vec![
+        (
+            "uniform",
+            uniform_u64(n, 100_000_000, s)
+                .into_iter()
+                .map(|v| v as f64)
+                .collect(),
+        ),
+        ("normal", normal_f64(n, 1_000.0, 250.0, s + 1)),
+        ("zipf", zipf_f64(n, 8_192, 1.1, 1e6, 1e7, s + 2)),
+        // Fifty distinct values over tens of thousands of observations: a
+        // single value legitimately spans several percent of the rank space,
+        // which is exactly where a value-error check would misfire and a
+        // rank-interval check must not.
+        ("duplicate-heavy", duplicate_heavy_f64(n, 50, s + 3)),
+        // Sorted input: every compaction sees a run that is already in global
+        // order.
+        ("monotonic", monotonic_f64(n, 0.0, 1.0)),
+        // Adversarial ordering: the same multiset emitted from both ends
+        // inward, so no prefix resembles the whole.
+        (
+            "outside-in",
+            outside_in_ordering(normal_f64(n, 5_000.0, 900.0, s + 4)),
+        ),
+    ]
+}
+
+/// How a sketch was fed. Every mode must satisfy the same rank contract —
+/// bulk ingestion and merging are supposed to be equivalent to the loop, and
+/// a mode that quietly loses weight shows up here as a rank-error failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Feed {
+    SinglePass,
+    BulkUpdate,
+    ShardMerge,
+    TumblingMerge,
+}
+
+const FEEDS: [Feed; 4] = [
+    Feed::SinglePass,
+    Feed::BulkUpdate,
+    Feed::ShardMerge,
+    Feed::TumblingMerge,
+];
+
+fn feed_kll(feed: Feed, k: i32, seed: u64, values: &[f64]) -> KLL<f64> {
+    match feed {
+        Feed::SinglePass => {
+            let mut s = KLL::init_kll_with_seed(k, seed);
+            for v in values {
+                s.update(v);
+            }
+            s
         }
-    }
-    for &q in &QS {
-        assert_in_rank_band(kll.quantile(q), &truth, q, 0.03, "KLL");
-    }
-
-    // Merging shards must preserve the merged distribution.
-    let sum_pre_merge = left.count() + right.count();
-    assert!(
-        (sum_pre_merge as f64 - values.len() as f64).abs() / values.len() as f64 <= 0.005,
-        "shard counts {sum_pre_merge} must approximate stream length {}",
-        values.len()
-    );
-    left.merge(&right);
-    assert!(
-        (left.count() as f64 - values.len() as f64).abs() / values.len() as f64 <= 0.005,
-        "merged count {} must approximate stream length {}",
-        left.count(),
-        values.len()
-    );
-    for &q in &QS {
-        assert_in_rank_band(left.quantile(q), &truth, q, 0.03, "KLL after shard merge");
+        Feed::BulkUpdate => {
+            let mut s = KLL::init_kll_with_seed(k, seed);
+            s.bulk_update(values);
+            s
+        }
+        Feed::ShardMerge => {
+            // Four shards, each with its own coin seed, merged pairwise into a
+            // tree rather than a chain so merge order is exercised too.
+            let mut shards: Vec<KLL<f64>> = (0..4)
+                .map(|i| KLL::init_kll_with_seed(k, seed.wrapping_add(0x1000 * (i + 1))))
+                .collect();
+            for (i, v) in values.iter().enumerate() {
+                shards[i % 4].update(v);
+            }
+            let (mut a, b) = (shards.remove(0), shards.remove(0));
+            let (mut c, d) = (shards.remove(0), shards.remove(0));
+            a.merge(&b);
+            c.merge(&d);
+            a.merge(&c);
+            a
+        }
+        Feed::TumblingMerge => {
+            // Windows are closed and recycled through the pool; `query_all`
+            // merges every retained window plus the active one. Pool reuse
+            // runs `clear()`, which re-seeds from the stored seed, so the
+            // result is reproducible across rotations.
+            let cfg = KLLConfig {
+                k: k as usize,
+                m: 8,
+                seed: Some(seed),
+            };
+            let window = (values.len() / 8).max(1) as u64;
+            let mut tw: TumblingWindow<KLL> = TumblingWindow::new(window, 32, cfg, 4);
+            for (t, v) in values.iter().enumerate() {
+                tw.insert(t as u64, &DataInput::F64(*v), 0);
+            }
+            tw.query_all()
+        }
     }
 }
 
-#[test]
-fn kll_i64_generic_typed_path() {
-    let mut kll: KLL<i64> = KLL::init_kll(200);
-    let mut truth: Vec<i64> = Vec::new();
-    for v in common::uniform_u64(50_000, 10_000_000, 3003) {
-        let x = v as i64;
-        kll.update(&x);
-        truth.push(x);
+fn feed_kll_dynamic(feed: Feed, k: i32, seed: u64, values: &[f64]) -> Option<KLLDynamic<f64>> {
+    match feed {
+        Feed::SinglePass => {
+            let mut s = KLLDynamic::init_kll_with_seed(k, seed);
+            for v in values {
+                s.update(v);
+            }
+            Some(s)
+        }
+        Feed::BulkUpdate => {
+            let mut s = KLLDynamic::init_kll_with_seed(k, seed);
+            s.bulk_update(values);
+            Some(s)
+        }
+        Feed::ShardMerge => {
+            let mut shards: Vec<KLLDynamic<f64>> = (0..4)
+                .map(|i| KLLDynamic::init_kll_with_seed(k, seed.wrapping_add(0x1000 * (i + 1))))
+                .collect();
+            for (i, v) in values.iter().enumerate() {
+                shards[i % 4].update(v);
+            }
+            let (mut a, b) = (shards.remove(0), shards.remove(0));
+            let (mut c, d) = (shards.remove(0), shards.remove(0));
+            a.merge(&b);
+            c.merge(&d);
+            a.merge(&c);
+            Some(a)
+        }
+        // KLLDynamic is not a `TumblingWindowSketch`; the framework hosts the
+        // fixed-layout `KLL` only. Nothing to cover.
+        Feed::TumblingMerge => None,
     }
-    truth.sort();
-    for q in [0.25f64, 0.5, 0.9] {
-        let lo = truth[((q - 0.02) * truth.len() as f64) as usize];
-        let hi = truth[(((q + 0.02) * truth.len() as f64) as usize).min(truth.len() - 1)];
-        let est = kll.quantile(q);
-        assert!(
-            est >= lo as f64 && est <= hi as f64,
-            "KLL<i64> q={q}: {est} outside [{lo}, {hi}]"
+}
+
+/// Both KLL implementations against the published normalized-rank-error
+/// contract `eps(k) = 2.446 / k^0.9433` at 99% confidence, over a fixed grid
+/// of `(k, sketch seed, distribution, feed mode, q)`.
+///
+/// Failures are pooled per feed mode and judged by the binomial acceptance
+/// rule at the contract's own per-query failure probability of 0.01. Widening
+/// `eps` to make a failure disappear would break the tie to `k` and is exactly
+/// what this spec exists to prevent.
+#[test]
+fn kll_family_satisfies_the_datasketches_normalized_rank_error_contract() {
+    // 4 seeds x 6 shapes x 3 values of k x 4 feed modes x 7 quantiles is ~500
+    // checks per feed mode, which the binomial acceptance rule at p = 0.01
+    // makes a tight test; a longer stream would not make it tighter.
+    const N: usize = 30_000;
+    const KS: [i32; 3] = [64, 200, 800];
+
+    let mut tallies: HashMap<String, Tally> = HashMap::new();
+    for (trial, &sketch_seed) in KLL_SKETCH_SEEDS.iter().enumerate() {
+        for (shape, values) in rank_streams(trial, N) {
+            let truth = NumericTruth::new(values.clone());
+            for &k in &KS {
+                let spec = RankErrorSpec::datasketches(k as usize);
+                for &feed in &FEEDS {
+                    let fixed = feed_kll(feed, k, sketch_seed, &values);
+                    spec.tally_into(
+                        tallies.entry(format!("KLL/{feed:?}")).or_default(),
+                        truth.sorted(),
+                        &RANK_QS,
+                        |q| fixed.quantile(q),
+                    );
+                    if let Some(dynamic) = feed_kll_dynamic(feed, k, sketch_seed, &values) {
+                        spec.tally_into(
+                            tallies.entry(format!("KLLDynamic/{feed:?}")).or_default(),
+                            truth.sorted(),
+                            &RANK_QS,
+                            |q| dynamic.quantile(q),
+                        );
+                    }
+                    let _ = shape;
+                }
+            }
+        }
+    }
+
+    for (label, tally) in tallies {
+        tally.assert_within(
+            &format!("{label} / normalized rank error"),
+            RankErrorSpec::datasketches(200).failure_probability,
+            &format!(
+                "n={N} k in {KS:?}, sketch seeds {KLL_SKETCH_SEEDS:02x?}, \
+                 stream shapes {:?}, q grid {RANK_QS:?}",
+                rank_streams(0, 1)
+                    .iter()
+                    .map(|(s, _)| *s)
+                    .collect::<Vec<_>>()
+            ),
         );
     }
 }
 
+/// Rank error must shrink as `k` grows, at the rate the contract states.
+/// A hard-coded tolerance cannot see this: it passes identically at `k = 64`
+/// and `k = 800`, so it would not notice a `k` that stopped being wired
+/// through to the compactor capacities at all.
 #[test]
-fn kll_dynamic_parity_with_kll() {
-    let values: Vec<f64> = normal_f64(40_000, 100.0, 15.0, 3004)
+fn kll_rank_error_shrinks_with_k_as_the_contract_predicts() {
+    const N: usize = 100_000;
+    let values: Vec<f64> = uniform_u64(N, 100_000_000, 0xC0FF_EE01)
         .into_iter()
-        .filter(|v| *v > 0.0)
+        .map(|v| v as f64)
         .collect();
     let truth = NumericTruth::new(values.clone());
+    let qs: Vec<f64> = (1..20).map(|i| i as f64 / 20.0).collect();
 
-    let mut a = KLL::init_kll(200);
-    let mut b = asap_sketchlib::KLLDynamic::<f64>::init_kll(200);
-    for v in &values {
-        a.update(v);
-        b.update(v);
-    }
-    for &q in &QS {
-        assert_in_rank_band(a.quantile(q), &truth, q, 0.03, "KLL normal");
-        assert_in_rank_band(b.quantile(q), &truth, q, 0.03, "KLLDynamic normal");
-    }
-}
-
-/// Rank-error contract for both KLL implementations across distributions and
-/// stream lengths: every quantile estimate lands inside the true rank band.
-#[test]
-fn kll_family_rank_error_across_distributions_and_lengths() {
-    const TOL: f64 = 0.02;
-    const QUANTILES: [f64; 7] = [0.0, 0.10, 0.25, 0.50, 0.75, 0.90, 1.0];
-    const SAMPLE_SIZES: [usize; 6] = [1_000, 5_000, 20_000, 100_000, 1_000_000, 5_000_000];
-    // Zipf indices are spread over a fixed grid spanning [1e6, 1e7].
-    const ZIPF_DOMAIN: usize = 8_192;
-    const ZIPF_LO: f64 = 1_000_000.0;
-    const ZIPF_HI: f64 = 10_000_000.0;
-
-    for (name, seed_base) in [("uniform", 0xA5A5_0000u64), ("zipf", 0xB4B4_0000u64)] {
-        for (i, &n) in SAMPLE_SIZES.iter().enumerate() {
-            let seed = seed_base + i as u64;
-            let values: Vec<f64> = if name == "uniform" {
-                uniform_u64(n, 100_000_000, seed)
-                    .into_iter()
-                    .map(|v| v as f64)
-                    .collect()
-            } else {
-                let step = (ZIPF_HI - ZIPF_LO) / (ZIPF_DOMAIN - 1) as f64;
-                zipf_u64(n, ZIPF_DOMAIN, 1.1, seed)
-                    .into_iter()
-                    .map(|idx| ZIPF_LO + step * idx as f64)
-                    .collect()
-            };
-
-            let mut kll = KLL::init_kll(200);
-            let mut dynamic = asap_sketchlib::KLLDynamic::<f64>::init_kll(200);
+    let mut worst: Vec<(i32, f64)> = Vec::new();
+    for k in [64i32, 256, 1024] {
+        let mut w: f64 = 0.0;
+        for &seed in &KLL_SKETCH_SEEDS {
+            let mut s = KLL::init_kll_with_seed(k, seed);
             for v in &values {
-                kll.update(v);
-                dynamic.update(v);
+                s.update(v);
             }
-            let truth = NumericTruth::new(values);
-
-            for &q in &QUANTILES {
-                assert_in_rank_band(
-                    kll.quantile(q),
-                    &truth,
-                    q,
-                    TOL,
-                    &format!("KLL {name} n={n} seed=0x{seed:08x}"),
-                );
-                assert_in_rank_band(
-                    dynamic.quantile(q),
-                    &truth,
-                    q,
-                    TOL,
-                    &format!("KLLDynamic {name} n={n} seed=0x{seed:08x}"),
-                );
+            for &q in &qs {
+                let v = s.quantile(q);
+                let (excl, incl) = truth.rank_interval(v);
+                let err = if q < excl {
+                    excl - q
+                } else if q > incl {
+                    q - incl
+                } else {
+                    0.0
+                };
+                w = w.max(err);
             }
         }
+        worst.push((k, w));
     }
+
+    for (k, w) in &worst {
+        let eps = RankErrorSpec::datasketches(*k as usize).epsilon();
+        assert!(
+            *w <= eps,
+            "KLL k={k}: worst rank error {w:.5} exceeds eps(k)={eps:.5} \
+             (n={N}, sketch seeds {KLL_SKETCH_SEEDS:02x?}, stream seed 0xC0FFEE01)"
+        );
+    }
+    // 16x more capacity must buy at least a 4x tighter rank error; the
+    // contract predicts 16^0.9433 = 13.4x.
+    let (k_lo, w_lo) = worst[0];
+    let (k_hi, w_hi) = worst[2];
+    assert!(
+        w_lo >= w_hi * 4.0,
+        "raising k from {k_lo} to {k_hi} moved the worst rank error only from \
+         {w_lo:.5} to {w_hi:.5}; the contract predicts a {:.1}x improvement, so \
+         k is not reaching the compactor capacities",
+        (k_hi as f64 / k_lo as f64).powf(0.9433)
+    );
 }
 
 // ---------------------------------------------------------------- DDSketch
 
-#[test]
-fn ddsketch_alpha_across_distributions_core_and_portable() {
-    let alpha = 0.01;
-    const DDS_QS: [f64; 7] = [0.0, 0.10, 0.25, 0.50, 0.75, 0.90, 1.0];
-    const SAMPLE_SIZES: [usize; 4] = [1_000, 5_000, 20_000, 30_000];
-    // Bucket-edge straddling ratio for the adversarial stream.
+/// Accuracy parameters spanning three orders of magnitude. The tightest is
+/// where floating-point round-off in the logarithmic mapping is most likely
+/// to matter, the loosest is where the bucket span per key is widest.
+const DDS_ALPHAS: [f64; 4] = [0.001, 0.01, 0.05, 0.1];
+
+/// Same q grid as the rank battery, so the two contracts are compared on the
+/// same questions rather than on grids chosen to flatter each sketch.
+const DDS_QS: [f64; 7] = [0.0, 0.01, 0.1, 0.5, 0.9, 0.99, 1.0];
+
+/// Streams for the relative-error battery. `adversarial` places a fifth of its
+/// mass exactly on bucket lower edges, where the mapping's error is at its
+/// maximum of exactly `alpha` and one ULP of drift decides the bucket.
+fn dds_streams(alpha: f64, n: usize, seed: u64) -> Vec<(&'static str, Vec<f64>)> {
     let gamma = (1.0 + alpha) / (1.0 - alpha);
-    // Zipf indices are spread over a fixed grid spanning [1e6, 1e7].
-    let zipf_step = (10_000_000.0 - 1_000_000.0) / 8_191.0;
+    vec![
+        (
+            "adversarial-bucket-edges",
+            log_uniform_f64(n, gamma, 5..40, seed),
+        ),
+        (
+            "normal",
+            normal_f64(n, 1_000.0, 250.0, seed + 1)
+                .into_iter()
+                .filter(|v| *v > 0.0)
+                .collect(),
+        ),
+        ("exponential", exponential_f64(n, 1e-3, seed + 2)),
+        (
+            "uniform",
+            uniform_u64(n, 9_000_000, seed + 3)
+                .into_iter()
+                .map(|v| 1_000_000.0 + v as f64)
+                .collect(),
+        ),
+        ("zipf", zipf_f64(n, 8_192, 1.1, 1e6, 1e7, seed + 4)),
+        // Nine decades in one stream: the bucket store spans a large index
+        // range and the mapping is exercised far from 1.0 in both directions.
+        (
+            "wide-dynamic-range",
+            uniform_u64(n, 1_000_000, seed + 5)
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| 10f64.powi((i % 10) as i32 - 4) * (1.0 + v as f64 / 1_000_000.0))
+                .collect(),
+        ),
+    ]
+}
 
-    for (label, seed_base) in [
-        ("adversarial", 3_005_000u64),
-        ("normal", 3_006_000),
-        ("exponential", 3_007_000),
-        ("uniform", 3_009_000),
-        ("zipf", 3_010_000),
-    ] {
+/// DDSketch's relative-value-error guarantee, for the core sketch and the
+/// portable wire twin, at every supported alpha.
+///
+/// The comparison is against the **exact nearest-rank order statistic** at the
+/// same `q`, using the same ceil convention `get_value_at_quantile` uses, so
+/// the two sides answer literally the same question. The tolerance is
+/// `alpha + numerical_slack`, where the slack is a few ULP of the logarithmic
+/// mapping — never a percentage of alpha, which would license breaking the
+/// advertised guarantee by that percentage.
+#[test]
+fn ddsketch_core_and_portable_satisfy_the_relative_value_error_contract() {
+    const SAMPLE_SIZES: [usize; 3] = [1_000, 20_000, 100_000];
+
+    for &alpha in &DDS_ALPHAS {
+        let spec = RelativeQuantileSpec::new(alpha);
+        let mut core_tally = Tally::default();
+        let mut port_tally = Tally::default();
         for (i, &n) in SAMPLE_SIZES.iter().enumerate() {
-            let seed = seed_base + i as u64;
-            let values: Vec<f64> = match label {
-                "adversarial" => log_uniform_f64(n, gamma, 5..40, seed),
-                "normal" => normal_f64(n, 1000.0, 250.0, seed)
-                    .into_iter()
-                    .filter(|v| *v > 0.0)
-                    .collect(),
-                "exponential" => exponential_f64(n, 1e-3, seed),
-                "uniform" => uniform_u64(n, 9_000_000, seed)
-                    .into_iter()
-                    .map(|v| 1_000_000.0 + v as f64)
-                    .collect(),
-                _ => zipf_u64(n, 8_192, 1.1, seed)
-                    .into_iter()
-                    .map(|idx| 1_000_000.0 + zipf_step * idx as f64)
-                    .collect(),
-            };
-
-            let mut core = DDSketch::new(alpha);
-            let mut port = PortableDds::new(alpha);
-            for v in &values {
-                core.add(v);
-                port.update(*v);
-            }
-            let truth = NumericTruth::new(values);
-            assert_eq!(
-                core.get_count() as usize,
-                truth.len(),
-                "{label} n={n}: dropped samples"
-            );
-
-            for &q in &DDS_QS {
-                // Contract: relative error <= alpha vs the TRUE order statistic.
-                let t = truth.quantile(q);
-                if t <= 0.0 {
-                    continue;
+            let seed = 3_005_000u64 + i as u64 * 101 + (alpha * 1e6) as u64;
+            for (label, values) in dds_streams(alpha, n, seed) {
+                let mut core = DDSketch::new(alpha);
+                let mut port = PortableDds::new(alpha);
+                for v in &values {
+                    core.add(v);
+                    port.update(*v);
                 }
-                let qc = core.get_value_at_quantile(q).unwrap();
-                let qp = port.quantile(q).unwrap();
-                assert!(
-                    ((qc - t) / t).abs() <= alpha * 1.05,
-                    "core {label} n={n} q={q}: {qc} vs {t} exceeds alpha={alpha}"
+                let truth = NumericTruth::new(values.clone());
+                assert_eq!(
+                    core.get_count() as usize,
+                    truth.len(),
+                    "{label} alpha={alpha} n={n} seed={seed}: core dropped samples"
                 );
-                assert!(
-                    ((qp - t) / t).abs() <= alpha * 1.05,
-                    "portable {label} n={n} q={q}: {qp} vs {t} exceeds alpha={alpha}"
+                assert_eq!(
+                    port.total_count() as usize,
+                    truth.len(),
+                    "{label} alpha={alpha} n={n} seed={seed}: portable dropped samples"
                 );
+                spec.tally_into(&mut core_tally, truth.sorted(), &DDS_QS, |q| {
+                    core.get_value_at_quantile(q)
+                });
+                spec.tally_into(&mut port_tally, truth.sorted(), &DDS_QS, |q| {
+                    port.quantile(q)
+                });
             }
         }
+        // The guarantee is deterministic, not probabilistic: DDSketch's error
+        // comes from bucket width alone, with no hash and no sampling, so a
+        // single violation is a defect and none are tolerated.
+        let context = format!(
+            "alpha={alpha} sizes={SAMPLE_SIZES:?} shapes={:?} q grid {DDS_QS:?}",
+            dds_streams(alpha, 1, 0)
+                .iter()
+                .map(|(s, _)| *s)
+                .collect::<Vec<_>>()
+        );
+        core_tally.assert_none(&format!("core DDSketch alpha={alpha}"), &context);
+        port_tally.assert_none(&format!("portable DdSketch alpha={alpha}"), &context);
+    }
+}
+
+/// `q = 0` and `q = 1` are exact min/max, not bucket representatives: both
+/// implementations track the true extremes alongside the bucket store, so the
+/// relative error at the endpoints is zero rather than merely within alpha.
+#[test]
+fn ddsketch_endpoints_return_the_exact_min_and_max() {
+    for &alpha in &DDS_ALPHAS {
+        let values = log_uniform_f64(5_000, (1.0 + alpha) / (1.0 - alpha), 3..30, 4_242);
+        let truth = NumericTruth::new(values.clone());
+        let mut core = DDSketch::new(alpha);
+        let mut port = PortableDds::new(alpha);
+        for v in &values {
+            core.add(v);
+            port.update(*v);
+        }
+        assert_eq!(
+            core.get_value_at_quantile(0.0),
+            Some(truth.min()),
+            "core alpha={alpha}: q=0 must be the exact minimum"
+        );
+        assert_eq!(
+            core.get_value_at_quantile(1.0),
+            Some(truth.max()),
+            "core alpha={alpha}: q=1 must be the exact maximum"
+        );
+        assert_eq!(
+            core.min(),
+            Some(truth.min()),
+            "core alpha={alpha}: min() must be exact"
+        );
+        assert_eq!(
+            core.max(),
+            Some(truth.max()),
+            "core alpha={alpha}: max() must be exact"
+        );
+        // The portable twin clamps its bucket representative into
+        // [min, max], so its endpoints are exact too.
+        let (p0, p1) = (port.quantile(0.0).unwrap(), port.quantile(1.0).unwrap());
+        assert!(
+            (p0 - truth.min()).abs() <= truth.min() * alpha,
+            "portable alpha={alpha}: q=0 gave {p0}, true min {}",
+            truth.min()
+        );
+        assert!(
+            (p1 - truth.max()).abs() <= truth.max() * alpha,
+            "portable alpha={alpha}: q=1 gave {p1}, true max {}",
+            truth.max()
+        );
+    }
+}
+
+/// Values placed deliberately on and around a bucket boundary. Whichever side
+/// of the edge the mapping lands on, the returned representative must stay
+/// within `alpha` — a value at the lower edge is over-estimated by exactly
+/// `alpha`, and one that slips into the bucket below is under-estimated by
+/// exactly `alpha`, so both sides are tight and neither may exceed it.
+#[test]
+fn ddsketch_satisfies_the_relative_error_contract_at_bucket_boundaries() {
+    for &alpha in &DDS_ALPHAS {
+        let gamma = (1.0 + alpha) / (1.0 - alpha);
+        let spec = RelativeQuantileSpec::new(alpha);
+        for k in [-40i32, -7, 0, 1, 13, 60, 200] {
+            let edge = gamma.powi(k);
+            if edge <= 0.0 || !edge.is_finite() {
+                continue;
+            }
+            let probes = [
+                edge,                         // exactly the lower edge
+                edge * (1.0 - f64::EPSILON),  // one ULP below it
+                edge * (1.0 + f64::EPSILON),  // one ULP above it
+                edge * gamma.sqrt(),          // bucket interior
+                edge * gamma * (1.0 - 1e-12), // just under the upper edge
+            ];
+            for probe in probes {
+                let mut core = DDSketch::new(alpha);
+                let mut port = PortableDds::new(alpha);
+                core.add(&probe);
+                port.update(probe);
+                if core.get_count() == 0 {
+                    continue; // outside the indexable range at this alpha
+                }
+                // A single-sample sketch answers every q with that sample's
+                // bucket, so this isolates the mapping from any rank effect.
+                let est = core.get_value_at_quantile(0.5).unwrap();
+                if let Err(detail) = spec.check(0.5, est, probe) {
+                    panic!("core DDSketch alpha={alpha} gamma^{k} boundary probe: {detail}");
+                }
+                let pest = port.quantile(0.5).unwrap();
+                if let Err(detail) = spec.check(0.5, pest, probe) {
+                    panic!("portable DdSketch alpha={alpha} gamma^{k} boundary probe: {detail}");
+                }
+            }
+        }
+    }
+}
+
+/// Merging shards and replaying promotion deltas must both leave the relative
+/// error contract intact, because both write into the same bucket store the
+/// guarantee is stated over.
+#[test]
+fn ddsketch_merge_and_delta_replay_preserve_the_relative_error_contract() {
+    use asap_sketchlib::message_pack_format::portable::ddsketch::DdSketchDelta;
+    use asap_sketchlib::octo_delta::DdDelta;
+
+    const N: usize = 40_000;
+    for &alpha in &DDS_ALPHAS {
+        let spec = RelativeQuantileSpec::new(alpha);
+        let values = zipf_f64(N, 8_192, 1.1, 1e3, 1e7, 7_654_321 + (alpha * 1e5) as u64);
+        let truth = NumericTruth::new(values.clone());
+
+        // Four-way shard merge, core side.
+        let mut shards: Vec<DDSketch> = (0..4).map(|_| DDSketch::new(alpha)).collect();
+        for (i, v) in values.iter().enumerate() {
+            shards[i % 4].add(v);
+        }
+        let mut merged = shards.remove(0);
+        for s in &shards {
+            merged.merge(s).expect("same-alpha merge");
+        }
+        assert_eq!(
+            merged.get_count() as usize,
+            N,
+            "alpha={alpha}: merge must preserve total count"
+        );
+        let mut merge_tally = Tally::default();
+        spec.tally_into(&mut merge_tally, truth.sorted(), &DDS_QS, |q| {
+            merged.get_value_at_quantile(q)
+        });
+        merge_tally.assert_none(
+            &format!("core DDSketch alpha={alpha} after a 4-way shard merge"),
+            &format!("zipf n={N} over [1e3, 1e7]"),
+        );
+
+        // Delta replay, core side: rebuild a sketch from bucket deltas only
+        // and require the same contract of it. The replayed sketch's own
+        // min/max come from bucket representatives, so its endpoints are
+        // within alpha rather than exact — the interior q grid is what the
+        // contract covers here.
+        let single = {
+            let mut s = DDSketch::new(alpha);
+            for v in &values {
+                s.add(v);
+            }
+            s
+        };
+        let mut replayed = DDSketch::new(alpha);
+        for (i, &count) in single.store_counts().iter().enumerate() {
+            if count > 0 {
+                replayed.apply_delta(DdDelta {
+                    index: single.store_offset() + i as i32,
+                    value: count,
+                });
+            }
+        }
+        assert_eq!(
+            replayed.get_count(),
+            single.get_count(),
+            "alpha={alpha}: delta replay must reproduce the total count"
+        );
+        let mut replay_tally = Tally::default();
+        spec.tally_into(&mut replay_tally, truth.sorted(), &DDS_QS[1..6], |q| {
+            replayed.get_value_at_quantile(q)
+        });
+        replay_tally.assert_none(
+            &format!("core DDSketch alpha={alpha} rebuilt from bucket deltas"),
+            &format!(
+                "zipf n={N} over [1e3, 1e7], interior q grid {:?}",
+                &DDS_QS[1..6]
+            ),
+        );
+
+        // Portable side: merge, then a delta carrying the same buckets.
+        let mut pa = PortableDds::new(alpha);
+        let mut pb = PortableDds::new(alpha);
+        for (i, v) in values.iter().enumerate() {
+            if i % 2 == 0 {
+                pa.update(*v);
+            } else {
+                pb.update(*v);
+            }
+        }
+        pa.merge(&pb).expect("same-alpha portable merge");
+        let mut port_tally = Tally::default();
+        spec.tally_into(&mut port_tally, truth.sorted(), &DDS_QS, |q| pa.quantile(q));
+        port_tally.assert_none(
+            &format!("portable DdSketch alpha={alpha} after merge"),
+            &format!("zipf n={N} over [1e3, 1e7]"),
+        );
+
+        let mut pr = PortableDds::new(alpha);
+        let delta = DdSketchDelta {
+            buckets: pa
+                .store_counts
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| **c > 0)
+                .map(|(i, c)| (pa.store_offset + i as i32, *c))
+                .collect(),
+            d_count: pa.total_count() as i64,
+            ..DdSketchDelta::default()
+        };
+        pr.apply_delta(&delta).expect("benign delta");
+        let mut pr_tally = Tally::default();
+        spec.tally_into(&mut pr_tally, truth.sorted(), &DDS_QS[1..6], |q| {
+            pr.quantile(q)
+        });
+        pr_tally.assert_none(
+            &format!("portable DdSketch alpha={alpha} rebuilt from a delta"),
+            &format!(
+                "zipf n={N} over [1e3, 1e7], interior q grid {:?}",
+                &DDS_QS[1..6]
+            ),
+        );
     }
 }
 
 // ---------------------------------------------------------------- UnivMonQ
 
+/// Exact aggregates are exact: `count`, `min` and `max` are maintained
+/// directly, not estimated, so no band applies to them at all.
 #[test]
-fn univmonq_full_metric_suite() {
+fn univmonq_count_min_and_max_are_exact() {
     let mut q = UnivMonQ::new(Default::default()).expect("default config valid");
-    let mut freq: HashMap<u64, u64> = HashMap::new();
+    let values: Vec<f64> = uniform_u64(20_000, 900, 3008)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    for v in &values {
+        q.update(v);
+    }
+    let truth = NumericTruth::new(values.clone());
+    assert_eq!(q.count() as usize, values.len(), "count must be exact");
+    assert_eq!(q.min(), Some(truth.min()), "min must be exact");
+    assert_eq!(q.max(), Some(truth.max()), "max must be exact");
+}
 
-    // Well-separated heavy hitters plus uniform background.
+/// UnivMon-Q's bottom layer sees every update, so a point frequency query is
+/// a Count Sketch query at `(depth, width)` and carries Count Sketch's L2
+/// bound — not a percentage. Its `F2` estimate is the AMS row-sum estimator
+/// over the same matrix and carries `sqrt(2*kappa/w)`.
+#[test]
+fn univmonq_frequency_and_f2_satisfy_the_count_sketch_bounds() {
+    use common::FreqTruth;
+    use common::specs::{CountSketchSpec, SecondMomentSpec};
+
+    let config = UnivMonQConfig::default();
+    let mut q = UnivMonQ::new(config).expect("default config valid");
+    let mut truth = FreqTruth::default();
+
+    // Well-separated heavy hitters plus a uniform background.
     for i in 0..40u64 {
-        let weight = (i + 1) * 60;
-        for _ in 0..weight {
+        for _ in 0..(i + 1) * 60 {
             q.update(&(i as f64));
-            *freq.entry(i).or_insert(0) += 1;
+            truth.observe(i as i64);
         }
     }
-    let bg = uniform_u64(20_000, 900, 3008);
-    let mut values: Vec<f64> = Vec::with_capacity(20_000 + 49_200);
-    for k in bg {
+    for k in uniform_u64(20_000, 900, 3008) {
         let key = 100u64 + k % 800;
         q.update(&(key as f64));
-        *freq.entry(key).or_insert(0) += 1;
-        values.push(key as f64);
+        truth.observe(key as i64);
     }
-    for (k, c) in &freq {
-        if *k < 40 {
-            values.extend(std::iter::repeat_n(*k as f64, *c as usize));
-        }
-    }
-    let n = values.len() as f64;
-    let mut sorted = values.clone();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let truth = NumericTruth::new(values.clone());
 
-    // Exact aggregates.
-    assert_eq!(q.count() as usize, values.len(), "count");
-    assert_eq!(q.min(), Some(sorted[0]), "min");
-    assert_eq!(q.max(), Some(sorted[sorted.len() - 1]), "max");
-
-    // Frequency of the heaviest separated key.
-    let heaviest_key = 39u64;
-    let hot_est = q.estimate_frequency(heaviest_key as f64) as f64;
-    assert_between(
-        hot_est,
-        freq[&heaviest_key] as f64 * 0.95,
-        freq[&heaviest_key] as f64 * 1.05,
-        "frequency of heaviest key",
+    let context = format!(
+        "UnivMonQConfig {{ levels: {}, width: {}, depth: {}, hash_seed: {} }}, \
+         40 separated heavy keys + uniform background (stream seed 3008)",
+        config.levels, config.width, config.depth, config.hash_seed
+    );
+    CountSketchSpec::new(config.depth, config.width).assert_contract(
+        "UnivMonQ::estimate_frequency (bottom layer Count Sketch)",
+        &truth,
+        |k| q.estimate_frequency(k as f64) as f64,
+        &context,
     );
 
-    // Distinct / F2 / entropy.
+    let f2_spec = SecondMomentSpec::new(config.depth, config.width);
+    if let Err(detail) = f2_spec.check(q.estimate_f2(), truth.f2()) {
+        panic!("UnivMonQ::estimate_f2: {detail}\n  context: {context}");
+    }
+}
+
+/// Ordered queries against the residual half of the documented bound.
+///
+/// The full contract in `docs/api/api_univmon_q.md` is
+///
+/// ```text
+///   sup_x |F_hat(x) - F(x)| <= 2 E_H + P_hat_R * epsilon_R
+/// ```
+///
+/// `E_H` is the frequency error over the *internally recovered* heavy set, and
+/// neither that set nor `m_R` is reachable through the public API — so the
+/// complete theorem **cannot be verified from outside the crate**, and this
+/// test does not claim to.
+///
+/// What it does verify is the strongest contract public state supports: the
+/// diffuse regime. The adaptive gate is `F2_hat / N^2 >= 1 / ordered_samples`,
+/// and both sides of that inequality are public (`estimate_f2`, `count`,
+/// `config().ordered_samples`). On a stream where the gate provably does not
+/// fire, the heavy set is empty, so `E_H = 0` and `P_hat_R = 1`, and the whole
+/// bound collapses to the distribution-free occurrence bound
+/// `epsilon_R = sqrt(ln(2/delta) / (2 m_R))` over the retained occurrence
+/// sample, whose size is observable as the number of CDF breakpoints.
+#[test]
+fn univmonq_ordered_queries_satisfy_the_residual_occurrence_bound_when_diffuse() {
+    use common::specs::{occurrence_sample_epsilon, rank_violation};
+
+    const DELTA: f64 = 0.01;
+    let config = UnivMonQConfig::default();
+    let mut q = UnivMonQ::new(config).expect("default config valid");
+
+    // Diffuse by construction: 200k observations spread over 200k distinct
+    // values, so no value carries enough mass to qualify as heavy.
+    let values: Vec<f64> = uniform_u64(200_000, 10_000_000, 0x0DDE_0001)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    for v in &values {
+        q.update(v);
+    }
+    let truth = NumericTruth::new(values.clone());
+    let n = q.count() as f64;
+
+    // The gate condition, read entirely from public state.
+    let gate = q.estimate_f2() / (n * n);
+    let threshold = 1.0 / config.ordered_samples as f64;
+    assert!(
+        gate < threshold,
+        "test premise broken: the adaptive gate fired (F2_hat/N^2 = {gate:.3e} >= \
+         1/ordered_samples = {threshold:.3e}), so the heavy set may be non-empty and \
+         E_H is no longer provably zero"
+    );
+
+    let breakpoints = q.cdf();
+    let m_r = breakpoints.len();
+    let eps = occurrence_sample_epsilon(m_r, DELTA);
+    let context = format!(
+        "diffuse uniform stream n={} distinct={}, ordered_samples={}, \
+         retained CDF breakpoints m_R={m_r}, delta={DELTA} -> epsilon_R={eps:.5}, \
+         stream seed 0x0DDE0001",
+        values.len(),
+        truth.sorted().windows(2).filter(|w| w[0] != w[1]).count() + 1,
+        config.ordered_samples
+    );
+
+    // The bound is a supremum over x, so every breakpoint must satisfy it.
+    let mut sup_tally = Tally::default();
+    for point in &breakpoints {
+        let (excl, incl) = truth.rank_interval(point.value);
+        let dist = if point.rank < excl {
+            excl - point.rank
+        } else if point.rank > incl {
+            point.rank - incl
+        } else {
+            0.0
+        };
+        sup_tally.record(dist <= eps, || {
+            format!(
+                "value {} reported rank {:.5} but occupies true ranks [{excl:.5}, {incl:.5}] \
+                 (distance {dist:.5} > epsilon_R {eps:.5})",
+                point.value, point.rank
+            )
+        });
+    }
+    sup_tally.assert_within(
+        "UnivMonQ CDF sup-error vs the residual occurrence bound",
+        DELTA,
+        &context,
+    );
+
+    // Inverting the same bound: a quantile answer's rank must land within
+    // epsilon_R of the requested q.
+    let mut quantile_tally = Tally::default();
+    for &qq in &[0.01f64, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99] {
+        let est = q.quantile(qq).expect("ordered_samples enabled");
+        let violation = rank_violation(truth.sorted(), qq, est, eps);
+        quantile_tally.record(violation.is_none(), || violation.unwrap());
+    }
+    quantile_tally.assert_within(
+        "UnivMonQ::quantile vs the residual occurrence bound",
+        DELTA,
+        &context,
+    );
+
+    // `rank` and `quantile` must be a consistent inverse pair: re-ranking a
+    // quantile answer has to reproduce the requested rank to within the same
+    // epsilon, or one of the two is reading a different CDF.
+    for &qq in &[0.1f64, 0.5, 0.9] {
+        let v = q.quantile(qq).expect("quantile");
+        let r = q.rank(v).expect("rank") as f64 / n;
+        assert!(
+            (r - qq).abs() <= 2.0 * eps,
+            "rank(quantile({qq})) = {r:.5}, off by {:.5} > 2*epsilon_R = {:.5}. {context}",
+            (r - qq).abs(),
+            2.0 * eps
+        );
+    }
+
+    // Monotonicity is structural: a CDF that decreases is malformed whatever
+    // the sampling error.
+    assert!(!breakpoints.is_empty(), "cdf must not be empty");
+    for w in breakpoints.windows(2) {
+        assert!(
+            w[0].rank <= w[1].rank + 1e-9,
+            "cdf ranks not monotone at {:?} -> {:?}. {context}",
+            w[0],
+            w[1]
+        );
+    }
+}
+
+/// Distinct count, entropy and heavy-hitter recall for UnivMon-Q's recursive
+/// sketch hierarchy.
+///
+/// Documented empirical regression, not a theorem. UnivMon's `g`-sum
+/// recurrence composes per-layer Count Sketch errors across `levels`
+/// geometrically sampled substreams; the resulting constant depends on the
+/// stream's own layer occupancy and the crate publishes no closed form for it,
+/// so there is no theoretical band to assert.
+///
+/// Band source: measured on this exact stream (40 separated heavy keys with
+/// weights 60..2400, plus 20k uniform background over 800 keys, stream seed
+/// 3008, default `UnivMonQConfig`). Observed relative errors are distinct
+/// 1.6%, entropy 0.3%; the bands below are 10% for both, roughly six times the
+/// observed movement, and heavy-hitter recall is 10/10 against a target of 8.
+#[test]
+fn univmonq_distinct_entropy_and_recall_stay_within_the_documented_empirical_band() {
+    use common::FreqTruth;
+
+    let mut q = UnivMonQ::new(Default::default()).expect("default config valid");
+    let mut truth = FreqTruth::default();
+    for i in 0..40u64 {
+        for _ in 0..(i + 1) * 60 {
+            q.update(&(i as f64));
+            truth.observe(i as i64);
+        }
+    }
+    for k in uniform_u64(20_000, 900, 3008) {
+        let key = 100u64 + k % 800;
+        q.update(&(key as f64));
+        truth.observe(key as i64);
+    }
+
+    let distinct = truth.distinct() as f64;
     assert_between(
         q.estimate_distinct(),
-        freq.len() as f64 * 0.90,
-        freq.len() as f64 * 1.10,
-        "distinct",
+        distinct * 0.90,
+        distinct * 1.10,
+        "UnivMonQ distinct (empirical band, stream seed 3008)",
     );
-    let f2_truth: f64 = freq.values().map(|c| (*c as f64).powi(2)).sum();
-    assert_between(q.estimate_f2(), f2_truth * 0.85, f2_truth * 1.15, "F2");
-    let p: Vec<f64> = freq.values().map(|c| *c as f64 / n).collect();
-    let h_truth: f64 = -p.iter().map(|p| p * p.ln()).sum::<f64>();
+    let entropy = truth.entropy(false);
     assert_between(
         q.estimate_entropy(),
-        h_truth * 0.90,
-        h_truth * 1.10,
-        "entropy (nats)",
+        entropy * 0.90,
+        entropy * 1.10,
+        "UnivMonQ entropy in nats (empirical band, stream seed 3008)",
     );
 
-    // Ordered queries: rank bands + monotone CDF + rank()/quantile() inverse pair.
-    for &qq in &QS {
-        match q.quantile(qq) {
-            Some(est) => assert_in_rank_band(est, &truth, qq, 0.04, "UnivMonQ quantile"),
-            None => panic!("quantile({qq}) returned None with ordered_samples enabled"),
-        }
-    }
-    let cdf_pts: Vec<UnivMonQPoint> = q.cdf();
-    assert!(!cdf_pts.is_empty(), "cdf must not be empty");
-    for w in cdf_pts.windows(2) {
-        assert!(w[0].rank <= w[1].rank + 1e-9, "cdf ranks not monotone");
-    }
-    let probe = sorted[sorted.len() / 3];
-    let r = q.rank(probe).expect("rank") as f64;
-    let true_rank = truth.cdf(probe) * n;
-    assert_between(
-        r,
-        true_rank * 0.94,
-        true_rank * 1.06,
-        "rank() vs empirical count",
-    );
-
-    // Heavy hitters among the well-separated keys (weights 1800..2400).
-    let hh = q.heavy_hitters(10);
-    let top_true: std::collections::HashSet<u64> = freq
-        .iter()
-        .filter(|(k, c)| **k >= 30 && **c >= 30 * 60)
-        .map(|(k, _)| *k)
-        .collect();
-    assert_eq!(
-        top_true.len(),
-        10,
-        "test setup: expected 10 separated heavy keys"
-    );
-    let hits = hh
+    // The ten heaviest separated keys carry weights 1860..2400, each at least
+    // 3x the heaviest background key, so a working heavy-hitter path finds
+    // essentially all of them.
+    let top_true: std::collections::HashSet<u64> = (30..40u64).collect();
+    let hits = q
+        .heavy_hitters(10)
         .iter()
         .filter(|(v, _)| top_true.contains(&(*v as u64)))
         .count();
     assert!(
         hits >= 8,
-        "heavy hitters recovered only {hits}/10 known keys"
+        "UnivMonQ recovered only {hits}/10 known heavy keys (empirical band, stream seed 3008)"
     );
 }
 
 // -------------------------------------------------------- TumblingWindow<KLL>
 
+/// Window bookkeeping is exact (which observations land in which window) while
+/// the answers inside a window carry KLL's rank error. Both halves are checked
+/// against their own standard: window membership by equality, quantiles by
+/// `eps(k)`.
 #[test]
-fn tumbling_kll_window_queries() {
-    let cfg = KLLConfig {
-        k: 200,
-        m: 8,
-        seed: None,
-    };
-    let mut tw: TumblingWindow<KLL> = TumblingWindow::new(100, 16, cfg, 4);
+fn tumbling_kll_windows_are_exact_and_answers_satisfy_the_rank_contract() {
+    const K: i32 = 200;
+    const SKETCH_SEED: u64 = 0x7717_0001;
+    const N: usize = 4_000;
+    const WINDOW: u64 = 400;
 
-    let all: Vec<f64> = uniform_u64(1000, 1_000_000, 3009)
+    let cfg = KLLConfig {
+        k: K as usize,
+        m: 8,
+        seed: Some(SKETCH_SEED),
+    };
+    let mut tw: TumblingWindow<KLL> = TumblingWindow::new(WINDOW, 16, cfg, 4);
+    let all: Vec<f64> = uniform_u64(N, 1_000_000, 3009)
         .iter()
         .map(|v| *v as f64)
         .collect();
     for (t, v) in all.iter().enumerate() {
-        tw.insert(t as u64, &DataInput::F64(*v), 999); // value param ignored for KLL
+        tw.insert(t as u64, &DataInput::F64(*v), 0);
     }
+
+    // Window boundaries are arithmetic, so this is an equality, not a band.
     assert_eq!(
         tw.closed_count(),
-        9,
-        "windows [0,900) should be closed at t=999"
+        (N as u64 / WINDOW - 1) as usize,
+        "windows [0, {}) should be closed at t={}",
+        N as u64 - WINDOW,
+        N - 1
     );
 
-    // query_all covers every observation.
-    let merged_all = tw.query_all();
-    let full_truth = NumericTruth::new(all.clone());
-    for &qq in &[0.5f64, 0.9] {
-        assert_in_rank_band(
-            merged_all.quantile(qq),
-            &full_truth,
-            qq,
-            0.05,
-            "tumbling query_all",
+    let spec = RankErrorSpec::datasketches(K as usize);
+    let context =
+        format!("k={K} sketch_seed=0x{SKETCH_SEED:08x} stream_seed=3009 n={N} window={WINDOW}");
+    let mut tally = Tally::default();
+    for (label, sketch, slice) in [
+        ("query_all", tw.query_all(), &all[..]),
+        // query_recent(1) = the active window plus the last closed one.
+        (
+            "query_recent(1)",
+            tw.query_recent(1),
+            &all[N - 2 * WINDOW as usize..],
+        ),
+        (
+            "active_sketch",
+            tw.active_sketch().clone(),
+            &all[N - WINDOW as usize..],
+        ),
+    ] {
+        let truth = NumericTruth::new(slice.to_vec());
+        spec.tally_into(
+            &mut tally,
+            truth.sorted(),
+            &[0.1, 0.25, 0.5, 0.75, 0.9],
+            |q| sketch.quantile(q),
         );
+        let _ = label;
     }
+    tally.assert_within(
+        "TumblingWindow<KLL> window queries / rank error",
+        spec.failure_probability,
+        &context,
+    );
 
-    // query_recent(1) = active window [900,1000) + last closed [800,900).
-    let recent: Vec<f64> = all[800..].to_vec();
-    let recent_truth = NumericTruth::new(recent);
-    let merged_recent = tw.query_recent(1);
-    for &qq in &[0.5f64, 0.9] {
-        assert_in_rank_band(
-            merged_recent.quantile(qq),
-            &recent_truth,
-            qq,
-            0.05,
-            "tumbling query_recent(1)",
-        );
-    }
-
-    // The active window alone is the exact last-100 slice.
-    let active_truth = NumericTruth::new(all[900..].to_vec());
-    let active_median = tw.active_sketch().quantile(0.5);
-    assert_in_rank_band(
-        active_median,
-        &active_truth,
-        0.5,
-        0.06,
-        "active window median",
+    // Rotation must not drop windows. `KLL::count()` is the *retained weighted
+    // mass*, not an exact counter — compaction promotes half a buffer at
+    // double weight, so the total is an unbiased randomized estimate of `n`
+    // and single-pass sketches already report `n +- a few` before any merge.
+    // The crate documents no exactness guarantee for it, so this is a
+    // consistency check rather than a theorem: the estimate must stay inside
+    // the same `eps(k)` band the rank contract works in, which a pipeline that
+    // silently discarded a whole window (12.5% of the stream here) could not.
+    let merged_count = tw.query_all().count() as f64;
+    let drift = (merged_count - N as f64).abs() / N as f64;
+    assert!(
+        drift <= spec.epsilon(),
+        "TumblingWindow<KLL>::query_all reported a weighted mass of {merged_count} for {N} \
+         inserts (drift {drift:.5} > eps(k) {:.5}); a dropped or duplicated window would \
+         show up here. {context}",
+        spec.epsilon()
     );
 }
 
+// --------------------------------------------- Portable HydraKll per-key
+
+/// Hydra routes each key to its own KLL cell, so each cell answers under the
+/// same rank contract as a standalone KLL over that key's observations.
+#[test]
+fn portable_hydra_kll_per_key_medians_satisfy_the_rank_contract() {
+    const K: usize = 200;
+    let spec = RankErrorSpec::datasketches(K);
+    let mut hk = HydraKllSketch::with_seed(3, 256, K as u16, 0x5EED_0500);
+    let mut truths: HashMap<&str, NumericTruth> = HashMap::new();
+    for (name, base, seed) in [("svc-a", 100.0f64, 3010u64), ("svc-b", 900.0, 3011)] {
+        let vals: Vec<f64> = normal_f64(4000, base, base * 0.05, seed)
+            .into_iter()
+            .map(f64::abs) // HydraKll cells are KLL: positive domain
+            .collect();
+        truths.insert(name, NumericTruth::new(vals.clone()));
+        for v in vals {
+            hk.update(name, v);
+        }
+    }
+    let mut tally = Tally::default();
+    for (name, truth) in &truths {
+        spec.tally_into(
+            &mut tally,
+            truth.sorted(),
+            &[0.1, 0.25, 0.5, 0.75, 0.9],
+            |q| hk.quantile(name, q),
+        );
+    }
+    tally.assert_within(
+        "portable HydraKll per-key quantiles / rank error",
+        spec.failure_probability,
+        &format!(
+            "k={K} sketch_seed=0x5EED0500, 3x256 grid, normal(100, 5) and normal(900, 45), \
+             stream seeds 3010/3011"
+        ),
+    );
+}
+
+// ------------------------------------------- DDSketch input rejection
+
+/// Structural guards, not accuracy: values the mapping cannot index and
+/// deltas spanning an implausible bucket range must be rejected without
+/// corrupting state. No error bound applies to any of it.
 #[test]
 fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
     let alpha = 0.01;
@@ -536,32 +1142,6 @@ fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
         0,
         "no allocation may occur for rejected values"
     );
-}
-
-// --------------------------------------------- Portable HydraKll per-key
-
-#[test]
-fn portable_hydra_kll_per_key_medians() {
-    let mut hk = HydraKllSketch::new(3, 256, 200);
-    let mut truths: HashMap<&str, NumericTruth> = HashMap::new();
-    for (name, base) in [("svc-a", 100.0f64), ("svc-b", 900.0)] {
-        let vals = normal_f64(
-            4000,
-            base,
-            base * 0.05,
-            if name == "svc-a" { 3010 } else { 3011 },
-        );
-        truths.insert(name, NumericTruth::new(vals.clone()));
-        for v in vals {
-            hk.update(name, v.abs()); // HydraKll cells are KLL: positive domain
-        }
-    }
-    for (name, truth) in truths {
-        for &qq in &[0.25f64, 0.5, 0.75] {
-            let est = hk.quantile(name, qq);
-            assert_in_rank_band(est, &truth, qq, 0.04, &format!("HydraKll {name}"));
-        }
-    }
 }
 
 #[test]

--- a/tests/e2e_windows.rs
+++ b/tests/e2e_windows.rs
@@ -1,0 +1,753 @@
+//! Windowed frameworks: every `EHSketchList` variant inside an
+//! `ExponentialHistogram`, and every `TumblingWindowSketch` implementation
+//! inside a `TumblingWindow`.
+//!
+//! The window machinery is shared, but the payloads are not, so a single
+//! tolerance across all of them would be meaningless. Each variant is checked
+//! against **its own** error metric — Count-Min's additive bound, Count
+//! Sketch's L2 bound, HLL's register model, KLL's rank error, DDSketch's
+//! relative value error — over the exact contents of the window the query
+//! actually covered.
+//!
+//! ## Reading the ground truth off a bucket span
+//!
+//! `query_interval_merge` snaps a requested interval to bucket boundaries, so
+//! an arbitrary `[t1, t2]` has no exact reference. Every query below therefore
+//! asks for the histogram's **full retained span**, `[payload[0].min_time,
+//! payload.last().max_time]`, which merges every retained bucket and nothing
+//! else. Both endpoints are public, so the reference window is known exactly
+//! and no tolerance is spent on bucket granularity.
+
+mod common;
+
+use common::specs::{
+    CardinalityConfidenceSpec, CountMinSpec, CountSketchSpec, RankErrorSpec, RelativeQuantileSpec,
+    Tally,
+};
+use common::{FreqTruth, NumericTruth, uniform_u64, zipf_u64};
+
+use asap_sketchlib::{
+    Coco, Count, CountL2HH, CountMin, DDSketch, DataInput, Elastic, ErtlMLE, ExponentialHistogram,
+    FastPath, FoldCS, FoldCSConfig, HyperLogLog, KLL, SketchNorm, TumblingWindow, UnivMon,
+    UnivMonQ, UnivMonQConfig, Vector2D,
+};
+
+const EH_K: usize = 8;
+const EH_WINDOW: u64 = 1_000_000; // no expiry inside the accuracy runs
+// Sized so the histogram's per-update prototype clone (an `ExponentialHistogram`
+// copies its prototype sketch on every insert) stays affordable in an
+// unoptimised `cargo test` run. The bounds are computed from each instance's
+// own dimensions, so a smaller grid narrows nothing about what is asserted.
+const N: usize = 10_000;
+const DOMAIN: usize = 2_048;
+const STREAM_SEED: u64 = 0x0E11_0001;
+
+/// Matrix dimensions for the counter-backed variants, chosen so their bounds
+/// are meaningful at `N` updates over `DOMAIN` keys.
+const ROWS: usize = 3;
+const COLS: usize = 512;
+
+/// The full retained span of a histogram: querying it merges every bucket, so
+/// the reference window is the whole stream that has not expired.
+fn full_span(eh: &ExponentialHistogram) -> (u64, u64) {
+    let first = eh.payload.first().expect("histogram has buckets");
+    let last = eh.payload.last().expect("histogram has buckets");
+    (first.min_time, last.max_time)
+}
+
+// ------------------------------------------------- Norm policy per variant
+
+/// Which merge rule each payload selects. `COUNTL2HH` and `UNIVMON` carry an
+/// L2 mass and are merged by it; every other variant has no L2 mass to read
+/// and falls back to the L1 bucket-size rule. Getting this wrong would silently
+/// change how buckets consolidate, and therefore how much of the window a query
+/// actually covers, so it is asserted per variant rather than assumed.
+#[test]
+fn every_eh_variant_selects_the_documented_merge_norm() {
+    let l2_variants = [
+        (
+            "COUNTL2HH",
+            asap_sketchlib::EHSketchList::COUNTL2HH(CountL2HH::with_dimensions(ROWS, COLS)),
+        ),
+        (
+            "UNIVMON",
+            asap_sketchlib::EHSketchList::UNIVMON(UnivMon::init_univmon(32, ROWS, COLS, 4)),
+        ),
+    ];
+    for (name, proto) in l2_variants {
+        assert!(
+            proto.supports_norm(SketchNorm::L2) && !proto.supports_norm(SketchNorm::L1),
+            "{name} must be an L2-merged payload"
+        );
+        let eh = ExponentialHistogram::new(EH_K, EH_WINDOW, proto);
+        assert_eq!(
+            eh.merge_norm,
+            SketchNorm::L2,
+            "{name} histogram must merge by L2 mass"
+        );
+    }
+
+    let l1_variants: Vec<(&str, asap_sketchlib::EHSketchList)> = vec![
+        (
+            "CM",
+            asap_sketchlib::EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+                ROWS, COLS,
+            )),
+        ),
+        (
+            "CS",
+            asap_sketchlib::EHSketchList::CS(Count::<Vector2D<i32>, FastPath>::with_dimensions(
+                ROWS, COLS,
+            )),
+        ),
+        (
+            "COCO",
+            asap_sketchlib::EHSketchList::COCO(Coco::init_with_size(512, 4)),
+        ),
+        (
+            "ELASTIC",
+            asap_sketchlib::EHSketchList::ELASTIC(Elastic::init_with_length(512)),
+        ),
+        (
+            "HLL",
+            asap_sketchlib::EHSketchList::HLL(HyperLogLog::<ErtlMLE>::new()),
+        ),
+        (
+            "KLL",
+            asap_sketchlib::EHSketchList::KLL(KLL::init_kll_with_seed(200, 0x5EED_0100)),
+        ),
+        (
+            "DDS",
+            asap_sketchlib::EHSketchList::DDS(DDSketch::new(0.01)),
+        ),
+    ];
+    for (name, proto) in l1_variants {
+        assert!(
+            proto.supports_norm(SketchNorm::L1),
+            "{name} must be an L1-merged payload"
+        );
+        let eh = ExponentialHistogram::new(EH_K, EH_WINDOW, proto);
+        assert_eq!(
+            eh.merge_norm,
+            SketchNorm::L1,
+            "{name} histogram must merge by bucket size"
+        );
+    }
+}
+
+// ------------------------------------------------ Counter-backed variants
+
+/// Feeds a Zipf key stream through a histogram and returns the merged payload
+/// over the full retained span, together with the exact truth for that span.
+fn run_keyed_variant(
+    proto: asap_sketchlib::EHSketchList,
+) -> (asap_sketchlib::EHSketchList, FreqTruth, String) {
+    let keys = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut eh = ExponentialHistogram::new(EH_K, EH_WINDOW, proto);
+    for (t, k) in keys.iter().enumerate() {
+        eh.update(t as u64, &DataInput::U64(*k));
+    }
+    let (lo, hi) = full_span(&eh);
+    let merged = eh
+        .query_interval_merge(lo, hi)
+        .expect("full-span interval must be covered");
+    let mut truth = FreqTruth::default();
+    for t in lo..=hi {
+        truth.observe(keys[t as usize] as i64);
+    }
+    let ctx = format!(
+        "k={EH_K} window={EH_WINDOW} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}, \
+         retained span [{lo}, {hi}] over {} buckets",
+        eh.payload.len()
+    );
+    (merged, truth, ctx)
+}
+
+#[test]
+fn eh_count_min_variant_satisfies_the_count_min_bound_over_the_retained_window() {
+    let (merged, truth, ctx) = run_keyed_variant(asap_sketchlib::EHSketchList::CM(CountMin::<
+        Vector2D<i32>,
+        FastPath,
+    >::with_dimensions(
+        ROWS, COLS
+    )));
+    CountMinSpec::new(ROWS, COLS).assert_contract(
+        "EHSketchList::CM",
+        &truth,
+        |k| merged.query(&DataInput::U64(k as u64)).expect("CM query"),
+        &ctx,
+    );
+}
+
+#[test]
+fn eh_count_sketch_variant_satisfies_the_l2_bound_over_the_retained_window() {
+    let (merged, truth, ctx) = run_keyed_variant(asap_sketchlib::EHSketchList::CS(Count::<
+        Vector2D<i32>,
+        FastPath,
+    >::with_dimensions(
+        ROWS, COLS
+    )));
+    CountSketchSpec::new(ROWS, COLS).assert_contract(
+        "EHSketchList::CS",
+        &truth,
+        |k| merged.query(&DataInput::U64(k as u64)).expect("CS query"),
+        &ctx,
+    );
+}
+
+#[test]
+fn eh_countl2hh_variant_satisfies_the_l2_bound_over_the_retained_window() {
+    let (merged, truth, ctx) = run_keyed_variant(asap_sketchlib::EHSketchList::COUNTL2HH(
+        CountL2HH::with_dimensions(ROWS, COLS),
+    ));
+    CountSketchSpec::new(ROWS, COLS).assert_contract(
+        "EHSketchList::COUNTL2HH",
+        &truth,
+        |k| merged.query(&DataInput::U64(k as u64)).expect("L2HH query"),
+        &ctx,
+    );
+}
+
+/// The heavy-hitter payloads keep a flow key beside each counter and evict on
+/// pressure, so their guarantee is one-sided on the keys they retain: a
+/// reported count never reads below the truth. Their full error sandwiches are
+/// covered in `e2e_heavy_hitters.rs`; what is new here is that the guarantee
+/// survives EH bucket merging.
+#[test]
+fn eh_heavy_hitter_variants_stay_one_sided_over_the_retained_window() {
+    for (name, proto) in [
+        (
+            "COCO",
+            asap_sketchlib::EHSketchList::COCO(Coco::init_with_size(1024, 4)),
+        ),
+        (
+            "ELASTIC",
+            asap_sketchlib::EHSketchList::ELASTIC(Elastic::init_with_length(1024)),
+        ),
+    ] {
+        // Both payloads key on strings, so the stream is fed as strings and
+        // the truth is keyed by the same identity.
+        let keys = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+        let mut eh = ExponentialHistogram::new(EH_K, EH_WINDOW, proto);
+        for (t, k) in keys.iter().enumerate() {
+            eh.update(t as u64, &DataInput::String(format!("f{k}")));
+        }
+        let (lo, hi) = full_span(&eh);
+        let merged = eh.query_interval_merge(lo, hi).expect("full span");
+        let mut truth = FreqTruth::default();
+        for t in lo..=hi {
+            truth.observe(keys[t as usize] as i64);
+        }
+        let ctx = format!(
+            "{name} k={EH_K} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}, \
+             retained span [{lo}, {hi}] over {} buckets",
+            eh.payload.len()
+        );
+
+        // Only the truly heavy keys are guaranteed to be retained; the
+        // one-sided property is asserted over those.
+        let mut tally = Tally::default();
+        for (k, c) in truth.top_k(32) {
+            let est = merged
+                .query(&DataInput::String(format!("f{k}")))
+                .expect("heavy-hitter query");
+            tally.record(est >= c as f64, || {
+                format!("key f{k}: true {c}, reported {est} (must never read low)")
+            });
+        }
+        tally.assert_none(
+            &format!("EHSketchList::{name} one-sided on heavy keys"),
+            &ctx,
+        );
+    }
+}
+
+#[test]
+fn eh_hll_variant_satisfies_the_register_error_model_over_the_retained_window() {
+    let keys = uniform_u64(N, 200_000, STREAM_SEED);
+    let mut eh = ExponentialHistogram::new(
+        EH_K,
+        EH_WINDOW,
+        asap_sketchlib::EHSketchList::HLL(HyperLogLog::<ErtlMLE>::new()),
+    );
+    for (t, k) in keys.iter().enumerate() {
+        eh.update(t as u64, &DataInput::U64(*k));
+    }
+    let (lo, hi) = full_span(&eh);
+    let merged = eh.query_interval_merge(lo, hi).expect("full span");
+    let distinct: std::collections::HashSet<u64> = (lo..=hi).map(|t| keys[t as usize]).collect();
+
+    // `HyperLogLog<ErtlMLE>` here is the p14 default: m = 2^14 registers.
+    let spec = CardinalityConfidenceSpec::hll(14, 4.0);
+    let mut tally = Tally::default();
+    spec.tally_into(
+        &mut tally,
+        merged.query(&DataInput::Str("card")).expect("HLL query"),
+        distinct.len(),
+    );
+    tally.assert_within(
+        "EHSketchList::HLL / register error model",
+        spec.per_check_failure(),
+        &format!(
+            "k={EH_K} uniform n={N} domain=200000 seed={STREAM_SEED:#x}, retained span \
+             [{lo}, {hi}] with {} distinct, tolerance={:.5}",
+            distinct.len(),
+            spec.tolerance()
+        ),
+    );
+}
+
+#[test]
+fn eh_kll_variant_satisfies_the_rank_error_contract_over_the_retained_window() {
+    const KLL_K: i32 = 200;
+    let values: Vec<f64> = uniform_u64(N, 1_000_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    let mut eh = ExponentialHistogram::new(
+        EH_K,
+        EH_WINDOW,
+        asap_sketchlib::EHSketchList::KLL(KLL::init_kll_with_seed(KLL_K, 0x5EED_0200)),
+    );
+    for (t, v) in values.iter().enumerate() {
+        eh.update(t as u64, &DataInput::F64(*v));
+    }
+    let (lo, hi) = full_span(&eh);
+    let merged = eh.query_interval_merge(lo, hi).expect("full span");
+    let truth = NumericTruth::new((lo..=hi).map(|t| values[t as usize]).collect());
+
+    let spec = RankErrorSpec::datasketches(KLL_K as usize);
+    let mut tally = Tally::default();
+    // The KLL payload answers `query(q)` as `quantile(q)`.
+    spec.tally_into(
+        &mut tally,
+        truth.sorted(),
+        &[0.1, 0.25, 0.5, 0.75, 0.9],
+        |q| merged.query(&DataInput::F64(q)).expect("KLL query"),
+    );
+    tally.assert_within(
+        "EHSketchList::KLL / normalized rank error",
+        spec.failure_probability,
+        &format!(
+            "k={EH_K} kll_k={KLL_K} sketch_seed=0x5EED0200 uniform n={N} seed={STREAM_SEED:#x}, \
+             retained span [{lo}, {hi}] with {} observations",
+            truth.len()
+        ),
+    );
+}
+
+#[test]
+fn eh_ddsketch_variant_satisfies_the_relative_value_error_contract_over_the_window() {
+    const ALPHA: f64 = 0.01;
+    let values: Vec<f64> = uniform_u64(N, 9_000_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| 1_000_000.0 + v as f64)
+        .collect();
+    let mut eh = ExponentialHistogram::new(
+        EH_K,
+        EH_WINDOW,
+        asap_sketchlib::EHSketchList::DDS(DDSketch::new(ALPHA)),
+    );
+    for (t, v) in values.iter().enumerate() {
+        eh.update(t as u64, &DataInput::F64(*v));
+    }
+    let (lo, hi) = full_span(&eh);
+    let merged = eh.query_interval_merge(lo, hi).expect("full span");
+    let truth = NumericTruth::new((lo..=hi).map(|t| values[t as usize]).collect());
+
+    // The DDS payload answers `query(q)` as `get_value_at_quantile(q)`.
+    let spec = RelativeQuantileSpec::new(ALPHA);
+    let mut tally = Tally::default();
+    spec.tally_into(
+        &mut tally,
+        truth.sorted(),
+        &[0.1, 0.25, 0.5, 0.75, 0.9],
+        |q| merged.query(&DataInput::F64(q)).ok(),
+    );
+    tally.assert_none(
+        "EHSketchList::DDS / relative value error",
+        &format!(
+            "alpha={ALPHA} k={EH_K} uniform n={N} seed={STREAM_SEED:#x}, retained span \
+             [{lo}, {hi}] with {} observations",
+            truth.len()
+        ),
+    );
+    // Count is maintained, so the merged payload holds the whole window.
+    assert_eq!(
+        merged.query(&DataInput::Str("count")).expect("count"),
+        truth.len() as f64,
+        "DDS payload must retain every observation in the merged span"
+    );
+}
+
+#[test]
+fn eh_univmon_variant_reports_the_exact_l1_over_the_retained_window() {
+    let keys = zipf_u64(N, DOMAIN, 1.1, STREAM_SEED);
+    let mut eh = ExponentialHistogram::new(
+        EH_K,
+        EH_WINDOW,
+        asap_sketchlib::EHSketchList::UNIVMON(UnivMon::init_univmon(32, 5, 2048, 8)),
+    );
+    for (t, k) in keys.iter().enumerate() {
+        eh.update(t as u64, &DataInput::U64(*k));
+    }
+    let (lo, hi) = full_span(&eh);
+    let merged = eh.query_interval_merge(lo, hi).expect("full span");
+    let mut truth = FreqTruth::default();
+    for t in lo..=hi {
+        truth.observe(keys[t as usize] as i64);
+    }
+    let ctx = format!(
+        "k={EH_K} zipf(1.1) domain={DOMAIN} n={N} seed={STREAM_SEED:#x}, retained span [{lo}, {hi}]"
+    );
+
+    // L1 is the maintained bucket size: exact, not estimated.
+    assert_eq!(
+        merged.query(&DataInput::Str("l1")).expect("l1"),
+        truth.total() as f64,
+        "UnivMon L1 over the merged span must be exact. {ctx}"
+    );
+
+    // L2 through UnivMon's recursive g-sum: documented empirical band.
+    //
+    // Band source: measured on this configuration and stream at 3% below the
+    // exact L2; the band below is 15%, five times the observed movement.
+    // UnivMon publishes no closed-form constant for the recurrence, so this
+    // is a regression on measured behaviour rather than a theorem.
+    let l2 = merged.query(&DataInput::Str("l2")).expect("l2");
+    let l2_truth = truth.l2_norm();
+    assert!(
+        l2 >= l2_truth * 0.85 && l2 <= l2_truth * 1.15,
+        "UnivMon L2 {l2:.1} vs exact {l2_truth:.1} outside the documented +-15% empirical \
+         band. {ctx}"
+    );
+}
+
+// ---------------------------------------------------------- Window semantics
+
+/// Expiry and interval queries, checked on the payload every variant shares.
+/// Bucket bookkeeping is arithmetic, so these are equalities.
+#[test]
+fn eh_expires_buckets_past_the_window_and_reports_its_retained_span() {
+    const WINDOW: u64 = 100;
+    let mut eh = ExponentialHistogram::new(
+        EH_K,
+        WINDOW,
+        asap_sketchlib::EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(
+            ROWS, COLS,
+        )),
+    );
+    for t in 0..500u64 {
+        if t % 3 == 0 {
+            eh.update(t, &DataInput::Str("req"));
+        }
+    }
+
+    let retained_min = eh.get_min_time().expect("buckets present");
+    let retained_max = eh.get_max_time().expect("buckets present");
+    assert_eq!(retained_max, 498, "newest retained timestamp");
+    assert!(eh.cover(retained_min, 498), "must cover its retained span");
+    assert!(!eh.cover(500, 600), "cannot cover beyond the observed span");
+
+    // Every retained bucket must reach at least to the cutoff.
+    let cutoff = retained_max.saturating_sub(WINDOW);
+    for b in &eh.payload {
+        assert!(
+            b.max_time >= cutoff,
+            "bucket [{}, {}] lies entirely before the cutoff {cutoff}",
+            b.min_time,
+            b.max_time
+        );
+    }
+
+    // The full-span query merges every retained bucket, so its count is the
+    // exact number of retained events — no bucket-granularity slack needed.
+    let (lo, hi) = full_span(&eh);
+    let merged = eh.query_interval_merge(lo, hi).expect("full span");
+    let retained_events = (lo..=hi).filter(|t| t % 3 == 0).count();
+    let est = merged.query(&DataInput::Str("req")).expect("CM query");
+    assert!(
+        est >= retained_events as f64,
+        "Count-Min must not underestimate the retained event count: {est} < {retained_events}"
+    );
+}
+
+// ------------------------------------------------------------ TumblingWindow
+
+/// `TumblingWindow<FoldCS>`: window bookkeeping is exact, and the folded Count
+/// Sketch inside each window carries the L2 bound at its *folded* width.
+#[test]
+fn tumbling_fold_cs_windows_are_exact_and_answers_satisfy_the_l2_bound() {
+    const FULL_COLS: usize = 4_096;
+    const FOLD_LEVEL: u32 = 2;
+    const WINDOW: u64 = 500;
+    const TOTAL: u64 = 3_000;
+
+    let cfg = FoldCSConfig {
+        rows: ROWS,
+        full_cols: FULL_COLS,
+        fold_level: FOLD_LEVEL,
+        top_k: 32,
+    };
+    let mut tw: TumblingWindow<FoldCS> = TumblingWindow::new(WINDOW, 16, cfg, 4);
+    let keys = zipf_u64(TOTAL as usize, 512, 1.1, STREAM_SEED);
+    for (t, k) in keys.iter().enumerate() {
+        tw.insert(t as u64, &DataInput::U64(*k), 1);
+    }
+
+    assert_eq!(
+        tw.closed_count(),
+        (TOTAL / WINDOW - 1) as usize,
+        "windows [0, {}) must be closed at t={}",
+        TOTAL - WINDOW,
+        TOTAL - 1
+    );
+
+    let folded_cols = FULL_COLS >> FOLD_LEVEL;
+    let spec = CountSketchSpec::new(ROWS, folded_cols);
+
+    // The active window is the exact last-`WINDOW` slice.
+    let mut active_truth = FreqTruth::default();
+    for k in &keys[(TOTAL - WINDOW) as usize..] {
+        active_truth.observe(*k as i64);
+    }
+    let active = tw.active_sketch();
+    spec.assert_contract(
+        "TumblingWindow<FoldCS> active window",
+        &active_truth,
+        |k| active.query(&DataInput::U64(k as u64)) as f64,
+        &format!(
+            "rows={ROWS} full_cols={FULL_COLS} fold_level={FOLD_LEVEL} -> {folded_cols} cols, \
+             window={WINDOW} zipf(1.1) domain=512 seed={STREAM_SEED:#x}"
+        ),
+    );
+
+    // `query_all` covers every observation.
+    let mut all_truth = FreqTruth::default();
+    for k in &keys {
+        all_truth.observe(*k as i64);
+    }
+    let all = tw.query_all();
+    spec.assert_contract(
+        "TumblingWindow<FoldCS> query_all",
+        &all_truth,
+        |k| all.query(&DataInput::U64(k as u64)) as f64,
+        &format!("all {TOTAL} observations across {} windows", TOTAL / WINDOW),
+    );
+
+    // `query_recent(2)` is the active window plus the two most recent closed
+    // ones — an exact time slice.
+    let mut recent_truth = FreqTruth::default();
+    for k in &keys[(TOTAL - 3 * WINDOW) as usize..] {
+        recent_truth.observe(*k as i64);
+    }
+    let recent = tw.query_recent(2);
+    spec.assert_contract(
+        "TumblingWindow<FoldCS> query_recent(2)",
+        &recent_truth,
+        |k| recent.query(&DataInput::U64(k as u64)) as f64,
+        "last three windows",
+    );
+
+    // Rotation and pool reuse: flushing then inserting again must produce a
+    // clean active window, not one carrying the previous window's counters.
+    tw.flush(TOTAL);
+    let closed_after_flush = tw.closed_count();
+    tw.insert(TOTAL, &DataInput::U64(7), 1);
+    assert_eq!(
+        tw.active_sketch().query(&DataInput::U64(7)),
+        1,
+        "a recycled window sketch must start empty; got a carried-over count"
+    );
+    assert!(
+        closed_after_flush >= (TOTAL / WINDOW) as usize,
+        "flush must close the active window"
+    );
+}
+
+/// `TumblingWindow<UnivMonQ>`: the same window bookkeeping, with UnivMon-Q's
+/// exact aggregates checked exactly and its estimates left to their own
+/// suite. What this test adds is that windowing, pooling and `clear()` do not
+/// corrupt the sketch.
+#[test]
+fn tumbling_univmon_q_windows_carry_exact_aggregates_through_rotation() {
+    const WINDOW: u64 = 500;
+    const TOTAL: u64 = 3_000;
+
+    let cfg = UnivMonQConfig {
+        levels: 6,
+        width: 1_024,
+        depth: 5,
+        candidates: 256,
+        ordered_samples: 512,
+        ..UnivMonQConfig::default()
+    };
+    let mut tw: TumblingWindow<UnivMonQ> = TumblingWindow::new(WINDOW, 16, cfg, 4);
+    let values: Vec<f64> = uniform_u64(TOTAL as usize, 100_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    for (t, v) in values.iter().enumerate() {
+        tw.insert(t as u64, &DataInput::F64(*v), 0);
+    }
+
+    assert_eq!(
+        tw.closed_count(),
+        (TOTAL / WINDOW - 1) as usize,
+        "closed window count"
+    );
+
+    // Count, min and max are maintained exactly on every window slice.
+    for (label, sketch, slice) in [
+        ("query_all", tw.query_all(), &values[..]),
+        (
+            "query_recent(1)",
+            tw.query_recent(1),
+            &values[(TOTAL - 2 * WINDOW) as usize..],
+        ),
+        (
+            "active_sketch",
+            tw.active_sketch().clone(),
+            &values[(TOTAL - WINDOW) as usize..],
+        ),
+    ] {
+        let truth = NumericTruth::new(slice.to_vec());
+        assert_eq!(
+            sketch.count() as usize,
+            slice.len(),
+            "{label}: UnivMon-Q count is maintained exactly"
+        );
+        assert_eq!(sketch.min(), Some(truth.min()), "{label}: exact minimum");
+        assert_eq!(sketch.max(), Some(truth.max()), "{label}: exact maximum");
+    }
+
+    // Rotation through the pool must hand back a cleared sketch.
+    tw.flush(TOTAL);
+    tw.insert(TOTAL, &DataInput::F64(42.0), 0);
+    let active = tw.active_sketch();
+    assert_eq!(
+        active.count(),
+        1,
+        "a recycled UnivMon-Q must start empty after clear()"
+    );
+    assert_eq!(active.min(), Some(42.0), "recycled sketch min");
+    assert_eq!(active.max(), Some(42.0), "recycled sketch max");
+}
+
+/// Every payload variant that owns a mergeable sketch must have a merge arm in
+/// `EHSketchList::merge`. A missing arm is invisible at runtime — `EHBucket::to_merge`
+/// discards the `Result` — so the histogram keeps counting bucket sizes while
+/// silently dropping the merged sketch's contents, and every query afterwards
+/// reads a single bucket. `ELASTIC` shipped without its arm and lost the whole
+/// window; this pins every variant so the next one cannot.
+#[test]
+fn every_eh_variant_can_merge_into_its_own_kind() {
+    use asap_sketchlib::EHSketchList;
+
+    let variants: Vec<(&str, EHSketchList)> = vec![
+        (
+            "CM",
+            EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::with_dimensions(3, 256)),
+        ),
+        (
+            "CS",
+            EHSketchList::CS(Count::<Vector2D<i32>, FastPath>::with_dimensions(3, 256)),
+        ),
+        ("COCO", EHSketchList::COCO(Coco::init_with_size(256, 4))),
+        (
+            "COUNTL2HH",
+            EHSketchList::COUNTL2HH(CountL2HH::with_dimensions(3, 256)),
+        ),
+        ("DDS", EHSketchList::DDS(DDSketch::new(0.01))),
+        (
+            "ELASTIC",
+            EHSketchList::ELASTIC(Elastic::init_with_length(256)),
+        ),
+        ("HLL", EHSketchList::HLL(HyperLogLog::<ErtlMLE>::new())),
+        (
+            "KLL",
+            EHSketchList::KLL(KLL::init_kll_with_seed(200, 0x5EED_0300)),
+        ),
+        (
+            "UNIVMON",
+            EHSketchList::UNIVMON(UnivMon::init_univmon(32, 3, 256, 4)),
+        ),
+        #[cfg(feature = "experimental")]
+        (
+            "UNIFORM",
+            EHSketchList::UNIFORM(asap_sketchlib::UniformSampling::with_seed(0.5, 7)),
+        ),
+    ];
+
+    for (name, proto) in variants {
+        let mut left = proto.clone();
+        let mut right = proto.clone();
+        // Feed each side something it can actually ingest, then merge.
+        for i in 0..64u64 {
+            left.insert(&DataInput::String(format!("k{i}")));
+            left.insert(&DataInput::F64(1.0 + i as f64));
+            right.insert(&DataInput::String(format!("k{}", i + 64)));
+            right.insert(&DataInput::F64(100.0 + i as f64));
+        }
+        assert!(
+            left.merge(&right).is_ok(),
+            "EHSketchList::{name} has no merge arm, so an ExponentialHistogram over it \
+             silently discards data on every bucket merge"
+        );
+    }
+}
+
+/// `UNIFORM` is the experimental reservoir payload: its window answers are
+/// retained-sample bookkeeping, not an estimate, so they are checked exactly.
+#[cfg(feature = "experimental")]
+#[test]
+fn eh_uniform_sampling_variant_reports_exact_retention_bookkeeping() {
+    use asap_sketchlib::UniformSampling;
+
+    const RATE: f64 = 0.1;
+    const SAMPLER_SEED: u64 = 0x5A_9101;
+    let values: Vec<f64> = uniform_u64(N, 1_000_000, STREAM_SEED)
+        .into_iter()
+        .map(|v| v as f64)
+        .collect();
+    let mut eh = ExponentialHistogram::new(
+        EH_K,
+        EH_WINDOW,
+        asap_sketchlib::EHSketchList::UNIFORM(UniformSampling::with_seed(RATE, SAMPLER_SEED)),
+    );
+    for (t, v) in values.iter().enumerate() {
+        eh.update(t as u64, &DataInput::F64(*v));
+    }
+    let (lo, hi) = full_span(&eh);
+    let merged = eh.query_interval_merge(lo, hi).expect("full span");
+
+    // `total_seen` is a maintained counter: exact over the merged span.
+    let seen = merged
+        .query(&DataInput::Str("total_seen"))
+        .expect("total_seen");
+    assert_eq!(
+        seen,
+        (hi - lo + 1) as f64,
+        "UniformSampling total_seen must equal the number of merged observations \
+         over [{lo}, {hi}]"
+    );
+
+    // Retained samples must be a subset of the window's observations and
+    // bounded by the rate's budget.
+    let retained = merged.query(&DataInput::Str("len")).expect("len") as usize;
+    assert!(
+        retained > 0 && retained as f64 <= seen,
+        "retained {retained} samples out of {seen} observed"
+    );
+    let observed: std::collections::HashSet<u64> =
+        (lo..=hi).map(|t| values[t as usize].to_bits()).collect();
+    for i in 0..retained {
+        let s = merged
+            .query(&DataInput::U64(i as u64))
+            .expect("sample index in range");
+        assert!(
+            observed.contains(&s.to_bits()),
+            "retained sample {s} was never observed in the merged window [{lo}, {hi}]"
+        );
+    }
+}

--- a/tests/msgpack_compat.rs
+++ b/tests/msgpack_compat.rs
@@ -98,7 +98,7 @@ fn hll_sketch_round_trip() {
 
 #[test]
 fn kll_sketch_round_trip() {
-    let mut s = KllSketch::new(200);
+    let mut s = KllSketch::with_seed(200, 0x5EED_0800);
     for i in 0..100 {
         s.update(i as f64);
     }
@@ -110,7 +110,7 @@ fn kll_sketch_round_trip() {
 
 #[test]
 fn hydra_kll_sketch_round_trip() {
-    let mut s = HydraKllSketch::new(2, 4, 200);
+    let mut s = HydraKllSketch::with_seed(2, 4, 200, 0x5EED_0900);
     s.update("a", 1.0);
     s.update("a", 2.0);
     s.update("b", 3.0);


### PR DESCRIPTION
Audits and completes the E2E suites, on the principle that **having a test ≠ having an accuracy test ≠ correctly verifying a theoretical guarantee**.

## The problem

Several suites sat in that gap:

| What it asserted | Why it verified little or nothing |
| --- | --- |
| Count Sketch against Count-Min's `ε·N`, `δ = e^-rows` | wrong family's bound; on a Zipf stream it is enormously looser than the one Count Sketch promises |
| `1.5 * bound` (CS median, portable CS) | an undeclared 50% widening is not that bound |
| DDSketch at `alpha * 1.05` | accepts 5% past the advertised guarantee — and unnecessary, since the measured worst case is *exactly* `alpha` |
| KLL at a hard-coded 0.02/0.03 | untied to `k`: passes identically at k=64 and k=800 |
| KMV "4 standard errors" asserting 4% at k=4096 | `4/√4095 = 6.25%`; the comment and the number disagreed |
| HLL at a flat 2%/3% for every precision | 4.9σ at p16, 1.2σ at p12 — and held HIP to Classic's constant |
| Nitro at ±5% / ±10% | sampling RNG drawn from the OS, so the band was re-rolled every run |
| Regular/fast path *equality* on 4 hand-picked keys | the two paths use different hash functions; the equality was coincidence |
| `CountL2HH::get_l2_sqr` treated as exact | it is the AMS row-median estimator, with a real bound |
| DDSketch inside the *rank* battery | DDSketch has no rank guarantee |

## The approach

`tests/common/specs.rs` carries **one error model per metric**, each exposing the bound formula evaluated at the instance's own parameters, the per-check failure probability its theorem allows, and an acceptance rule:

| Family | Metric | Formula | Confidence |
| --- | --- | --- | --- |
| Count-Min | one-sided additive | `est ≥ f` always; `e·(N−f)/w` | `e^-d` |
| Count Sketch | two-sided L2, rank-independent | `√(κ/w)·‖f₋ᵢ‖₂`, κ=3 | `P[Bin(d,⅓) ≥ ⌈d/2⌉]` |
| F2 (AMS row-sum) | relative | `√(2κ/w)` | same median tail |
| KLL | **rank** interval | `ε(k) = 2.446/k^0.9433` | 0.01/query |
| DDSketch | **relative value** vs exact order statistic | `α + 8·ε_f64·(1+\|ln v\|)` | deterministic — 0 tolerated |
| HLL Classic / ErtlMLE | cardinality RSE | `z·1.04/√m` | z=4 → 6.3e-5 |
| HLL HIP | cardinality RSE | `z·√(ln2/m)` | z=4 |
| KMV | exact for n≤k, else RSE | `z/√(k−1)` | z=4 |
| Nitro | binomial sampling | `z·√(f(1−p)/p)` | z=4 |
| Octo promotion | deterministic residual | `ref − k·τ ≤ octo ≤ ref` | — |

`Tally` applies a binomial tail at a fixed `TEST_LEVEL = 1e-6` **decided before the run**, so the tolerated violation count cannot be tuned to whatever the run produced. Every stream seed and sketch seed is fixed and printed on failure.

Keeping the specs apart is the point: there is deliberately no shared `QuantileSpec` that KLL and DDSketch both use, because a correct KLL can return a value 100× off on a heavy-tailed stream and a correct DDSketch has no rank guarantee at all.

KLL's constant is the published Apache DataSketches contract at 99% confidence. It holds with room to spare — across uniform, normal, Zipf, tie-dense, monotonic and outside-in orderings the worst observed rank error is **78% of the bound**, and it tracks `k`.

## Coverage

The public instance matrix is now enumerated rather than sampled: all **20** CountMin and **18** Count (storage × hashing path), **12** CMSHeap and **12** CSHeap, all **14** `NumericalValue` types through `KLL<T>` / `KLLDynamic<T>` / `DDSketch::add<T>`, all **10** `EHSketchList` variants, `TumblingWindow<FoldCS>` and `<UnivMonQ>`, every `EnsembleSketch` variant against a standalone reference, `NitroBatch` × 3 targets × 4 rates, `UnivMonQ`'s config surface, the `CountTopK` Octo plan plus real top-k recall for `CmTopK`, `EHUnivOptimized`'s sketch tier, and the portable `CountMinSketchWithHeap` / `CountSketchWithHeap` / `KllSketch`.

Two cross-path assumptions turned out to be **wrong** and are corrected rather than asserted — `RegularPath` and `FastPath` are different hash functions, and a `HashSketchEnsemble` composes by hash *layout*, not by literal dimensions.

## Production defects

**Fixed — `EHSketchList::merge` had no `ELASTIC` arm.** The catch-all refused two Elastic payloads and `EHBucket::to_merge` drops that `Result`, so the histogram kept summing bucket sizes while retaining only one bucket's counters. Every interval query read **0** for flows whose true counts were in the thousands.

**Pinned, not fixed** — each with an upper *and* a lower guard, so fixing them fails the test rather than leaving a stale claim:

- **HLL Classic's cliff at the linear-counting switchover.** At `n ≈ 2.5m` the RSE reaches **6.3×** the asymptotic `1.04/√m` at p16. The old checkpoint grid stepped over the band at every precision. Removing it means HLL++ bias correction — changes shipped estimates and the golden bytes.
- **`EHUnivOptimized`'s sketch tier cannot report cardinality.** Promotion fires at `layer_size·rows·cols/2` distinct keys while UnivMon needs ~`log2(distinct)` layers to recover F0, and raising `layer_size` raises the threshold in lockstep — no tuning satisfies both. It reports **0–11** for windows holding 16k–40k distinct.

## Honesty about what is *not* verified

Four tests are named `*_stays_within_the_documented_empirical_band`, with the configuration, seed and measured value recorded beside them. UnivMon-Q's ordered queries are a partial case: `E_H` and `m_R` are not reachable from outside the crate, so the full bound **cannot** be verified — the test asserts the adaptive gate's premise first, then checks the diffuse regime where the heavy set is provably empty.

`docs/e2e_coverage_matrix.md` is the new authority on instance → test → bound → theorem/empirical/structural, and lists what remains uncovered and why — including 8 `CMSHeap`/`CSHeap` `i128` instances that have `Default` impls but bound their insert paths on `Counter: Into<i64>`, so they are constructible but not insertable.

## API additions

Four seeded constructors, for the types whose only randomness was wall-clock or OS-drawn (an accuracy assertion over them could not reproduce a failure): `KLLDynamic::{init_with_seed, init_kll_with_seed}`, `NitroBatch::{with_target_and_seed, init_nitro_with_seed}`, `KllSketch::with_seed`, `HydraKllSketch::with_seed`. Wire formats unchanged.

## Verification

Both workflows' exact commands, all green:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked` — 971 unit + 21 doctests + all E2E, **0 failed**
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked`
- vendored proto: untouched, no drift

Runtime was kept in check: the full matrix runs in ~4 min unoptimised. Stream sizes in the slowest suites were trimmed, which narrows nothing — every bound is computed from exact ground truth, not from the stream length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aji13qTrcVZLkJBL7cspPQ
