### PR TITLE
fix(hll): drop the 32-bit large-range correction from the Classic estimator

### DIFF
--- a/src/message_pack_format/portable/hll.rs
+++ b/src/message_pack_format/portable/hll.rs
@@ -352,7 +352,9 @@ impl HllSketch {
         }
     }
 
-    /// Estimate cardinality (Classic HLL estimator with small/large-range corrections).
+    /// Estimate cardinality (Classic HLL estimator with the small-range
+    /// correction). Ranks are drawn from a 64-bit hash, so the estimate needs
+    /// no large-range correction.
     pub fn estimate(&self) -> f64 {
         let m = self.registers.len() as f64;
         if m == 0.0 {
@@ -373,9 +375,6 @@ impl HllSketch {
 
         if est <= m * 5.0 / 2.0 && zero_count != 0 {
             est = m * (m / zero_count as f64).ln();
-        } else if est > 143_165_576.533 {
-            let aux = i32::MAX as f64;
-            est = -aux * (1.0 - est / aux).ln();
         }
         est
     }
@@ -621,6 +620,26 @@ impl MessagePackCodec for HllSketchDelta {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Ranks are drawn from a 64-bit hash, so a register state whose estimate
+    /// runs past the 32-bit range must still follow the HyperLogLog formula
+    /// rather than saturate or turn into a NaN.
+    #[test]
+    fn estimate_holds_past_the_32_bit_range() {
+        for rank in [12u8, 16, 18, 20] {
+            let mut sketch = HllSketch::new(HllVariant::Regular, 14);
+            sketch.registers.fill(rank);
+            let m = sketch.registers.len() as f64;
+            let alpha_m = 0.7213 / (1.0 + 1.079 / m);
+            let expected = alpha_m * m * 2f64.powi(rank as i32);
+            let estimate = sketch.estimate();
+            let error = (estimate - expected).abs() / expected;
+            assert!(
+                error <= 1e-9,
+                "rank {rank} estimate {estimate} deviates from {expected} by {error:.6}"
+            );
+        }
+    }
 
     #[test]
     fn msgpack_delta_against_empty_round_trips() {

--- a/src/sketches/hll.rs
+++ b/src/sketches/hll.rs
@@ -206,7 +206,9 @@ impl<Registers: HllRegisterStorage, H: SketchHasher> HyperLogLogImpl<Classic, Re
         1.0 / z
     }
 
-    /// Returns the estimated cardinality using the classic HyperLogLog algorithm with small/large range corrections.
+    /// Returns the estimated cardinality using the classic HyperLogLog
+    /// algorithm with the small-range correction. Ranks are drawn from a
+    /// 64-bit hash, so the estimate needs no large-range correction.
     pub fn estimate(&self) -> usize {
         let m = Registers::NUM_REGISTERS as f64;
         let alpha_m = 0.7213 / (1.0 + 1.079 / m);
@@ -221,9 +223,6 @@ impl<Registers: HllRegisterStorage, H: SketchHasher> HyperLogLogImpl<Classic, Re
             if zero_count != 0 {
                 est = m * (m / zero_count as f64).ln();
             }
-        } else if est > 143165576.533 {
-            let correction_aux = i32::MAX as f64;
-            est = 1.0 * -correction_aux * (1.0 - est / correction_aux).ln();
         }
         est as usize
     }
@@ -609,6 +608,40 @@ mod tests {
     #[test]
     fn hll_ertl_p12_merge_within_two_percent() {
         assert_merge_accuracy_within::<HyperLogLogP12<ErtlMLE>>("HllErtlP12", P12_ERROR_TOLERANCE);
+    }
+
+    /// Ranks are drawn from a 64-bit hash, so a register state whose estimate
+    /// runs past the 32-bit range must still follow the HyperLogLog formula
+    /// rather than saturate or collapse to zero.
+    #[test]
+    fn classic_estimate_holds_past_the_32_bit_range() {
+        const REGISTER_BITS: usize = HllBucketList::REGISTER_BITS;
+        let m = HllBucketList::NUM_REGISTERS as f64;
+        let alpha_m = 0.7213 / (1.0 + 1.079 / m);
+
+        // A hash selecting `bucket` whose leading run gives every register the
+        // same rank, so the estimate is `alpha_m * m * 2^rank` in closed form.
+        for rank in [12u32, 16, 18, 20] {
+            let mut hll = HyperLogLog::<Classic>::default();
+            for bucket in 0..HllBucketList::NUM_REGISTERS as u64 {
+                let hashed = (bucket << REGISTER_BITS) | (1 << (REGISTER_BITS - rank as usize));
+                HyperLogLog::<Classic>::insert_with_hash(&mut hll, hashed);
+            }
+            assert!(
+                hll.registers_as_slice().iter().all(|&r| r == rank as u8),
+                "rank {rank} state was not built: got {:?}",
+                &hll.registers_as_slice()[..4]
+            );
+
+            let expected = alpha_m * m * 2f64.powi(rank as i32);
+            let estimate = hll.estimate() as f64;
+            // The only slack is `estimate`'s truncation to a whole count.
+            let error = (estimate - expected).abs() / expected;
+            assert!(
+                error <= 1e-6,
+                "rank {rank} estimate {estimate} deviates from {expected} by {error:.6}"
+            );
+        }
     }
 
     // insert 10 values and check corresponding counter is updated


### PR DESCRIPTION
## What

Both Classic HyperLogLog estimators — `sketches::hll::HyperLogLogImpl<Classic, ..>::estimate` and the portable `message_pack_format::portable::HllSketch::estimate` — rank their registers over a 64-bit hash, then folded the raw estimate through a large-range correction scaled to `i32::MAX`:

```rust
} else if est > 143165576.533 {
    let correction_aux = i32::MAX as f64;
    est = 1.0 * -correction_aux * (1.0 - est / correction_aux).ln();
}
```

Past an estimate of ~1.43e8 the correction distorts the result. Past ~2.15e9 the argument to `ln` turns negative: the native estimator produces NaN and `NaN as usize` saturates to **0**, the portable one returns NaN.

The correction is meaningless at a 64-bit rank width, so this removes it from both. The small-range correction is untouched.

## Test

One regression test per estimator builds a uniform-rank register state and holds the result to the closed form `alpha_m * m * 2^rank` for ranks 12, 16, 18 and 20. Ranks 18 and 20 land past the old threshold and returned 0 / NaN before this change.

## Verified locally

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked` (all suites pass)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked`
- vendored proto regeneration shows no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgfN2HVmixAX2U4rQJgPGx