### PR TITLE
Cut the 0.3.0 release section and repoint the pinned tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ signals a backwards-compatible change.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-07
+
+Breaking release. Adds `Bloom` and `SpaceSaving`, completes ASAPv1 wire
+coverage for every implemented sketch, and corrects the Nitro row sampler.
+The wire format and the `serde` shape of several types changed; see
+**Changed** below for the payloads and types affected.
+
 ### Added
 
 - **`UnivMonQQuery::ordered_query_diagnostics`**, returning
@@ -525,7 +532,8 @@ Initial crates.io release.
 
 Pre-release tag. Not published to crates.io.
 
-[Unreleased]: https://github.com/ProjectASAP/asap_sketchlib/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/ProjectASAP/asap_sketchlib/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/ProjectASAP/asap_sketchlib/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/ProjectASAP/asap_sketchlib/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/ProjectASAP/asap_sketchlib/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/ProjectASAP/asap_sketchlib/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Alternatively, pin to a tagged revision from GitHub:
 
 ```toml
 [dependencies]
-asap_sketchlib = { git = "https://github.com/ProjectASAP/asap_sketchlib", tag = "v0.2.2" }
+asap_sketchlib = { git = "https://github.com/ProjectASAP/asap_sketchlib", tag = "v0.3.0" }
 ```
 
 ### Count distinct users with HyperLogLog


### PR DESCRIPTION
Release prep for `0.3.0`. `Cargo.toml` was already at `0.3.0`; this is the paperwork that was left behind.

- `CHANGELOG.md`: closes `[Unreleased]` as `## [0.3.0] - 2026-09-07` with a summary of what the release contains, leaves an empty `[Unreleased]` above it, and adds the `[0.3.0]` compare link.
- `README.md`: the git-dependency example pinned `tag = "v0.2.2"`; it now pins `v0.3.0`. The `asap_sketchlib = "0.3"` crates.io snippet above it was already correct.

No source changes.

## Verification

`ci.yml` has `paths-ignore: ["**/*.md", "docs/**"]`, so this PR runs no checks. Run locally instead:

- `cargo fmt --all -- --check` — pass
- `cargo test --locked --doc` — 21 passed. `src/lib.rs:1` is `#![doc = include_str!("../README.md")]`, so the README is crate-level documentation and its code blocks are doctests. The edit is inside a ```toml block, so nothing compiled changed, but the doctests were run rather than assumed.
- `cargo publish --dry-run --locked` — packaged 232 files, 4.7 MiB (1.1 MiB compressed), verification build clean.

## After merge

```
git tag -a v0.3.0 -m "v0.3.0"
git push origin v0.3.0
cargo publish --locked
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)