### PR TITLE
docs: drop dead comments, PR-history narrative and issue references

### DIFF
--- a/src/common/hashspec.rs
+++ b/src/common/hashspec.rs
@@ -75,10 +75,10 @@ pub const CANONICAL_HASH_SEED: usize = 5;
 /// derivation strategy so consumers can validate hash compatibility
 /// before merging.
 ///
-/// `asap_sketchlib`'s wire-format CountSketch (and the upcoming CMS
-/// byte-parity fix) construct a `HashSpec::default()` and feed it to
-/// [`derive_index`] / [`derive_sign`] on the hot path. The default
-/// matches Go's `portableHashSpec()`:
+/// `asap_sketchlib`'s wire-format CountSketch constructs a
+/// `HashSpec::default()` and feeds it to [`derive_index`] /
+/// [`derive_sign`] on the hot path. The default matches Go's
+/// `portableHashSpec()`:
 ///
 /// - `seed_list = CANONICAL_HASH_SEED_TABLE`
 /// - `canonical_seed_index = CANONICAL_HASH_SEED` (= 5)

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -21,7 +21,7 @@
 pub mod hash;
 /// Cross-language hash spec (`HashSpec`/`derive_index`/`derive_sign`)
 /// shared by matrix-backed sketches that need byte parity with
-/// `sketchlib-go` (CountSketch, the upcoming CMS PR, …).
+/// `sketchlib-go`.
 pub mod hashspec;
 pub mod heap;
 pub mod input;

--- a/src/message_pack_format/portable/countminsketch.rs
+++ b/src/message_pack_format/portable/countminsketch.rs
@@ -13,11 +13,9 @@ use crate::{DataInput, FastPath, Vector2D};
 // `CountMinSketch` and `CountMinDelta` below are the public-field,
 // proto-decode-friendly types consumed by the ASAP query engine
 // accumulators, backed by `asap_sketchlib`'s in-tree CountMin. The
-// high-throughput in-process variant above (`CountMin`) keeps its
-// original design.
+// high-throughput in-process variant is
+// `crate::sketches::countminsketch::CountMin`, which keeps its own design.
 // =====================================================================
-
-// (de-duplicated) use serde::{Deserialize, Serialize};
 
 // ----- asap_sketchlib-backed Count-Min helpers -----
 // Used below by `CountMinSketch`. Lives in this file so the wire-format
@@ -775,7 +773,7 @@ mod tests {
     /// Any drift in [`CountMinSketch::update`]'s hash → column-index
     /// derivation breaks this test cell-for-cell; that is the contract
     /// `cross_language_parity::cms_byte_parity_with_go` in ASAPCollector
-    /// relies on. Closes part of ProjectASAP/ASAPCollector#243.
+    /// relies on.
     #[test]
     fn test_update_then_envelope_matches_sketchlib_go_bytes() {
         use crate::proto::sketchlib::{

--- a/src/message_pack_format/portable/countsketch.rs
+++ b/src/message_pack_format/portable/countsketch.rs
@@ -10,8 +10,8 @@ use crate::message_pack_format::{Error as MsgPackError, MessagePackCodec};
 //
 // `CountSketch` and `CountSketchDelta` below are the public-field,
 // proto-decode-friendly types consumed by the ASAP query engine
-// accumulators. The high-throughput in-process variant above
-// (`Count`) keeps its original design.
+// accumulators. The high-throughput in-process variant is
+// `crate::sketches::countsketch::Count`, which keeps its own design.
 // =====================================================================
 
 // Count Sketch (a.k.a. Count-Min-style signed-counter sketch) —
@@ -22,16 +22,12 @@ use crate::message_pack_format::{Error as MsgPackError, MessagePackCodec};
 // format that DataCollector's `countsketchprocessor` emits via the
 // modified OTLP `Metric.data = CountSketch{…}` variant.
 //
-// This is the minimal surface needed for PR C-CountSketch in the
-// modified-OTLP hot path: construct from a decoded proto state, merge
+// The surface is: construct from a decoded proto state, merge
 // element-wise with another sketch, emit the matrix for queries and
 // serialization. The richer query semantics of Count Sketch (median-
-// of-estimators heavy-hitter tracking, `TopKState` integration, etc.)
-// are intentionally deferred to a follow-up — the wire format already
-// carries the matrix losslessly, so the merge/store round-trip works
-// with just a matrix today.
-
-// (de-duplicated) use serde::{Deserialize, Serialize};
+// of-estimators heavy-hitter tracking, `TopKState` integration) are not
+// implemented here — the wire format carries the matrix losslessly, so
+// the merge/store round-trip works with just a matrix.
 
 /// Default Top-K capacity. Mirrors sketchlib-go `TOPK_SIZE = 100`.
 pub const COUNT_SKETCH_TOPK_CAPACITY: usize = 100;
@@ -772,8 +768,7 @@ mod tests {
     /// Any drift in [`CountSketch::update`]'s hash → (col, sign)
     /// derivation breaks this test cell-for-cell; that is the contract
     /// `cross_language_parity::countsketch_byte_parity_with_go` in
-    /// ASAPCollector relies on. Closes part of
-    /// ProjectASAP/ASAPCollector#243.
+    /// ASAPCollector relies on.
     #[test]
     fn test_update_then_envelope_matches_sketchlib_go_bytes() {
         use crate::proto::sketchlib::{

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -24,15 +24,14 @@ pub const MAX_APPLY_DELTA_SPAN_BUCKETS: i64 = 1 << 22;
 //
 // `DdSketch` and `DdSketchDelta` below are the public-field,
 // proto-decode-friendly types consumed by the query-engine
-// accumulators. The high-throughput in-process variant above
-// (`DDSketch`) keeps its original design.
+// accumulators. The high-throughput in-process variant is
+// `crate::sketches::ddsketch::DDSketch`, which keeps its own design.
 // =====================================================================
 
 // DDSketch — log-bucketed quantile sketch, mergeable by store-index alignment.
 //
-// Parallel to `count_sketch::CountSketch`: the minimum viable surface
-// needed for the modified-OTLP `Metric.data = DDSketch{…}` hot path
-// (PR C-CountSketch follow-up). Holds the bucket counts, their
+// Parallel to `count_sketch::CountSketch`, for the modified-OTLP
+// `Metric.data = DDSketch{…}` hot path. Holds the bucket counts, their
 // absolute-index base offset, and the aggregate `{count, sum, min, max}`.
 //
 // Merge semantics: two sketches with the same relative-accuracy
@@ -42,11 +41,9 @@ pub const MAX_APPLY_DELTA_SPAN_BUCKETS: i64 = 1 << 22;
 //
 // The wire format is the protobuf-encoded
 // `asap_sketchlib::proto::sketchlib::DDSketchState`. Quantile
-// estimation against stored data is intentionally deferred — queries
-// currently return a placeholder error and fall through to the
-// exact-backend fallback.
-
-// (de-duplicated) use serde::{Deserialize, Serialize};
+// estimation against stored data is not implemented here: queries
+// return a placeholder error and fall through to the exact-backend
+// fallback.
 
 /// Sparse delta between two consecutive DDSketch snapshots — the
 /// input shape for [`DdSketch::apply_delta`]. Mirrors the
@@ -434,9 +431,9 @@ impl DdSketch {
         let gamma = (1.0 + self.alpha) / (1.0 - self.alpha);
         let ln_gamma = gamma.ln();
         // Reject finite-but-extreme values whose bucket index would be
-        // unrepresentable or force an arbitrarily distant allocation
-        // (asap_sketchlib#70 item 4). Uses the SHARED bounds helper so core
-        // and portable can never drift algebraically.
+        // unrepresentable or force an arbitrarily distant allocation. Uses
+        // the SHARED bounds helper so core and portable can never drift
+        // algebraically.
         let (min_v, max_v) = crate::sketches::ddsketch::ddsketch_indexable_bounds(self.alpha);
         if value < min_v || value > max_v {
             return;
@@ -506,7 +503,7 @@ impl DdSketch {
                 // Representative: lower edge γ^k scaled by (1+α) — matches the
                 // core DDSketch and DataDog's logarithmic_mapping.go. The old
                 // log-midpoint γ^(k+0.5) gave edge error √γ−1 > α, silently
-                // violating the α guarantee near a bucket edge (#70/#73).
+                // violating the α guarantee near a bucket edge.
                 return Some(gamma.powf(k as f64) * (1.0 + self.alpha));
             }
         }
@@ -794,11 +791,9 @@ mod tests {
         );
     }
 
-    /// Core accuracy claim for PRs #60-#63 end-to-end: building a
-    /// sketch via `base + apply_delta()` produces quantile estimates
-    /// within DDSketch's α bound of the ground-truth full-sketch
-    /// path. If this fails, the paper's delta-reconstitution story
-    /// is broken.
+    /// Building a sketch via `base + apply_delta()` produces quantile
+    /// estimates within DDSketch's α bound of the ground-truth
+    /// full-sketch path.
     #[test]
     fn test_delta_chain_preserves_quantile_accuracy() {
         let alpha = 0.01;

--- a/src/sketch_framework/tumbling.rs
+++ b/src/sketch_framework/tumbling.rs
@@ -1221,7 +1221,7 @@ mod tests {
         assert!(p50 < p90, "p50 ({p50:.1}) should be < p90 ({p90:.1})");
     }
 
-    // -- Seeded determinism (issue #77) ---------------------------------------
+    // -- Seeded determinism ---------------------------------------------------
 
     #[test]
     fn kll_tumbling_seeded_is_byte_identical_across_instances() {

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -190,8 +190,7 @@ impl TryFrom<DDSketchState> for DDSketch {
 /// `minIndexableValue`/`maxIndexableValue`. Values outside this range are
 /// dropped rather than mapped to an arbitrarily distant bucket index — that
 /// guards the dense bucket store against a single finite-but-extreme outlier
-/// forcing an allocation spanning the whole index gap (asap_sketchlib#70
-/// item 4 / sketchlib-go#72).
+/// forcing an allocation spanning the whole index gap.
 ///
 /// Single source of truth shared by core `DDSketch`, the portable wire twin,
 /// and tests, so the two implementations cannot drift algebraically again.
@@ -236,9 +235,8 @@ impl DDSketch {
     /// Values outside `[min_indexable_value, max_indexable_value]` are also
     /// dropped rather than mapped to an arbitrarily distant bucket index — that
     /// guards the dense store against a single finite-but-extreme outlier
-    /// forcing an allocation spanning the whole index gap (asap_sketchlib#70
-    /// item 4 / sketchlib-go#72). Dropped silently, like the non-positive case,
-    /// since `add` has no error channel.
+    /// forcing an allocation spanning the whole index gap. Dropped silently,
+    /// like the non-positive case, since `add` has no error channel.
     #[inline(always)]
     pub fn add<T: NumericalValue>(&mut self, val: &T) {
         let v = val.to_f64();
@@ -406,10 +404,9 @@ impl DDSketch {
     ///
     /// This is a REAL runtime check, not a `debug_assert!` — the previous
     /// assert was compiled out in release builds, so a release-mode
-    /// mismatched merge corrupted results with no signal at all
-    /// (asap_sketchlib#70 item 2). DataDog's `MergeWith` and sketchlib-go's Go
-    /// `Merge` both return an error here; the portable `DdSketch::merge` in this
-    /// same crate already does too.
+    /// mismatched merge corrupted results with no signal at all. DataDog's
+    /// `MergeWith` and sketchlib-go's Go `Merge` both return an error here;
+    /// the portable `DdSketch::merge` in this same crate already does too.
     pub fn merge(&mut self, other: &DDSketch) -> Result<(), String> {
         if (self.alpha - other.alpha).abs() >= 1e-12 || (self.gamma - other.gamma).abs() >= 1e-12 {
             return Err(format!(
@@ -457,7 +454,7 @@ impl DDSketch {
     /// RelativeAccuracy())`. This makes the relative error EXACTLY α at both
     /// bucket edges — the log-midpoint γ^(k+0.5) used previously gave edge error
     /// √γ−1 (≈ α + α²/2 > α), silently violating the advertised α-accuracy
-    /// guarantee near a bucket edge (asap_sketchlib#70 / sketchlib-go#73 item 1).
+    /// guarantee near a bucket edge.
     #[inline]
     fn bin_representative(&self, k: i32) -> f64 {
         self.lower_bound(k) * (1.0 + self.alpha)
@@ -622,7 +619,7 @@ mod tests {
         }
     }
 
-    // DataDog-parity tests (asap_sketchlib#70 / sketchlib-go#73, #72).
+    // DataDog-parity tests.
 
     #[test]
     fn representative_within_alpha_at_bucket_edges() {
@@ -650,7 +647,7 @@ mod tests {
     #[test]
     fn merge_alpha_mismatch_is_a_real_runtime_error() {
         // Was a debug_assert!, compiled out in release; now a real Result even
-        // in release builds (asap_sketchlib#70 item 2).
+        // in release builds.
         let mut a = DDSketch::new(0.01);
         let b = DDSketch::new(0.02);
         a.add(&5.0);
@@ -667,8 +664,7 @@ mod tests {
     #[test]
     fn untrackable_extreme_is_dropped() {
         // A single finite-but-extreme outlier outside the indexable range must
-        // not be recorded, so the dense bucket store never spans the whole gap
-        // (asap_sketchlib#70 item 4 / sketchlib-go#72).
+        // not be recorded, so the dense bucket store never spans the whole gap.
         let mut d = DDSketch::new(0.01);
         for i in 1..=2000 {
             d.add(&(f64::from(i)));

--- a/src/sketches/kll.rs
+++ b/src/sketches/kll.rs
@@ -829,8 +829,7 @@ impl<T: NumericalValue> KLL<T> {
     /// fields, matching `sketchlib-go::KLLSketch.SerializePortable`.
     /// See the `KLLState` docstring in `proto/kll/kll.proto`: index `i`
     /// in `levels` maps to compactor level `num_levels - 1 - i` in the
-    /// in-memory representation. Closes part of
-    /// ProjectASAP/ASAPCollector#243.
+    /// in-memory representation.
     pub fn wire_levels(&self) -> Vec<u32> {
         // Walk from top compactor-level downward, accumulating sizes.
         let n = self.num_levels;
@@ -1512,9 +1511,9 @@ mod tests {
         );
     }
 
-    // Exact repro from asap_sketchlib issue #68: merging a KLL(k=200) over
-    // 1..=1000 into an empty sketch used to drop N from 1000 to ~350 and
-    // drift the median from ~500 to ~700, because the old `merge` replayed
+    // Merge-weight regression: merging a KLL(k=200) over 1..=1000 into an
+    // empty sketch used to drop N from 1000 to ~350 and drift the median
+    // from ~500 to ~700, because the old `merge` replayed
     // every retained item through `update()` at weight 1 — discarding the
     // level weight of every item retained above level 0.
     //

--- a/src/sketches/kll_dynamic.rs
+++ b/src/sketches/kll_dynamic.rs
@@ -361,8 +361,7 @@ impl<T: NumericalValue> KLLDynamic<T> {
     /// The previous implementation replayed *every* item of `other` —
     /// across all of its levels — through `push_value`, i.e. at weight 1,
     /// silently discarding the level weight of everything `other` had
-    /// retained above level 0 (the same class of bug as `KLL::merge`, see
-    /// asap_sketchlib issue #68).
+    /// retained above level 0 (the same class of bug as `KLL::merge`).
     pub fn merge(&mut self, other: &KLLDynamic<T>) {
         if other.items.is_empty() {
             return; // `other` is empty: nothing to merge.
@@ -749,8 +748,8 @@ mod tests {
         );
     }
 
-    // Exact repro from asap_sketchlib issue #68 (KLLDynamic variant):
-    // merging a KLL(k=200) over 1..=1000 into an empty sketch used to
+    // Merge-weight regression, KLLDynamic variant: merging a KLL(k=200)
+    // over 1..=1000 into an empty sketch used to
     // rescale N down to `other`'s retained-item count and drift the
     // median, because the old `merge` replayed every retained item
     // through `push_value` at weight 1 regardless of which level it was
@@ -861,9 +860,9 @@ mod tests {
         );
     }
 
-    // Deterministic regression for a PR #71 review comment: `merge`
-    // assumed level h (h >= 1) is always a single sorted run in both
-    // operands. That holds for `KLL` (fixed-capacity), whose `compact`
+    // Deterministic regression: `merge` assumed level h (h >= 1) is always
+    // a single sorted run in both operands. That holds for `KLL`
+    // (fixed-capacity), whose `compact`
     // maintains it as a standing invariant via merge-promotion — but
     // `KLLDynamic::compact` re-sorts a level's *entire* contents from
     // scratch on every call instead, so a level that received a

--- a/tests/common/specs.rs
+++ b/tests/common/specs.rs
@@ -885,12 +885,12 @@ pub fn occurrence_sample_epsilon(samples: usize, delta: f64) -> f64 {
 /// # Why this is not the same as a rank-interval check
 ///
 /// Scoring each *estimated breakpoint* against the true rank interval of its
-/// own value — which is what the ordered-query test used to do — only ever
-/// looks at `x` values the estimate itself chose. An estimate that is right
-/// wherever it has a breakpoint and simply *has no breakpoint* across a region
-/// carrying a lot of mass scores zero error under that check and arbitrarily
-/// large error under this one. `cdf_sup_distance_detects_a_gap_a_breakpoint_scan_misses`
-/// in `tests/e2e_quantiles.rs` is exactly that fixture.
+/// own value only ever looks at `x` values the estimate itself chose. An
+/// estimate that is right wherever it has a breakpoint and simply *has no
+/// breakpoint* across a region carrying a lot of mass scores zero error under
+/// that check and arbitrarily large error under this one.
+/// `cdf_sup_distance_detects_a_gap_a_breakpoint_scan_misses` in
+/// `tests/e2e_quantiles.rs` is exactly that fixture.
 pub fn cdf_sup_distance(estimated: &[(f64, f64)], sorted_truth: &[f64]) -> (f64, f64) {
     let n = sorted_truth.len();
     assert!(
@@ -934,9 +934,8 @@ pub fn cdf_sup_distance(estimated: &[(f64, f64)], sorted_truth: &[f64]) -> (f64,
     (worst, worst_at)
 }
 
-/// The measurement the ordered-query test used to make: for each estimated
-/// breakpoint, the distance from its reported rank to the true rank interval
-/// of its own value.
+/// For each estimated breakpoint, the distance from its reported rank to the
+/// true rank interval of its own value.
 ///
 /// Kept **only** so a fixture can show that it reports zero where
 /// [`cdf_sup_distance`] reports a large error. It is not a Kolmogorov distance

--- a/tests/e2e_bulk.rs
+++ b/tests/e2e_bulk.rs
@@ -6,9 +6,7 @@
 //! The load-bearing assertion here is **equality**: with a fixed compaction
 //! seed, `bulk_update` and a loop of `update` must produce byte-identical
 //! sketches and bit-identical quantiles. The rank check beside it is a sanity
-//! floor, and its tolerance is `eps(k)` from `KllRankSpec` — not a hand-picked
-//! 0.03, which would pass identically at every `k` and so could not notice `k`
-//! failing to reach the compactors.
+//! floor at `eps(k)` from `KllRankSpec`, so its tolerance tracks `k`.
 
 mod common;
 
@@ -177,10 +175,8 @@ fn kll_bulk_data_input_batch_matches_loop() {
 }
 
 /// With a seeded coin, `KLLDynamic`'s bulk path must be *exactly* the loop
-/// path — same retained mass, same quantile bits. The previous version of this
-/// test built both sides with the wall-clock-seeded `init_kll`, so the two
-/// sketches had different coins and the 5% count tolerance was absorbing
-/// nondeterminism rather than measuring anything about `bulk_update`.
+/// path — same retained mass, same quantile bits. Both sides are built with
+/// `init_kll_with_seed`, so they share a coin.
 #[test]
 fn kll_dynamic_bulk_vs_loop_is_exact_under_a_shared_seed() {
     const SKETCH_SEED: u64 = 0x5EED_0700;

--- a/tests/e2e_cardinality.rs
+++ b/tests/e2e_cardinality.rs
@@ -120,9 +120,7 @@ macro_rules! hll_battery {
             // Shard merge over the *same* identities is an **equality**, not a
             // band: HLL registers combine by elementwise maximum, so merging
             // the even and odd halves reproduces the single pass register for
-            // register. Scoring it as a second confidence-band check — which is
-            // what this battery used to do — counted one number twice and
-            // tested nothing the single pass had not already tested.
+            // register.
             {
                 const MERGE_N: u64 = 200_000;
                 let mbase = IDENTITY_NAMESPACE_STRIDE * (CHECKPOINTS.len() as u64 + 1);

--- a/tests/e2e_experimental.rs
+++ b/tests/e2e_experimental.rs
@@ -101,17 +101,15 @@ fn kmv_trial(k: usize, n: usize, seed_idx: usize, namespace: u64) -> KMV {
 ///   RSE(n, k)     = sqrt( (n - k + 1) / (n (k - 2)) )  ->  1/sqrt(k - 2)
 /// ```
 ///
-/// The suite previously modelled this as `1/sqrt(k - 1)` and called that
-/// "marginally conservative". It is not: `1/sqrt(k-1) < 1/sqrt(k-2)`, so it was
-/// a *stricter* band than the estimator earns. The exact finite-`n` form is
-/// used now, which is stricter still at small `n` and correct at every `n`.
+/// The bands use the exact finite-`n` form, not the `1/sqrt(k - 2)` limit: it
+/// is tighter at small `n` and correct at every `n`.
 ///
 /// # Trial unit
 ///
 /// One `(k, hash seed, regime)` triple is one sketch, one estimate, one trial —
-/// and no two trials share a hash function or an identity. Reading rising
-/// checkpoints off one accumulating sketch, as this suite used to, produces
-/// *nested* estimates that share every retained hash.
+/// and no two trials share a hash function or an identity. Rising checkpoints
+/// read off one accumulating sketch would instead be *nested* estimates
+/// sharing every retained hash.
 #[test]
 fn kmv_estimates_stay_inside_their_relative_standard_error_band_over_independent_hash_seeds() {
     const KS: [usize; 3] = [64, 1_024, 4_096];
@@ -212,9 +210,8 @@ fn kmv_is_exact_below_k_and_estimates_at_k() {
 /// KMV retains the `k` smallest hashes of everything it has seen. Any hash
 /// among the global `k` smallest is also among the `k` smallest of whichever
 /// shard produced it, so merging the shards recovers exactly the single pass's
-/// retained set — the estimate is the *same number*, not a second draw. Scoring
-/// it as another confidence-band check, which this suite used to do, counted
-/// one experiment twice.
+/// retained set — the estimate is the *same number*, not a second draw, so it
+/// is asserted as an equality rather than scored against a confidence band.
 #[test]
 fn kmv_duplicates_are_inert_and_a_shard_merge_reproduces_the_single_pass_exactly() {
     const K: usize = 4_096;
@@ -279,8 +276,7 @@ fn kmv_duplicates_are_inert_and_a_shard_merge_reproduces_the_single_pass_exactly
 /// `ceil(total_seen * rate)`. So:
 ///
 /// - the retained size is `ceil(n * rate)` **exactly** — it is computed, never
-///   sampled, and the old `assert_between(len, 850.0, 1150.0)` band was
-///   asserting slack around a number that has none;
+///   sampled, so there is no slack for a band to assert around;
 /// - because the priorities are i.i.d. and independent of the values, the
 ///   retained set is a uniform sample **without replacement** of that size from
 ///   the `n` values seen. That is where the statistics live.

--- a/tests/e2e_frequency.rs
+++ b/tests/e2e_frequency.rs
@@ -95,8 +95,6 @@ fn countmin_fast_path_zipf_conforms_to_the_count_min_model_and_merges_shards_exa
 /// of it. Different hash functions place keys in different columns, so the two
 /// collide on different key pairs. On a 40k-update Zipf stream at 3x4096 they
 /// disagree on roughly a third of keys — every disagreement inside the bound.
-/// An earlier version of this test asserted equality on four hand-picked keys,
-/// which held by coincidence at those dimensions rather than by contract.
 ///
 /// `e2e_matrix_instances.rs` covers the equality that *is* contractual: on a
 /// collision-free workload both paths return exact counts.
@@ -284,8 +282,7 @@ fn countmin_fast_path_conforms_to_the_count_min_model() {
 /// The library's hash is fixed by the sketch's type parameter, so every sketch
 /// here draws from the same hash function and the keys inside one sketch share
 /// it. They are therefore *not* independent Bernoulli trials, and a binomial
-/// over keys — which is what this test used to do — assumes exactly the
-/// independence that does not hold.
+/// over keys assumes exactly the independence that does not hold.
 ///
 /// What is asserted instead:
 ///

--- a/tests/e2e_nitro.rs
+++ b/tests/e2e_nitro.rs
@@ -697,10 +697,9 @@ fn cells(cm: &CountMin<Vector2D<i32>, FastPath>) -> Vec<i32> {
 /// identical to one that was never interrupted.
 ///
 /// This is the property the sampling state has to be *complete* for. The
-/// rounding stream is the part that used to be dropped: it was `#[serde(skip)]`
-/// with a fixed default, so a decoded sketch restarted the Bernoulli sequence
-/// from the same constant every time and drifted from the uninterrupted run at
-/// any rate whose reciprocal is not an integer.
+/// rounding stream is part of it: it is serialized, so a decoded sketch
+/// continues the Bernoulli sequence rather than restarting it from a constant,
+/// which matters at any rate whose reciprocal is not an integer.
 #[test]
 fn a_serde_round_trip_after_every_update_reproduces_the_uninterrupted_run() {
     const UPDATES: usize = 600;

--- a/tests/e2e_octo.rs
+++ b/tests/e2e_octo.rs
@@ -262,10 +262,9 @@ fn cm_fast_path_promotes_on_the_same_schedule_as_the_regular_path() {
 }
 
 #[test]
-fn cm_delta_addressing_survives_columns_past_the_old_u16_ceiling() {
-    // Regression: `CmDelta` used to address cells with u16 row/col, so any
-    // geometry wider than 65_536 columns silently wrapped deltas onto the
-    // wrong cell. The fields are u32, so a wider sketch must stay exact.
+fn cm_delta_addressing_survives_columns_past_the_u16_ceiling() {
+    // `CmDelta`'s row and col fields are u32, so a geometry wider than
+    // 65_536 columns addresses every cell exactly.
     let rows = 3;
     let cols = 100_000;
     let stream = keys(60_000, 4_096, 9_108);
@@ -286,7 +285,7 @@ fn cm_delta_addressing_survives_columns_past_the_old_u16_ceiling() {
                 parent.as_storage().query_one_counter(r, c)
                     + child.as_storage().query_one_counter(r, c),
                 reference.as_storage().query_one_counter(r, c),
-                "cell ({r},{c}) mis-addressed past the old u16 ceiling"
+                "cell ({r},{c}) mis-addressed past the u16 ceiling"
             );
         }
     }
@@ -983,9 +982,6 @@ mod runtime {
         // outlive the sketch. `insert` hashes for partitioning and prepares the
         // payload on this thread, so nothing borrowed crosses to a worker and
         // the string below is free the instant the call returns.
-        //
-        // This used to be a use-after-free: `insert` transmuted the input to
-        // 'static and queued it, so workers hashed freed heap.
         let n = 20_000u64;
         let mut runtime = OctoRuntime::new(&config(4), HllOctoPlan::new(), HllOctoAggregator::new);
         for i in 0..n {

--- a/tests/e2e_quantiles.rs
+++ b/tests/e2e_quantiles.rs
@@ -1170,10 +1170,10 @@ fn cdf_sup_distance_detects_a_gap_a_breakpoint_scan_misses() {
     // Both are exactly the true CDF at those two values.
     let estimated: Vec<(f64, f64)> = vec![(1.0, 0.2), (9.0, 1.0)];
 
-    // The old measurement: each breakpoint's reported rank against its own
-    // value's true rank interval. Value 1 occupies ranks [0.0, 0.2] and is
-    // reported at 0.2; value 9 occupies [0.8, 1.0] and is reported at 1.0.
-    // Both are inside, so the old check sees a perfect estimate.
+    // `breakpoint_rank_interval_distance` scores each breakpoint's reported
+    // rank against its own value's true rank interval. Value 1 occupies ranks
+    // [0.0, 0.2] and is reported at 0.2; value 9 occupies [0.8, 1.0] and is
+    // reported at 1.0. Both are inside, so it sees a perfect estimate.
     let breakpoint_only = breakpoint_rank_interval_distance(&estimated, &sorted_truth);
     assert_eq!(
         breakpoint_only, 0.0,
@@ -1454,9 +1454,8 @@ fn ddsketch_rejects_untrackable_values_and_mapping_mismatches() {
     // Non-finite / non-positive / beyond-indexable-range values must be
     // dropped by BOTH implementations: silently, without corrupting bucket 0
     // (NaN floor-casts to 0) and without letting one sample force a distant-
-    // bucket allocation (unguarded, f64::MAX mapped ~35k buckets away at
-    // alpha=0.01 — ~277 KiB of amplification per sample, scaling with 1/lnγ;
-    // #70 item 4).
+    // bucket allocation (unguarded, f64::MAX maps ~35k buckets away at
+    // alpha=0.01 — ~277 KiB of amplification per sample, scaling with 1/lnγ).
     for v in [
         f64::NAN,
         f64::NEG_INFINITY,

--- a/tests/e2e_windows.rs
+++ b/tests/e2e_windows.rs
@@ -448,9 +448,8 @@ fn eh_univmon_variant_reports_the_exact_l1_over_the_retained_window() {
     // `l2` is `sqrt(F2_hat)` where `F2_hat` is the row-median AMS estimate over
     // the sketch's own 5x2048 counters, so `SecondMomentSpec`'s relative bound
     // `b = sqrt(2*kappa/w)` on F2 becomes `[sqrt(1-b), sqrt(1+b)]` on the norm.
-    // At 5x2048 that is about -4.2%/+4.1%, three times tighter than the +-15%
-    // this used to accept, and it is tied to the configuration: halving `cols`
-    // widens the band automatically.
+    // At 5x2048 that is about -4.2%/+4.1%, tied to the configuration: halving
+    // `cols` widens the band automatically.
     //
     // This is the *terminal* layer's bound. UnivMon's recurrence composes
     // per-layer estimates, and the crate publishes no closed form for the

--- a/tests/hll_custom_precision.rs
+++ b/tests/hll_custom_precision.rs
@@ -3,8 +3,7 @@
 //! This is an integration test, so it compiles as a separate crate: it only
 //! sees `asap_sketchlib`'s public surface, and it never imports `serde`,
 //! `serde-big-array`, or any of the other names the macro expansion needs.
-//! That makes it a real check that the exported macro is usable downstream —
-//! see issue #94.
+//! That makes it a real check that the exported macro is usable downstream.
 //!
 //! The precisions here are deliberately outside the built-in
 //! {12, 14, 16} set, including `lg_k = 18` (needed by sketch-bench's

--- a/tests/msgpack_compat.rs
+++ b/tests/msgpack_compat.rs
@@ -80,8 +80,7 @@ fn dd_sketch_round_trip() {
     s.update(100.0);
     let bytes = s.to_msgpack().expect("encode");
     let restored = DdSketch::from_msgpack(&bytes).expect("decode");
-    // `count` was dropped from the wire (ProjectASAP/sketchlib-go#243);
-    // recover it by summing the bucket array.
+    // `count` is not on the wire; recover it by summing the bucket array.
     assert_eq!(restored.total_count(), 3);
 }
 

--- a/tests/sketches_go_parity_probe.rs
+++ b/tests/sketches_go_parity_probe.rs
@@ -40,8 +40,8 @@ const COUNTMIN_GOLDEN_HEX: &str = include_str!("../src/sketches/testdata/cms_env
 const HLL_GOLDEN_HEX: &str = include_str!("../src/sketches/testdata/hll_envelope_golden.hex");
 
 /// 403-byte DDSketch envelope for `alpha=0.01`, `(1..=50)` integer-as-f64
-/// input, AFTER dropping the DataPoint-level METRIC scalars
-/// (count/sum/min/max → proto tags 4-7 reserved, ProjectASAP/sketchlib-go#243).
+/// input, without the DataPoint-level METRIC scalars (count/sum/min/max →
+/// proto tags 4-7 reserved).
 ///
 /// NOTE: this is currently the RUST-produced value; it MUST be reconciled
 /// against the parallel `sketchlib-go` golden regeneration before declaring
@@ -231,9 +231,8 @@ fn sketches_ddsketch_matches_go_envelope() {
     let alpha = sk.alpha();
     let gamma = (1.0 + alpha) / (1.0 - alpha);
     let alpha_wire = (gamma - 1.0) / (gamma + 1.0);
-    // The DataPoint-level METRIC scalars (count/sum/min/max) were dropped
-    // from the wire (ProjectASAP/sketchlib-go#243); only alpha + the bucket
-    // array remain.
+    // The DataPoint-level METRIC scalars (count/sum/min/max) are not on the
+    // wire; only alpha + the bucket array.
     let state = DdSketchState {
         alpha: alpha_wire,
         store_counts: sk.store_counts().to_vec(),

--- a/tests/spec_self_tests.rs
+++ b/tests/spec_self_tests.rs
@@ -43,7 +43,7 @@ fn bad_row_threshold_is_ceil_half_the_depth() {
             assert!(
                 spec.bad_row_threshold() < rows / 2 + 1,
                 "d={rows}: for even depth ceil(d/2) must be strictly smaller than \
-                 d/2+1, which is what the old code used"
+                 d/2+1, the naive majority threshold"
             );
         }
     }
@@ -60,9 +60,9 @@ fn bad_row_threshold_is_ceil_half_the_depth() {
 /// The binomial tails the threshold selects, at the marginal `kappa = 3`.
 ///
 /// Pinned numerically so a change to either the threshold or the tail
-/// routine is visible. `d = 4` is the case the old `d/2 + 1` got wrong: it
-/// claimed 0.111 where the estimator earns 0.407, i.e. it advertised a
-/// bound almost four times stronger than the median supports.
+/// routine is visible. `d = 4` is where `d/2 + 1` diverges: it gives 0.111
+/// where the estimator earns 0.407, a bound almost four times stronger than
+/// the median supports.
 #[test]
 fn marginal_failure_probabilities_match_the_hand_computed_tails() {
     let cases = [
@@ -81,10 +81,10 @@ fn marginal_failure_probabilities_match_the_hand_computed_tails() {
             spec.marginal_failure()
         );
     }
-    // The old formula at d=4, kept as an explicit contrast.
+    // `d/2 + 1` at d=4, kept as an explicit contrast.
     assert!(
         (binomial_tail_ge(4, 3, 1.0 / 3.0) - 0.111_111_111_111).abs() < 1e-9,
-        "P[Bin(4, 1/3) >= 3] is the number the old threshold reported"
+        "P[Bin(4, 1/3) >= 3] is the number a `d/2 + 1` threshold reports"
     );
 }
 
@@ -147,8 +147,8 @@ fn two_same_direction_bad_rows_move_an_averaged_four_row_median_out_of_band() {
 }
 
 /// Raising `kappa` until the union bound over `D` keys closes must respect
-/// the corrected threshold, so an even-depth sketch now needs a wider
-/// simultaneous band than it used to be given.
+/// `ceil(d/2)`, which gives an even-depth sketch a wider simultaneous band
+/// than `d/2 + 1` would.
 #[test]
 fn simultaneous_kappa_reflects_the_corrected_threshold() {
     let spec = CountSketchSpec::new(4, 2048);
@@ -160,7 +160,7 @@ fn simultaneous_kappa_reflects_the_corrected_threshold() {
         SIMULTANEOUS_LEVEL / 512.0
     );
     // Two bad rows out of four is a `kappa^-2` tail, so the required kappa
-    // is far larger than the `kappa^-3` the old threshold implied.
+    // is far larger than the `kappa^-3` a `d/2 + 1` threshold implies.
     let old_style = {
         let mut lo = 3.0f64;
         let mut hi = lo;

--- a/tests/xtest_consumer.rs
+++ b/tests/xtest_consumer.rs
@@ -178,8 +178,7 @@ fn cross_language_proto() {
         other => panic!("expected DDSketch sketch_state, got {other:?}"),
     };
 
-    // `count` was dropped from the wire (ProjectASAP/sketchlib-go#243);
-    // recover it by summing the bucket counts.
+    // `count` is not on the wire; recover it by summing the bucket counts.
     let dd_total_count: u64 = dd_state.store_counts.iter().copied().sum();
     println!(
         "[DDSketch]   alpha={:.4} count={} buckets={} offset={}",
@@ -1177,8 +1176,7 @@ struct DdFromProto {
     store_counts: Vec<u64>,
     store_offset: i32,
     // Total count is recovered by summing the bucket array; the
-    // DataPoint-level count/min/max scalars were dropped from the wire
-    // (ProjectASAP/sketchlib-go#243).
+    // DataPoint-level count/min/max scalars are not on the wire.
     count: u64,
 }
 


### PR DESCRIPTION
Comment-only cleanup across `src/` and `tests/`. No behaviour, no public API, no assertion or tolerance changes.

## What comes out

**Dead comments** — three commented-out `use serde::{Deserialize, Serialize};` lines in `portable/{countminsketch,countsketch,ddsketch}.rs`, each of which already has the real import at the top of its file.

**Stale positional references** — three banners claimed the high-throughput variant lived "above" in the same file. `CountMin`, `Count` and `DDSketch` all live under `crate::sketches::`; the comments now name the real paths.

**PR / issue references** — `ProjectASAP/ASAPCollector#243`, `ProjectASAP/sketchlib-go#243`, `asap_sketchlib#70`, `sketchlib-go#72`/`#73`, issues `#68`, `#77` and `#94`, `PR #71`, `PRs #60-#63`. The behaviour each one described is kept as a plain statement.

**Development-process prose** — "the minimal surface needed for PR C-CountSketch", "intentionally deferred to a follow-up", "works with just a matrix today", the "upcoming CMS PR" / "upcoming CMS byte-parity fix" forward references (that work has since landed).

**Test-history narrative** — every site in `tests/` that described what a *previous version of the test* did rather than what this one asserts: the wall-clock-seeded `init_kll` story in `e2e_bulk.rs`, the four hand-picked keys in `e2e_frequency.rs`, the `1/sqrt(k - 1)` model and the `assert_between(len, 850.0, 1150.0)` band in `e2e_experimental.rs`, and the same shape in `e2e_cardinality.rs`, `e2e_windows.rs`, `e2e_nitro.rs`, `e2e_octo.rs`, `e2e_quantiles.rs` and `common/specs.rs`. In `spec_self_tests.rs`, "the old code" / "the old threshold" now name `d/2 + 1` directly — which is what the contrast the test computes is actually about.

## What stays

- The Apache-2.0 header in `sketches/hll.rs` and the provenance block in `sketches/ddsketch.rs`.
- Algorithm rationale that names a superseded approach.
- `e2e_nitro.rs`'s "old field layout" / "old encoder" wording in `a_payload_written_before_the_rounding_field_existed_still_decodes`. That describes the legacy payload the test builds and decodes — current behaviour of a compatibility path, not project history.

## One non-comment change

`e2e_octo.rs`'s `cm_delta_addressing_survives_columns_past_the_old_u16_ceiling` and its assertion message drop the word "old", which the removed comment was the only thing explaining. No callers.

## Checks

Run locally against this branch:

| command | result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` | pass |
| `cargo test --all-features --locked` | pass, 0 failed across all targets + 21 doctests |
| `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked` | pass |

`proto-vendored-up-to-date` is unaffected — nothing under `proto/` or `src/proto/generated` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4acfgC4nFYvYadFpjMXsw