### PR TITLE
fix(ddsketch): carry the running scalars through the derived serde form

### DIFF
--- a/src/sketch_framework/eh_sketch_list.rs
+++ b/src/sketch_framework/eh_sketch_list.rs
@@ -326,6 +326,33 @@ mod tests {
         assert!((10.0..=30.0).contains(&q50), "unexpected q50 {q50}");
     }
 
+    /// `EHSketchList` derives its serde form from the variants it holds, so a
+    /// round trip of a nested DDSketch must carry the sketch's whole state.
+    #[test]
+    fn nested_ddsketch_survives_a_serde_round_trip() {
+        let mut dd = EHSketchList::DDS(DDSketch::new(0.01));
+        for v in [10.0f64, 20.0, 30.0, 40.0] {
+            dd.insert(&DataInput::F64(v));
+        }
+        let before = match &dd {
+            EHSketchList::DDS(inner) => (inner.get_count(), inner.sum(), inner.min(), inner.max()),
+            _ => panic!("expected the DDSketch variant"),
+        };
+
+        let bytes = rmp_serde::to_vec(&dd).expect("encode");
+        let restored: EHSketchList = rmp_serde::from_slice(&bytes).expect("decode");
+        let after = match &restored {
+            EHSketchList::DDS(inner) => (inner.get_count(), inner.sum(), inner.min(), inner.max()),
+            _ => panic!("expected the DDSketch variant"),
+        };
+        assert_eq!(after, before, "the nested sketch lost its running state");
+
+        let q50 = restored
+            .query(&DataInput::F64(0.5))
+            .expect("query the restored DDSketch");
+        assert!((10.0..=40.0).contains(&q50), "unexpected q50 {q50}");
+    }
+
     #[test]
     fn supports_norm_whitelist_is_enforced() {
         let cm = EHSketchList::CM(CountMin::<Vector2D<i32>, FastPath>::default());

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -122,24 +122,66 @@ impl Buckets {
 /// `count` by summing the buckets.
 ///
 /// The derived `Serialize` / `Deserialize` is a separate, Rust-internal form
-/// used where a `DDSketch` is nested in another type; it skips the four running
-/// scalars.
+/// used where a `DDSketch` is nested in another type. It carries the same state
+/// as the ASAPv1 payload — `alpha`, the bucket store, and `sum` / `min` / `max`
+/// — and rebuilds the index mapping and `count` on the way in, refusing a state
+/// the ASAPv1 decoder would refuse.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(try_from = "DDSketchState")]
 pub struct DDSketch {
     alpha: f64,
+    #[serde(skip)]
     gamma: f64,
+    #[serde(skip)]
     log_gamma: f64,
+    #[serde(skip)]
     inv_log_gamma: f64,
 
     store: Buckets,
     #[serde(skip)]
     count: u64,
-    #[serde(skip)]
     sum: f64,
-    #[serde(skip)]
     min: f64,
-    #[serde(skip)]
     max: f64,
+}
+
+/// The fields a serialized [`DDSketch`] carries, in the order it emits them.
+/// `gamma` / `log_gamma` / `inv_log_gamma` follow from `alpha` and `count` is
+/// the sum of the buckets, so none of the four reaches the wire.
+#[derive(Deserialize)]
+struct DDSketchState {
+    alpha: f64,
+    store: Buckets,
+    sum: f64,
+    min: f64,
+    max: f64,
+}
+
+impl TryFrom<DDSketchState> for DDSketch {
+    type Error = String;
+
+    fn try_from(state: DDSketchState) -> Result<Self, Self::Error> {
+        wire::check_alpha(state.alpha)?;
+        let counts = state.store.counts.as_slice();
+        wire::check_store_span(state.store.offset, counts.len())?;
+        let count = wire::total_count(counts)
+            .ok_or_else(|| "DDSketch bucket counts overflow the total sample count".to_string())?;
+        wire::check_scalars(count, state.sum, state.min, state.max)?;
+
+        let gamma = (1.0 + state.alpha) / (1.0 - state.alpha);
+        let log_gamma = gamma.ln();
+        Ok(Self {
+            alpha: state.alpha,
+            gamma,
+            log_gamma,
+            inv_log_gamma: 1.0 / log_gamma,
+            store: state.store,
+            count,
+            sum: state.sum,
+            min: state.min,
+            max: state.max,
+        })
+    }
 }
 
 /// Smallest and largest finite positive values whose bucket index is
@@ -647,5 +689,116 @@ mod tests {
         // A large-but-trackable value is still recorded.
         d.add(&(max_indexable / 2.0));
         assert_eq!(d.get_count(), count_before + 1);
+    }
+
+    fn populated_sketch() -> DDSketch {
+        let mut sketch = DDSketch::new(0.01);
+        for v in [0.25f64, 1.0, 2.0, 3.0, 10.0, 50.0, 100.0, 1000.0] {
+            sketch.add(&v);
+        }
+        sketch
+    }
+
+    /// The derived serde form carries every scalar the buckets do not
+    /// determine, so a round trip continues the run rather than resetting it.
+    #[test]
+    fn serde_round_trip_keeps_the_running_scalars() {
+        let sketch = populated_sketch();
+        let bytes = rmp_serde::to_vec(&sketch).expect("encode");
+        let restored: DDSketch = rmp_serde::from_slice(&bytes).expect("decode");
+
+        assert_eq!(restored.get_count(), sketch.get_count());
+        assert_eq!(restored.sum(), sketch.sum());
+        assert_eq!(restored.min(), sketch.min());
+        assert_eq!(restored.max(), sketch.max());
+        assert_eq!(restored.alpha(), sketch.alpha());
+        assert_eq!(restored.store_counts(), sketch.store_counts());
+        assert_eq!(restored.store_offset(), sketch.store_offset());
+        for q in [0.0, 0.25, 0.5, 0.9, 1.0] {
+            assert_eq!(
+                restored.get_value_at_quantile(q),
+                sketch.get_value_at_quantile(q),
+                "quantile {q} moved across the round trip"
+            );
+        }
+    }
+
+    /// A decoded sketch keeps ingesting on top of the state it came back with.
+    #[test]
+    fn serde_round_trip_leaves_the_sketch_usable() {
+        let sketch = populated_sketch();
+        let bytes = rmp_serde::to_vec(&sketch).expect("encode");
+        let mut restored: DDSketch = rmp_serde::from_slice(&bytes).expect("decode");
+
+        restored.add(&5.0f64);
+        assert_eq!(restored.get_count(), sketch.get_count() + 1);
+        assert_eq!(restored.sum(), sketch.sum() + 5.0);
+        assert_eq!(
+            restored.store_counts().iter().sum::<u64>(),
+            restored.get_count(),
+            "the recovered count drifted from the buckets"
+        );
+    }
+
+    /// The scalars are checked against the store the same way the ASAPv1
+    /// decoder checks them: a populated store with an empty sketch's scalars
+    /// is refused rather than decoded into an inconsistent sketch.
+    #[test]
+    fn serde_refuses_scalars_that_disagree_with_the_store() {
+        #[derive(Serialize)]
+        struct CraftedState {
+            alpha: f64,
+            store: Buckets,
+            sum: f64,
+            min: f64,
+            max: f64,
+        }
+
+        let crafted = CraftedState {
+            alpha: 0.01,
+            store: Buckets {
+                counts: Vector1D::from_vec(vec![1u64, 2]),
+                offset: -3,
+            },
+            sum: 0.0,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+        };
+        let bytes = rmp_serde::to_vec(&crafted).expect("encode crafted state");
+        let err = rmp_serde::from_slice::<DDSketch>(&bytes)
+            .expect_err("scalars disagreeing with the store must be refused");
+        assert!(
+            err.to_string().contains("DDSketch scalars"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// An alpha outside `(0, 1)` gives a meaningless index mapping, so it is
+    /// refused on the way in rather than at the first query.
+    #[test]
+    fn serde_refuses_an_out_of_range_alpha() {
+        #[derive(Serialize)]
+        struct CraftedState {
+            alpha: f64,
+            store: Buckets,
+            sum: f64,
+            min: f64,
+            max: f64,
+        }
+
+        let crafted = CraftedState {
+            alpha: 1.5,
+            store: Buckets {
+                counts: Vector1D::from_vec(Vec::new()),
+                offset: 0,
+            },
+            sum: 0.0,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+        };
+        let bytes = rmp_serde::to_vec(&crafted).expect("encode crafted state");
+        let err = rmp_serde::from_slice::<DDSketch>(&bytes)
+            .expect_err("an out-of-range alpha must be refused");
+        assert!(err.to_string().contains("alpha"), "unexpected error: {err}");
     }
 }

--- a/src/sketches/ddsketch/wire.rs
+++ b/src/sketches/ddsketch/wire.rs
@@ -79,7 +79,7 @@ struct DdPayload {
 /// Checks a relative accuracy against the domain [`DDSketch::new`] accepts:
 /// finite and strictly inside `(0, 1)`. Outside it the `gamma` derivation is
 /// non-positive or infinite and every bucket index is meaningless.
-fn check_alpha(alpha: f64) -> Result<(), String> {
+pub(super) fn check_alpha(alpha: f64) -> Result<(), String> {
     if !alpha.is_finite() || alpha <= 0.0 || alpha >= 1.0 {
         return Err(format!("DDSketch alpha {alpha} is not in (0, 1)"));
     }
@@ -89,7 +89,7 @@ fn check_alpha(alpha: f64) -> Result<(), String> {
 /// Checks a bucket store's index span: an empty store sits at offset `0`, and
 /// a populated one's highest index `offset + len - 1` is representable as an
 /// `i32`. Applied before the store is rebuilt from the declared offset.
-fn check_store_span(offset: i32, len: usize) -> Result<(), String> {
+pub(super) fn check_store_span(offset: i32, len: usize) -> Result<(), String> {
     if len == 0 {
         if offset != 0 {
             return Err(format!(
@@ -108,7 +108,7 @@ fn check_store_span(offset: i32, len: usize) -> Result<(), String> {
 }
 
 /// Total sample count, the checked sum of every bucket. `None` on overflow.
-fn total_count(counts: &[u64]) -> Option<u64> {
+pub(super) fn total_count(counts: &[u64]) -> Option<u64> {
     counts.iter().try_fold(0u64, |acc, &c| acc.checked_add(c))
 }
 
@@ -116,7 +116,7 @@ fn total_count(counts: &[u64]) -> Option<u64> {
 /// carries `0.0` / `+inf` / `-inf`, the state [`DDSketch::new`] starts in. A
 /// populated one carries finite scalars with `0 < min <= max`, and `sum >= min`
 /// since every ingested value is at least `min`.
-fn check_scalars(count: u64, sum: f64, min: f64, max: f64) -> Result<(), String> {
+pub(super) fn check_scalars(count: u64, sum: f64, min: f64, max: f64) -> Result<(), String> {
     if count == 0 {
         if sum == 0.0 && min == f64::INFINITY && max == f64::NEG_INFINITY {
             return Ok(());


### PR DESCRIPTION
## What

`DDSketch` marked `count`, `sum`, `min` and `max` as `#[serde(skip)]`, and nothing rebuilt them on the way in:

```rust
let restored: DDSketch = rmp_serde::from_slice(&rmp_serde::to_vec(&original)?)?;
// original.get_count() == 2, restored.get_count() == 0
```

The buckets came back intact while every running scalar was reset to its empty-sketch value, so the decoded sketch was internally inconsistent and any further `add` or `merge` continued from there. This is not only a nested-in-theory path: `EHSketchList` derives its serde form from the variants it holds, so an `EHSketchList::DDS` round trip lost the same state. `docs/features.md` lists DDSketch under serde support, which is now true rather than aspirational.

## How

The derived form now carries exactly what the ASAPv1 payload carries — `alpha`, the bucket store, and the three scalars the buckets do not determine. Per the spec's **Q-DERIVED** rule, state a decoder can recompute is not carried: `gamma` / `log_gamma` / `inv_log_gamma` follow from `alpha`, and `count` is the sum of the buckets, so all four are rebuilt in a `#[serde(try_from)]` shim.

That shim reuses the ASAPv1 decoder's own checks (`check_alpha`, `check_store_span`, `total_count`, `check_scalars`, promoted to `pub(super)`), so the two paths cannot drift: a state the wire decoder refuses is a deserialization error here too, rather than a silently inconsistent sketch.

The ASAPv1 envelope is untouched — no wire-format change.

## Test

- `serde_round_trip_keeps_the_running_scalars` — count, sum, min, max, store and every quantile survive
- `serde_round_trip_leaves_the_sketch_usable` — a decoded sketch keeps ingesting, count stays equal to the bucket sum
- `nested_ddsketch_survives_a_serde_round_trip` — the `EHSketchList::DDS` path
- `serde_refuses_scalars_that_disagree_with_the_store` / `serde_refuses_an_out_of_range_alpha`

## Verified locally

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked` (all suites pass)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked`
- vendored proto regeneration shows no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgfN2HVmixAX2U4rQJgPGx